### PR TITLE
CI: restrict workflow-level token permissions to {} across all workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze (javascript-typescript)

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,12 +1,13 @@
 name: Dependabot auto-merge
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   dependabot:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]' && (contains(github.event.pull_request.title, 'minor') || contains(github.event.pull_request.title, 'patch'))
     steps:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   lint:
     name: ESLint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,16 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
+permissions: {}
 
 jobs:
   release:
     name: Build and release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Fixes the Scorecard `Token-Permissions` regression introduced by `release.yml` (PR #29).

The pattern applied to all four affected workflows:
- Add `permissions: {}` at the workflow level (deny-all default)
- Declare only the specific write permissions needed at the **job** level

| Workflow | Change |
|---|---|
| `release.yml` | Move `contents/id-token/attestations: write` → job level |
| `dependabot-auto-merge.yml` | Move `contents/pull-requests: write` → job level |
| `eslint.yml` | Add `permissions: {}` at workflow level (job already had correct grants) |
| `codeql.yml` | Add `permissions: {}` at workflow level (job already had correct grants) |

`scorecard.yml` was already correct (`permissions: read-all` at workflow level).

## Scorecard impact

`Token-Permissions` should move from 0 → 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)