### PR TITLE
feat: add Buy Me a Coffee button to How to use settings tab

### DIFF
--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -480,5 +480,16 @@ export class WritingStudioSettingsTab extends PluginSettingTab {
     this.helpComponent.load();
     el.addClass('ws-help-content');
     await MarkdownRenderer.render(this.app, HELP_CONTENT, el, '', this.helpComponent);
+    const supportDiv = el.createDiv({ cls: 'ws-support-footer' });
+    supportDiv.createEl('a', {
+      href: 'https://buymeacoffee.com/writerp777',
+      attr: { target: '_blank', rel: 'noopener noreferrer' }
+    }).createEl('img', {
+      attr: {
+        src: 'https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&slug=writerp777&button_colour=c9a84c&font_colour=000000&font_family=Georgia&outline_colour=000000&coffee_colour=ffffff',
+        alt: 'Buy me a coffee',
+        height: '40'
+      }
+    });
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -1769,3 +1769,10 @@ body .ws-launcher select {
 .ws-log-day-meta {
   color: var(--text-muted);
 }
+
+.ws-support-footer {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--background-modifier-border);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- Adds a Buy Me a Coffee button at the bottom of the Help tab in Settings, below the rendered help content
- Styled with `.ws-support-footer` — top border, centered, with spacing — added to `styles.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)