### PR TITLE
Docs: add CII Best Practices baseline-1 badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Transform Obsidian into a professional writing environment. Writing Studio bundl
 
 [![CodeQL](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/writerP-777/obsidian-writing-studio/badge)](https://securityscorecards.dev/viewer/?uri=github.com/writerP-777/obsidian-writing-studio)
+[![CII Best Practices](https://www.bestpractices.dev/projects/12832/badge)](https://www.bestpractices.dev/projects/12832)
 [![ESLint](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml)
 
 Every push and pull request is scanned automatically:


### PR DESCRIPTION
## Summary

- Adds the CII Best Practices baseline-1 badge to the Security section of the README
- Project registered at bestpractices.dev, ID 12832

## Scorecard impact

The `CII-Best-Practices` Scorecard check will now detect the registered project and award credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)