### PR TITLE
docs: add Notebook Navigator to sidebar explorer open instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ The Folder Sidebar Explorer opens a navigable folder tree in a sidebar panel. Yo
 **To open:**
 - Use the command **Open folder in sidebar explorer** from the command palette.
 - Right-click any folder in the file explorer and choose **Open in sidebar explorer** under **Writing studio options**.
+- Right-click any folder in [Notebook Navigator](https://github.com/johansan/notebook-navigator) and choose **Open in sidebar explorer** (requires Notebook Navigator to be installed).
 - Assign a hotkey in Settings → Hotkeys.
 
 **Browsing and navigation:**


### PR DESCRIPTION
Adds a third bullet to the Folder Sidebar Explorer \"To open\" section documenting that right-clicking a folder in Notebook Navigator now shows \"Open in sidebar explorer\". Shipped in v2.4.5 but missing from the docs.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)