### PR TITLE
CI: add signed release workflow with Sigstore build provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    name: Build and release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build plugin
+        run: npm run build
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          files: |
+            main.js
+            manifest.json
+            styles.css
+          generate_release_notes: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on bare-version tags (`2.1.9` style)
- Builds the plugin (`npm ci` + `npm run build`)
- Creates the GitHub Release with `main.js`, `manifest.json`, `styles.css` and auto-generated release notes
- Attests all three artifacts via `actions/attest-build-provenance` so the OpenSSF Scorecard `Signed-Releases` check can verify provenance against the GitHub Attestations API

## Scorecard impact

| Check | Before | After |
|---|---|---|
| Signed-Releases | 0 | ~10 (once next release is cut via this workflow) |

## Workflow changes

All future releases will be created by pushing a bare version tag (e.g. `git tag 2.2.0 && git push origin 2.2.0`). The workflow replaces the current manual upload process.

## Actions pinned

| Action | Version | SHA |
|---|---|---|
| `actions/checkout` | v4 | `34e114876b` |
| `actions/setup-node` | v6.4.0 | `48b55a011b` |
| `softprops/action-gh-release` | v3.0.0 | `b4309332981a` |
| `actions/attest-build-provenance` | v4.1.0 | `a2bbfa25375f` |

## Test plan

- [ ] CI (ESLint + CodeQL) passes on this PR
- [ ] After merge: push a test tag `2.1.10` (or next real release) and verify the workflow creates the release and attestations appear at `github.com/writerP-777/obsidian-writing-studio/attestations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)