### PR TITLE
chore: add acceptance criteria protocol and release preflight

### DIFF
--- a/.claude/commands/release-check.md
+++ b/.claude/commands/release-check.md
@@ -1,0 +1,22 @@
+Run the release preflight checklist for version $ARGUMENTS.
+
+If no version argument is provided, ask Don for the target version before proceeding.
+
+Check each item below and report PASS or FAIL. Do not tag until all four pass.
+
+1. **CHANGELOG heading** — Read CHANGELOG.md and confirm it contains a `## [$ARGUMENTS]` heading (exact match including brackets, e.g. `## [2.4.5]`).
+2. **Tag prefix** — Confirm `$ARGUMENTS` begins with a digit, not the letter v (correct: `2.4.5`, wrong: `v2.4.5`).
+3. **Lint** — Run: `npm run lint`
+4. **Manifest version** — Read manifest.json and confirm the `version` field equals `$ARGUMENTS` exactly.
+
+Report results as a table:
+
+| Check | Result | Detail |
+|---|---|---|
+| CHANGELOG heading | PASS/FAIL | e.g. "## [2.4.5] found" or "heading not found" |
+| Tag prefix | PASS/FAIL | state the value if it starts with v |
+| Lint | PASS/FAIL | error/warning count if failed |
+| Manifest version | PASS/FAIL | actual value if mismatched |
+
+If all four pass: state "Release preflight passed — safe to tag $ARGUMENTS."
+If any fail: state "Release preflight FAILED — do not tag until all items pass." List exactly what needs fixing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,13 +72,9 @@ These are enforced automatically. Never violate them:
 
 
 
-\## Manifest Requirements
-
-\- version must match GitHub release tag exactly (no "v" prefix)
-
-\- id, name, description must exactly match community-plugins.json entry
-
-\- minAppVersion must be kept current
+## Manifest Rules
+- id, name, and description must exactly match the community-plugins.json entry
+- minAppVersion must be kept current
 
 
 
@@ -93,6 +89,15 @@ Attach these as individual binary files to the GitHub Release — NOT in a zip:
 \- styles.css (if used)
 
 
+
+## Release Preflight
+
+Before tagging any release, run `/release-check <version>`. Do not tag until all items pass:
+
+1. CHANGELOG.md contains a `## [version]` heading matching the tag exactly
+2. The tag contains no v prefix (correct: `2.4.5`, wrong: `v2.4.5`)
+3. `npm run lint` passes with 0 errors and 0 warnings
+4. manifest.json version field matches the tag exactly
 
 \## Commands
 
@@ -131,4 +136,17 @@ At the end of every session, always invoke `/end-session` before stopping.
 If the session appears to be wrapping up (user says "done", "that's it", "bye", "stop", "exit", or goes quiet after completing a task), proactively suggest running `/end-session`.
 
 Session notes are saved to: `C:\Users\donpu\Vaults\Pucik Notes\Obsidian Writing Studio\`
+
+## Acceptance Criteria Protocol
+
+Before beginning any non-trivial task — defined as any task that touches more than one file, introduces a new setting, or changes behavior a user would notice — write a short acceptance criteria block and surface it to Don for approval before writing any code. When in doubt whether a task qualifies, apply the protocol.
+
+Use this template:
+  Done when: [what is verifiably true when the work is finished]
+  Stop if:   [conditions that halt the work]
+  Out of scope: [explicit exclusions, if any]
+
+Work does not begin until Don gives an affirmative response. Displaying the block and continuing is not sufficient.
+
+If a Cowork direction brief already includes acceptance criteria, use those instead of generating new ones.
 


### PR DESCRIPTION
## Summary

- Replaces `## Manifest Requirements` with `## Manifest Rules` (id/name/description match + minAppVersion; version/tag rule moves to Release Preflight)
- Adds `## Release Preflight` section to CLAUDE.md with 4-point checklist and instruction to run `/release-check` before tagging
- Adds `## Acceptance Criteria Protocol` section to CLAUDE.md with template and explicit approval-gate rule
- Adds `.claude/commands/release-check.md` skill that mechanically runs all four preflight checks (lint, manifest version, CHANGELOG heading, tag prefix) and reports a pass/fail table

## Test plan

- [ ] CLAUDE.md reads cleanly — no duplicate rules, no contradictions with existing sections
- [ ] `/release-check <version>` skill is invocable and runs all four checks against the given version
- [ ] Old `## Manifest Requirements` content fully preserved in new sections (nothing dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)