### PR TITLE
docs: add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 **Version 2.2.1** · Desktop only
 
 ![GitHub all releases](https://img.shields.io/github/downloads/writerP-777/obsidian-writing-studio/total)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12832/badge)](https://www.bestpractices.dev/projects/12832)
 
 Writing Studio turns Obsidian into a dedicated environment for serious nonfiction work — from your first research notes to a finished, exported manuscript. It bundles a project binder, writing modes, focus and typography tools, sprint timer, progress tracking, manuscript export, and WordPress publishing into a single plugin.
 


### PR DESCRIPTION
## Summary

- Adds the OpenSSF Best Practices badge to the badge row in README.md, alongside the GitHub downloads badge
- No other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)