### PR TITLE
docs: add /start-session command and populate README Features section

### DIFF
--- a/.claude/commands/start-session.md
+++ b/.claude/commands/start-session.md
@@ -1,0 +1,17 @@
+Start a new session. Do the following before we begin any work:
+
+1. Read CONTEXT.md
+2. Read all memory files linked in MEMORY.md
+3. Run: git fetch origin && git status && git log --oneline -10
+4. Run: npm run lint
+5. Check open GitHub issues: gh issue list --state open --limit 20
+6. Check open PRs: gh pr list --state open
+7. Read the latest end-session note (exclude Cowork updates):
+   Get-ChildItem "C:\Users\donpu\Vaults\Pucik Notes\Obsidian Writing Studio\*Session Update.md" | Where-Object { $_.Name -notmatch 'Cowork' } | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content
+8. If today is Monday, check: gh issue view 1185 --repo johansan/notebook-navigator
+
+Then give me a structured session brief:
+- Last session summary: what was worked on and what was completed
+- Current state: version (from manifest.json), branch status, any uncommitted work, lint result, open issues and PRs flagged ready-for-agent
+- Known next steps: based on session notes, open issues, and memory
+- Flags: anything that needs attention before we start (failing lint, stale memory, pending releases, etc.)

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,6 @@ main.js
 Thumbs.db
 
 # Local Claude Code settings
-.claude/
+.claude/*
+!.claude/commands/
+!.claude/commands/**

--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ Writing Studio turns Obsidian into a dedicated environment for serious nonfictio
 
 ## Features
 
+**Writing Binder** — Organize your manuscript as an ordered collection of documents with per-item status, word count, and export flags. Drag chapters into order, toggle items in or out of export, and add files from anywhere in your vault.
+
+**Project Manager** — Create projects from six templates (blank, book, article series, blog collection, journal article, magazine article), set a total word count goal, and switch between projects from the Launcher.
+
+**Compile Preview** — Concatenate all binder documents in order and render them as a finished manuscript in a split pane, without exporting.
+
+**Writing Modes** — Switch between Draft (distraction-free), Edit (full tooling), and Review (read-only) modes from the status bar, command palette, context menu, or Launcher.
+
+**Focus Mode** — Dim everything except the paragraph or sentence you are writing. Configurable dim level, font size override, sidebar collapse, and typewriter scroll.
+
+**Typography Mode** — Apply a curated font, constrained line length, and controlled line height to the editor. Fourteen font options including iA Writer fonts, Google Fonts, and custom system fonts.
+
+**Sprint Timer** — Run timed writing sessions with a draggable floating overlay. Set duration, word goal, and scope (file or project). Quick-start presets (10 m, 15 m, 25 m) available from the Launcher.
+
+**Progress Tracking** — Live word counts in the status bar and Launcher, session delta tracking, per-document and per-project word count goals with inline progress banners, and a 30-day writing log with streak tracking.
+
+**Export Engine** — Export to Manuscript (HTML), PDF, Word (.docx), RTF, HTML, Markdown, and EPUB. Manuscript format produces industry-standard layout with no external tools; other formats require Pandoc.
+
+**WordPress Publishing** — Publish directly to WordPress from Obsidian. Set post title, status, categories, tags, excerpt, and scheduled date. Supports multiple sites with per-site credentials and connection testing.
+
+**Folder Sidebar Explorer** — Browse any vault folder in a sidebar panel. Search by name or file content, preview Markdown files and images inline, and insert selected text directly into the active editor.
+
 ## Language support
 
 Writing Studio is available in the following languages in addition to English:


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/start-session.md` — a project-level slash command that runs a structured session startup checklist and produces a session brief (last session summary, current state, next steps, flags)
- Updates `.gitignore` to expose `.claude/commands/` so the slash command is tracked in git
- Populates the empty `## Features` section in README.md with descriptions of all eleven plugin features

## Test plan

- [ ] Verify `/start-session` is available as a slash command in Claude Code for this project
- [ ] Confirm README Features section renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)