### PR TITLE
Chore: add Pocock agent workflow scaffolding and track CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ Thumbs.db
 
 # Local Claude Code settings
 .claude/
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+\# Obsidian Plugin: obsidian-writing-studio
+
+
+
+\## Critical Reference Documents
+
+ALL Obsidian API and submission requirements are in local docs.
+
+Before writing any code, read the relevant section below.
+
+Before finishing any task, verify output does not violate plugin guidelines.
+
+
+
+\- @docs/obsidian-dev-docs/docs/plugins/releasing/plugin-guidelines.md
+
+\- @docs/obsidian-dev-docs/docs/plugins/releasing/submit-your-plugin.md
+
+\- @docs/obsidian-dev-docs/docs/reference/
+
+
+
+\## ObsidianReviewBot — Required Rules
+
+These are enforced automatically. Never violate them:
+
+
+
+1\. Use normalizePath() for ALL file/folder paths
+
+&#x20;  Import: `import { normalizePath } from "obsidian"`
+
+
+
+2\. NEVER use innerHTML, outerHTML, or insertAdjacentHTML
+
+&#x20;  Use Obsidian DOM helpers or native DOM API instead
+
+
+
+3\. ALL Promises must be awaited or handled
+
+&#x20;  Unhandled promises will be flagged by ESLint
+
+
+
+4\. NEVER cast to `any` — use proper TypeScript types
+
+
+
+5\. Do NOT assign styles via JavaScript — use CSS classes only
+
+
+
+6\. Do NOT include "Obsidian" in the plugin description field
+
+
+
+7\. Use sentence case in all UI text (settings, notices, modals)
+
+
+
+8\. Do NOT detach leaves in onunload()
+
+
+
+9\. Do NOT add custom ordering to ribbon items
+
+
+
+10\. Description in manifest.json must end with . ? ! or )
+
+
+
+\## Manifest Requirements
+
+\- version must match GitHub release tag exactly (no "v" prefix)
+
+\- id, name, description must exactly match community-plugins.json entry
+
+\- minAppVersion must be kept current
+
+
+
+\## Release Assets Required
+
+Attach these as individual binary files to the GitHub Release — NOT in a zip:
+
+\- main.js
+
+\- manifest.json
+
+\- styles.css (if used)
+
+
+
+\## Commands
+
+npm run dev       # watch build
+
+npm run build     # production build
+
+npm run lint      # run before every commit — catches ReviewBot issues
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues for this repo. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,33 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-*.md
+│   └── ...
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.


### PR DESCRIPTION
## Summary

- Removes `CLAUDE.md` from `.gitignore` so project rules and agent skills configuration survive reclones
- Adds `docs/agents/` config files created by `/setup-matt-pocock-skills` for the Claude Code skills system (issue tracker, triage labels, domain doc layout)

## Files changed

- `.gitignore` — removed `CLAUDE.md` exclusion
- `CLAUDE.md` — now tracked in repo; contains ObsidianReviewBot rules, manifest requirements, and `## Agent skills` index
- `docs/agents/issue-tracker.md` — GitHub Issues conventions for skills
- `docs/agents/triage-labels.md` — triage label vocabulary mapping
- `docs/agents/domain.md` — domain doc layout for agent navigation

## Plugin impact

None. No source files, manifest, or release assets were changed. This is developer workflow infrastructure only.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)