### PR TITLE
Docs: fix CII badge to use baseline image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Transform Obsidian into a professional writing environment. Writing Studio bundl
 
 [![CodeQL](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/writerP-777/obsidian-writing-studio/badge)](https://securityscorecards.dev/viewer/?uri=github.com/writerP-777/obsidian-writing-studio)
-[![CII Best Practices](https://www.bestpractices.dev/projects/12832/badge)](https://www.bestpractices.dev/projects/12832)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12832/baseline)](https://www.bestpractices.dev/projects/12832)
 [![ESLint](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml)
 
 Every push and pull request is scanned automatically:


### PR DESCRIPTION
## Summary

Fixes the CII Best Practices badge URL in the README.

The generic `/badge` endpoint shows "In Progress 0%" (Passing tier progress, which we haven't started). The `/baseline` endpoint correctly displays the earned **Baseline Level 1** status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)