### PR TITLE
Docs: add direct advisory URL to SECURITY.md for scorecard

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,9 +49,9 @@ Issues that are solely within Obsidian core, the operating system, or third-part
 
 To report a vulnerability privately:
 
-1. Navigate to the **Security** tab of this repository.
-2. Click **Report a vulnerability** to open a private advisory draft.
-3. Provide as much detail as possible, including:
+1. Open a private advisory draft at:
+   **https://github.com/writerP-777/obsidian-writing-studio/security/advisories/new**
+2. Provide as much detail as possible, including:
    - A clear description of the vulnerability
    - Steps to reproduce or a proof-of-concept
    - The potential impact and affected versions


### PR DESCRIPTION
## Summary

- Adds a direct hyperlink to the GitHub private advisory form in SECURITY.md
- Fixes the OpenSSF Scorecard Security-Policy check: score is currently 4/10 with warning "no linked content found" — a clickable URL satisfies the linked-content requirement

## Test plan

- Scorecard workflow passes on CI after merge
- Security-Policy alert transitions to fixed in the Security tab on next scorecard run
