### PR TITLE
Chore: add session notes rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,11 @@ Default label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-h
 
 Single-context layout — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
 
+## Session notes
+
+At the end of every session, always invoke `/end-session` before stopping.
+
+If the session appears to be wrapping up (user says "done", "that's it", "bye", "stop", "exit", or goes quiet after completing a task), proactively suggest running `/end-session`.
+
+Session notes are saved to: `C:\Users\donpu\Vaults\Pucik Notes\Obsidian Writing Studio\`
+


### PR DESCRIPTION
## Summary

- Adds `## Session notes` section to `CLAUDE.md` instructing agents to always invoke `/end-session` before stopping
- Documents vault save path and trigger phrases for proactive suggestions

## Plugin impact

None. Documentation-only change to CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)