### PR TITLE
Fix #105: teardown must not write settings — typography & writing mode persistence

### DIFF
--- a/main.js
+++ b/main.js
@@ -11755,7 +11755,9 @@ var TypographyMode = class {
     }
   }
   destroy() {
-    void this.disable();
+    this.active = false;
+    this.removeCustomProperties();
+    activeDocument.body.classList.remove("writing-studio-typography");
   }
 };
 
@@ -11799,6 +11801,7 @@ var WritingModes = class {
   constructor(plugin) {
     this.currentMode = "none";
     this.statusBarEl = null;
+    this.reviewPrior = null;
     this.plugin = plugin;
     this.app = plugin.app;
   }
@@ -11809,7 +11812,7 @@ var WritingModes = class {
   getCurrentMode() {
     return this.currentMode;
   }
-  async switchMode(mode) {
+  async switchMode(mode, silent = false) {
     if (this.currentMode === mode) return;
     this.currentMode = mode;
     const config = WRITING_MODE_CONFIGS[mode];
@@ -11833,12 +11836,16 @@ var WritingModes = class {
     }
     if (config.forceReadingView) {
       this.forceReadingView();
+    } else {
+      this.restoreEditorViewMode();
     }
     this.updateStatusBar();
     this.plugin.settings.currentWritingMode = mode;
     await this.plugin.saveSettings();
-    const modeLabel = mode === "none" ? t2("writingModes.normal") : t2(`launcher.mode.${mode}`);
-    new import_obsidian13.Notice(t2("writingModes.switchedTo", { mode: modeLabel }));
+    if (!silent) {
+      const modeLabel = mode === "none" ? t2("writingModes.normal") : t2(`launcher.mode.${mode}`);
+      new import_obsidian13.Notice(t2("writingModes.switchedTo", { mode: modeLabel }));
+    }
   }
   collapseSidebars() {
     const left = this.app.workspace.leftSplit;
@@ -11854,9 +11861,22 @@ var WritingModes = class {
   }
   forceReadingView() {
     const leaf = this.app.workspace.getMostRecentLeaf();
-    if (leaf && leaf.view.getViewType() === "markdown") {
-      leaf.view.setState({ mode: "preview" }, { history: false });
+    if (!leaf || !(leaf.view instanceof import_obsidian13.MarkdownView)) return;
+    const mode = leaf.view.getMode();
+    if (mode !== "preview") {
+      this.reviewPrior = { leaf, mode };
     }
+    void this.setLeafMode(leaf, "preview");
+  }
+  restoreEditorViewMode() {
+    const prior = this.reviewPrior;
+    this.reviewPrior = null;
+    if (!prior || !(prior.leaf.view instanceof import_obsidian13.MarkdownView)) return;
+    void this.setLeafMode(prior.leaf, prior.mode);
+  }
+  async setLeafMode(leaf, mode) {
+    const state = leaf.getViewState();
+    await leaf.setViewState({ ...state, state: { ...state.state, mode } });
   }
   updateStatusBar() {
     if (!this.statusBarEl) return;
@@ -11872,13 +11892,17 @@ var WritingModes = class {
   restore() {
     const saved = this.plugin.settings.currentWritingMode;
     if (saved && saved !== "none") {
-      void this.switchMode(saved);
+      void this.switchMode(saved, true);
     }
   }
   destroy() {
-    if (this.currentMode !== "none") {
-      void this.switchMode("none");
+    if (this.currentMode === "none") return;
+    const config = WRITING_MODE_CONFIGS[this.currentMode];
+    if (!config.sidebarsVisible) {
+      this.expandSidebars();
     }
+    this.restoreEditorViewMode();
+    this.currentMode = "none";
   }
 };
 

--- a/src/TypographyMode.ts
+++ b/src/TypographyMode.ts
@@ -99,6 +99,11 @@ export class TypographyMode {
   }
 
   destroy(): void {
-    void this.disable();
+    // Teardown removes DOM/CSS state only — it must never write settings.
+    // Unload runs on every app quit, so calling disable() here would erase
+    // the persisted state that "Persist across sessions" exists to keep.
+    this.active = false;
+    this.removeCustomProperties();
+    activeDocument.body.classList.remove('writing-studio-typography');
   }
 }

--- a/src/WritingModes.ts
+++ b/src/WritingModes.ts
@@ -1,4 +1,5 @@
-import { App, Notice } from 'obsidian';
+import { App, MarkdownView, Notice } from 'obsidian';
+import type { WorkspaceLeaf } from 'obsidian';
 import type WritingStudioPlugin from '../main';
 import { WritingModeType, WRITING_MODE_CONFIGS } from '../models/WritingMode';
 import { t } from './i18n';
@@ -8,6 +9,7 @@ export class WritingModes {
   private app: App;
   private currentMode: WritingModeType = 'none';
   private statusBarEl: HTMLElement | null = null;
+  private reviewPrior: { leaf: WorkspaceLeaf; mode: string } | null = null;
 
   constructor(plugin: WritingStudioPlugin) {
     this.plugin = plugin;
@@ -23,7 +25,7 @@ export class WritingModes {
     return this.currentMode;
   }
 
-  async switchMode(mode: WritingModeType): Promise<void> {
+  async switchMode(mode: WritingModeType, silent = false): Promise<void> {
     if (this.currentMode === mode) return;
     this.currentMode = mode;
     const config = WRITING_MODE_CONFIGS[mode];
@@ -57,14 +59,18 @@ export class WritingModes {
     // Reading View
     if (config.forceReadingView) {
       this.forceReadingView();
+    } else {
+      this.restoreEditorViewMode();
     }
 
     this.updateStatusBar();
     this.plugin.settings.currentWritingMode = mode;
     await this.plugin.saveSettings();
 
-    const modeLabel = mode === 'none' ? t('writingModes.normal') : t(`launcher.mode.${mode}`);
-    new Notice(t('writingModes.switchedTo', { mode: modeLabel }));
+    if (!silent) {
+      const modeLabel = mode === 'none' ? t('writingModes.normal') : t(`launcher.mode.${mode}`);
+      new Notice(t('writingModes.switchedTo', { mode: modeLabel }));
+    }
   }
 
   private collapseSidebars(): void {
@@ -83,9 +89,24 @@ export class WritingModes {
 
   private forceReadingView(): void {
     const leaf = this.app.workspace.getMostRecentLeaf();
-    if (leaf && leaf.view.getViewType() === 'markdown') {
-      (leaf.view as unknown as { setState(s: { mode: string }, o: { history: boolean }): void }).setState({ mode: 'preview' }, { history: false });
+    if (!leaf || !(leaf.view instanceof MarkdownView)) return;
+    const mode = leaf.view.getMode();
+    if (mode !== 'preview') {
+      this.reviewPrior = { leaf, mode };
     }
+    void this.setLeafMode(leaf, 'preview');
+  }
+
+  private restoreEditorViewMode(): void {
+    const prior = this.reviewPrior;
+    this.reviewPrior = null;
+    if (!prior || !(prior.leaf.view instanceof MarkdownView)) return;
+    void this.setLeafMode(prior.leaf, prior.mode);
+  }
+
+  private async setLeafMode(leaf: WorkspaceLeaf, mode: string): Promise<void> {
+    const state = leaf.getViewState();
+    await leaf.setViewState({ ...state, state: { ...state.state, mode } });
   }
 
   private updateStatusBar(): void {
@@ -103,13 +124,21 @@ export class WritingModes {
   restore(): void {
     const saved = this.plugin.settings.currentWritingMode;
     if (saved && saved !== 'none') {
-      void this.switchMode(saved);
+      // Silent: a startup restore should not toast on every launch
+      void this.switchMode(saved, true);
     }
   }
 
   destroy(): void {
-    if (this.currentMode !== 'none') {
-      void this.switchMode('none');
+    // Teardown restores workspace state only — it must never write settings.
+    // switchMode('none') here would persist 'none' on every clean shutdown,
+    // leaving restore() nothing to restore.
+    if (this.currentMode === 'none') return;
+    const config = WRITING_MODE_CONFIGS[this.currentMode];
+    if (!config.sidebarsVisible) {
+      this.expandSidebars();
     }
+    this.restoreEditorViewMode();
+    this.currentMode = 'none';
   }
 }

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -17,6 +17,10 @@ export class TFolder {
   }
 }
 
+export class MarkdownView {}
+
+export class WorkspaceLeaf {}
+
 export class Notice {
   static messages: string[] = [];
   constructor(message = '') {

--- a/tests/modes.test.ts
+++ b/tests/modes.test.ts
@@ -1,0 +1,130 @@
+import { TypographyMode } from '../src/TypographyMode';
+import { WritingModes } from '../src/WritingModes';
+import { Notice } from 'obsidian';
+
+// TypographyMode touches the Obsidian `activeDocument` global; fake it for node
+const fakeActiveDocument = {
+  body: { classList: { add: jest.fn(), remove: jest.fn() } },
+  documentElement: { style: { setProperty: jest.fn(), removeProperty: jest.fn() } },
+};
+(globalThis as { activeDocument?: unknown }).activeDocument = fakeActiveDocument;
+
+function makeTypographyPlugin() {
+  return {
+    settings: {
+      typographyModeActive: false,
+      persistTypography: true,
+      typographyFont: 'mono',
+      customFontName: '',
+      maxLineLength: 65,
+      typographyFontSize: 18,
+      lineHeight: 1.7,
+      letterSpacing: 'normal',
+    },
+    saveSettings: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('TypographyMode teardown must not write settings', () => {
+  it('destroy() leaves the persisted active state untouched', async () => {
+    const plugin = makeTypographyPlugin();
+    const mode = new TypographyMode(plugin as never);
+
+    await mode.enable();
+    expect(plugin.settings.typographyModeActive).toBe(true);
+    const savesAfterEnable = plugin.saveSettings.mock.calls.length;
+
+    mode.destroy();
+
+    expect(plugin.settings.typographyModeActive).toBe(true);
+    expect(plugin.saveSettings.mock.calls.length).toBe(savesAfterEnable);
+    expect(mode.isActive()).toBe(false);
+  });
+
+  it('user disable() still persists the off state', async () => {
+    const plugin = makeTypographyPlugin();
+    const mode = new TypographyMode(plugin as never);
+
+    await mode.enable();
+    await mode.disable();
+
+    expect(plugin.settings.typographyModeActive).toBe(false);
+  });
+});
+
+function makeWritingModesPlugin() {
+  return {
+    app: {
+      workspace: {
+        leftSplit: null,
+        rightSplit: null,
+        getMostRecentLeaf: () => null,
+      },
+    },
+    settings: { currentWritingMode: 'none' },
+    saveSettings: jest.fn().mockResolvedValue(undefined),
+    focusMode: { isActive: () => false, enable: jest.fn(), disable: jest.fn() },
+    typographyMode: {
+      isActive: () => false,
+      enable: jest.fn().mockResolvedValue(undefined),
+      disable: jest.fn().mockResolvedValue(undefined),
+    },
+    openBinder: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+beforeEach(() => {
+  Notice.messages = [];
+});
+
+describe('WritingModes teardown must not write settings', () => {
+  it('destroy() leaves the persisted mode untouched', async () => {
+    const plugin = makeWritingModesPlugin();
+    const wm = new WritingModes(plugin as never);
+
+    await wm.switchMode('draft');
+    expect(plugin.settings.currentWritingMode).toBe('draft');
+    const savesAfterSwitch = plugin.saveSettings.mock.calls.length;
+
+    wm.destroy();
+
+    expect(plugin.settings.currentWritingMode).toBe('draft');
+    expect(plugin.saveSettings.mock.calls.length).toBe(savesAfterSwitch);
+    expect(wm.getCurrentMode()).toBe('none');
+  });
+
+  it('user switch to none still persists none', async () => {
+    const plugin = makeWritingModesPlugin();
+    const wm = new WritingModes(plugin as never);
+
+    await wm.switchMode('draft');
+    await wm.switchMode('none');
+
+    expect(plugin.settings.currentWritingMode).toBe('none');
+  });
+});
+
+describe('WritingModes startup restore', () => {
+  it('restore() switches silently to the saved mode', async () => {
+    const plugin = makeWritingModesPlugin();
+    plugin.settings.currentWritingMode = 'edit';
+    const wm = new WritingModes(plugin as never);
+    const spy = jest.spyOn(wm, 'switchMode');
+
+    wm.restore();
+    await Promise.all(spy.mock.results.map(r => r.value as Promise<void>));
+
+    expect(spy).toHaveBeenCalledWith('edit', true);
+    expect(wm.getCurrentMode()).toBe('edit');
+    expect(Notice.messages).toEqual([]);
+  });
+
+  it('a user-initiated switch still shows a notice', async () => {
+    const plugin = makeWritingModesPlugin();
+    const wm = new WritingModes(plugin as never);
+
+    await wm.switchMode('draft');
+
+    expect(Notice.messages.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #105 (audit unit 2/15).

## Acceptance criteria (self-recorded — Don released this unit end-to-end, including merge)

Done when:
- Quitting Obsidian (plugin unload) no longer writes `typographyModeActive=false` or `currentWritingMode='none'`; with persistence enabled, both features survive a restart for the first time.
- User-initiated toggles/switches still persist exactly as before.
- Leaving review mode restores the editor view mode that was active before review forced reading view.
- Startup restore is silent; user switches still show the notice.
- Lint 0/0, all tests pass, production build clean, main.js committed with source.

Stop if: fix requires changes beyond TypographyMode.ts, WritingModes.ts, test files. (Not hit.)
Out of scope: forceReadingView only affecting the most recent leaf (#105 minor, deferred — noted below).

## What changed

- **`TypographyMode.destroy()`** removes the body class and CSS custom properties only. The design rule from the audit (cross-cutting pattern 2) is applied: *teardown removes DOM/CSS state; settings change only on user action.*
- **`WritingModes.destroy()`** expands sidebars if the mode had hidden them and restores the editor view mode, then clears the in-memory mode — without writing settings. The unload-path Notice and the typography force-disable side effect are gone (typography has its own destroy).
- **Review one-way door fixed:** `forceReadingView` records the leaf's prior mode; any transition to a non-review mode restores it.
- **Typed API:** the `setState` structural cast replaced with `instanceof MarkdownView`, `getMode()`, and `leaf.getViewState()/setViewState()`.
- **Silent restore:** `switchMode(mode, silent)` — `restore()` passes `silent=true`, so launches no longer toast.

## Deferred (per issue, listed as minor)
`forceReadingView` still targets only the most recent leaf; other open panes stay editable in review mode. Cosmetic relative to the persistence fix; revisit if it bothers in practice.

## Tests
6 new regression tests in `tests/modes.test.ts`: destroy leaves persisted state untouched (both classes), user actions still persist, restore is silent and applies the saved mode, user switches still toast. 66/66 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)