### PR TITLE
Chore: pin codemirror versions to match Obsidian runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
         "fflate": "^0.8.2"
       },
       "devDependencies": {
-        "@codemirror/state": "^6.5.0",
-        "@codemirror/view": "^6.38.6",
+        "@codemirror/state": "6.5.0",
+        "@codemirror/view": "6.38.6",
         "@types/node": "^25.7.0",
         "esbuild": "0.28.0",
         "eslint-plugin-obsidianmd": "^0.3.0",
-        "obsidian": "*",
+        "obsidian": "latest",
         "tslib": "2.8.1",
         "typescript": "6.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,13 @@
     "lint": "node node_modules/eslint-plugin-obsidianmd/node_modules/eslint/bin/eslint.js --max-warnings 0 main.ts src/ modals/",
     "version": "node version-bump.mjs && git add manifest.json versions.json"
   },
+  "overrides": {
+    "@codemirror/state": "6.5.0",
+    "@codemirror/view": "6.38.6"
+  },
   "devDependencies": {
-    "@codemirror/state": "^6.5.0",
-    "@codemirror/view": "^6.38.6",
+    "@codemirror/state": "6.5.0",
+    "@codemirror/view": "6.38.6",
     "@types/node": "^25.7.0",
     "esbuild": "0.28.0",
     "eslint-plugin-obsidianmd": "^0.3.0",


### PR DESCRIPTION
## Summary

- Pins `@codemirror/state` and `@codemirror/view` to exact versions (`6.5.0` / `6.38.6`) in both `devDependencies` and `overrides`
- Root cause: `obsidian@1.12.3` hard-pins these as exact peer deps; any `npm install` that resolves them to a newer minor version fails with `ERESOLVE`
- Since Obsidian provides codemirror at runtime, these devDeps are type-only — bumping them independently of Obsidian is also incorrect (could reference APIs that don't exist in Obsidian's bundled version)
- The `overrides` field ensures even transitive dependencies cannot resolve to a different version

## Test plan

- [ ] ESLint CI passes
- [ ] After merge, `@dependabot rebase` on #42, #43, #44 — all should pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)