### PR TITLE
ci: sign release artifacts with cosign for OpenSSF Scorecard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,25 @@ jobs:
       - name: Build plugin
         run: npm run build
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+
+      - name: Sign release artifacts
+        run: |
+          cosign sign-blob --bundle=main.js.bundle main.js
+          cosign sign-blob --bundle=manifest.json.bundle manifest.json
+          cosign sign-blob --bundle=styles.css.bundle styles.css
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: |
             main.js
+            main.js.bundle
             manifest.json
+            manifest.json.bundle
             styles.css
+            styles.css.bundle
           generate_release_notes: true
 
       - name: Attest build provenance


### PR DESCRIPTION
## Summary
- Installs cosign (v3.5.0, pinned by commit hash) in the release workflow
- Signs `main.js`, `manifest.json`, and `styles.css` with keyless Sigstore OIDC signing
- Attaches `.bundle` files alongside release assets so OpenSSF Scorecard detects them
- Keeps the existing `actions/attest-build-provenance` step for GitHub-native attestations

## Why
Scorecard's Signed-Releases check looks for `.bundle`/`.sig`/`.asc` files attached directly to GitHub releases. The existing `attest-build-provenance` step stores attestations in GitHub's attestation store, which Scorecard currently doesn't detect, hence the 0 score. Adding cosign bundles as release assets fixes this.

## Test plan
- [ ] Merge and tag a release — confirm `.bundle` files appear in release assets
- [ ] Confirm cosign signing step completes without error in the Actions log
- [ ] Re-check OpenSSF Scorecard after next weekly scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)