### PR TITLE
Fix #107: export execution — LaTeX PDF engine per docs, execFile instead of shell string

### DIFF
--- a/main.js
+++ b/main.js
@@ -13242,7 +13242,7 @@ em { font-style: italic; }
 };
 
 // src/ExportEngine.ts
-var execAsync = (0, import_util.promisify)(import_child_process.exec);
+var execFileAsync = (0, import_util.promisify)(import_child_process.execFile);
 var MANUSCRIPT_CSS = `
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body {
@@ -13583,28 +13583,21 @@ ${this.markdownToHtml(content)}
       await this.writeFile(tempMdPath, content);
       const absOutput = this.getAbsPath(outputPath);
       const absInput = this.getAbsPath(tempMdPath);
-      const isPdf = outputPath.endsWith(".pdf");
-      const args = [
-        `"${absInput}"`,
-        `--from markdown`,
-        `-o "${absOutput}"`
-      ];
-      if (isPdf) {
-        args.push("--pdf-engine=wkhtmltopdf");
-      }
+      const args = [absInput, "--from", "markdown", "-o", absOutput];
       if (opts.font) {
         const safeFont = opts.font.replace(/["'`\\$]/g, "");
-        args.push(`-V mainfont="${safeFont}"`);
+        args.push("-V", `mainfont=${safeFont}`);
       }
-      await execAsync(`${pandocPath} ${args.join(" ")}`);
+      await execFileAsync(pandocPath, args);
       new import_obsidian16.Notice(t2("exportEngine.exportedTo", { path: outputPath }));
       return outputPath;
     } catch (e) {
       throw new Error(`Pandoc export failed: ${e instanceof Error ? e.message : String(e)}
 Ensure pandoc is installed.`);
     } finally {
-      const tmpFile = this.app.vault.getAbstractFileByPath(tempMdPath);
-      if (tmpFile instanceof import_obsidian16.TFile) await this.app.fileManager.trashFile(tmpFile);
+      if (this.app.vault.getAbstractFileByPath(tempMdPath) instanceof import_obsidian16.TFile) {
+        await this.app.vault.adapter.remove(tempMdPath);
+      }
     }
   }
   async exportPdf(content, outputPath, opts) {

--- a/src/ExportEngine.ts
+++ b/src/ExportEngine.ts
@@ -1,5 +1,5 @@
 import { App, MarkdownView, TFile, normalizePath, Notice } from 'obsidian';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import type WritingStudioPlugin from '../main';
 import { EpubEngine, EpubChapter } from './EpubEngine';
@@ -9,7 +9,7 @@ interface FileSystemAdapter {
   getFullPath?(vaultPath: string): string;
 }
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export type ExportFormat = 'pdf' | 'docx' | 'rtf' | 'md' | 'html' | 'epub' | 'manuscript';
 export type ExportScope = 'current' | 'selected' | 'project';
@@ -434,33 +434,28 @@ ${this.markdownToHtml(content)}
       const absOutput = this.getAbsPath(outputPath);
       const absInput = this.getAbsPath(tempMdPath);
 
-      const isPdf = outputPath.endsWith('.pdf');
-
-      const args = [
-        `"${absInput}"`,
-        `--from markdown`,
-        `-o "${absOutput}"`,
-      ];
-
-      // --pdf-engine is only valid for PDF output; passing it for DOCX/RTF
-      // causes a fatal error in pandoc 3.x and must be omitted.
-      if (isPdf) {
-        args.push('--pdf-engine=wkhtmltopdf');
-      }
+      // No --pdf-engine flag: pandoc defaults to LaTeX for PDF output, which
+      // is what the README tells users to install (TeX Live / MiKTeX)
+      const args = [absInput, '--from', 'markdown', '-o', absOutput];
 
       if (opts.font) {
         const safeFont = opts.font.replace(/["'`\\$]/g, '');
-        args.push(`-V mainfont="${safeFont}"`);
+        args.push('-V', `mainfont=${safeFont}`);
       }
 
-      await execAsync(`${pandocPath} ${args.join(' ')}`);
+      // execFile: no shell, so a pandoc path with spaces (C:\Program Files\...)
+      // works and path/font content cannot be interpreted as shell syntax
+      await execFileAsync(pandocPath, args);
       new Notice(t('exportEngine.exportedTo', { path: outputPath }));
       return outputPath;
     } catch (e) {
       throw new Error(`Pandoc export failed: ${e instanceof Error ? e.message : String(e)}\nEnsure pandoc is installed.`);
     } finally {
-      const tmpFile = this.app.vault.getAbstractFileByPath(tempMdPath);
-      if (tmpFile instanceof TFile) await this.app.fileManager.trashFile(tmpFile);
+      // Remove the temp file outright via the adapter — trashing it
+      // accumulated a .tmp.md in .trash/ on every pandoc export
+      if (this.app.vault.getAbstractFileByPath(tempMdPath) instanceof TFile) {
+        await this.app.vault.adapter.remove(tempMdPath);
+      }
     }
   }
 


### PR DESCRIPTION
Closes #107 (audit unit 4/15).

## Acceptance criteria (self-recorded — Don released this unit end-to-end, including merge)

Done when:
- A user who installs MiKTeX/TeX Live per the README gets working PDF export (no forced wkhtmltopdf).
- A pandoc path containing spaces works; no shell interprets the command.
- Pandoc temp files no longer accumulate in `.trash/`.
- Lint 0/0, tests pass, build clean, main.js committed with source.

## What changed
- Dropped the hardcoded `--pdf-engine=wkhtmltopdf` (`ExportEngine.ts:447-449`) — pandoc's default PDF engine is LaTeX, matching the README requirements table.
- `execAsync(shell string)` → `execFileAsync(pandocPath, argsArray)` — no shell, no quoting, no injection surface; args passed as a real array (`--from markdown` was previously a single joined token that only worked because the shell re-split it).
- Temp `.tmp.md` removed via `adapter.remove()` in the `finally` block. (First attempt used `vault.delete()` — the obsidianmd lint rule correctly flagged it; adapter removal is the right call for a plugin-generated temp artifact.)

No behavior change for docx/rtf beyond the safer invocation. 74/74 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)