### PR TITLE
Chore: add .npmrc to allow legacy peer deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary

- Adds `.npmrc` with `legacy-peer-deps=true` to unblock Dependabot PRs for `@codemirror/state`, `@codemirror/view`, and `fflate`
- Root cause: `obsidian@1.12.3` hard-pins exact codemirror peer dep versions (`6.5.0` / `6.38.6`); any npm install that resolves these to newer minor versions fails with `ERESOLVE`
- Since codemirror packages are dev/type-only here (Obsidian provides codemirror at runtime), peer dep strictness adds no safety value

## Test plan

- [ ] ESLint CI passes on this PR
- [ ] After merge, trigger `@dependabot rebase` on PRs #40, #42, #45 and verify ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)