### PR TITLE
docs: correct language count to 10 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ All notable changes to Writing Studio are documented here.
 ## [2.3.0]
 
 ### Added
-- **Internationalization (i18n):** all plugin UI strings are now fully translated into 12 languages: English, Chinese (Simplified), Hindi, Spanish, Arabic, French, Bengali, Portuguese (Brazil), Russian, Japanese, German, and Korean. Locale is detected automatically from Obsidian's language setting and falls back to English for any unsupported locale.
+- **Internationalization (i18n):** all plugin UI strings are now fully translated into 10 languages: English, Chinese (Simplified), Spanish, Arabic, French, Portuguese (Brazil), Russian, Japanese, German, and Korean. Locale is detected automatically from Obsidian's language setting and falls back to English for any unsupported locale.
 - `src/i18n.ts` — i18next wrapper with `initI18n()` and `t()` helper
-- `src/i18n/` — locale JSON files for all 12 languages (~580 keys each)
+- `src/i18n/` — locale JSON files (~580 keys each)
 - Status badges and document type labels in Targets Dashboard and Writing Binder are now translated
 - Word-count suffix in Writing Binder adapts per language (e.g., 字, 語, 자, W)
 - i18n key-parity test suite (`tests/i18n-parity.test.ts`) — CI catches missing translations automatically


### PR DESCRIPTION
Removes Hindi and Bengali from the supported language list in CHANGELOG.md — both locale files exist in the codebase but neither language appears in Obsidian's language dropdown, so users cannot activate them. Corrects the count from 12 to 10.

GitHub release notes for 2.3.0 were already updated directly via \gh release edit\.