### PR TITLE
chore: set authorUrl in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,6 @@
   "minAppVersion": "1.8.7",
   "description": "A professional writing environment with Focus Mode, Writing Binder, Sprint Timer, WordPress publishing, Folder Sidebar Explorer, and more.",
   "author": "Don Pucik",
-  "authorUrl": "",
+  "authorUrl": "https://github.com/writerP-777",
   "isDesktopOnly": true
 }


### PR DESCRIPTION
## Summary

- Replaces empty `"authorUrl": ""` with `"authorUrl": "https://github.com/writerP-777"`
- Empty-value fields violate Obsidian plugin guidelines (submit-your-plugin.md: do not include fields with empty values)

## Context

Empty `authorUrl` was identified as a potential contributing factor in Writing Studio being removed from the community plugin registry on 2026-06-02. Fixing this before filing the re-add PR ensures the manifest is fully compliant.

## Test plan

- [x] `npm run lint` passes with 0 errors, 0 warnings
- [x] `manifest.json` is valid JSON with no empty-value fields