### PR TITLE
Fix #110: local-date helper — UTC "today" eliminated across the plugin

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,10 +27,10 @@ __export(main_exports, {
   default: () => WritingStudioPlugin
 });
 module.exports = __toCommonJS(main_exports);
-var import_obsidian30 = require("obsidian");
+var import_obsidian31 = require("obsidian");
 
 // src/BinderView.ts
-var import_obsidian6 = require("obsidian");
+var import_obsidian7 = require("obsidian");
 
 // models/BinderItem.ts
 var STATUS_COLORS = {
@@ -9981,8 +9981,18 @@ var TargetsDashboardModal = class extends import_obsidian3.Modal {
 };
 
 // modals/PublishModal.ts
+var import_obsidian5 = require("obsidian");
+
+// src/dates.ts
 var import_obsidian4 = require("obsidian");
-var PublishModal = class extends import_obsidian4.Modal {
+var momentUntyped = import_obsidian4.moment;
+var moment = momentUntyped;
+function localDateString(date) {
+  return moment(date).format("YYYY-MM-DD");
+}
+
+// modals/PublishModal.ts
+var PublishModal = class extends import_obsidian5.Modal {
   constructor(app, plugin, filePath) {
     super(app);
     this.selectedSiteId = "";
@@ -10011,7 +10021,7 @@ var PublishModal = class extends import_obsidian4.Modal {
       return;
     }
     await this.loadExistingMeta();
-    new import_obsidian4.Setting(contentEl).setName(t2("publishModal.siteName")).addDropdown((d) => {
+    new import_obsidian5.Setting(contentEl).setName(t2("publishModal.siteName")).addDropdown((d) => {
       sites.forEach((s) => {
         d.addOption(s.id, s.nickname || s.url);
       });
@@ -10025,10 +10035,10 @@ var PublishModal = class extends import_obsidian4.Modal {
         void this.loadCategories().then(() => this.render());
       });
     });
-    new import_obsidian4.Setting(contentEl).setName(t2("publishModal.postTitleName")).addText((tx) => tx.setValue(this.postTitle).onChange((v) => {
+    new import_obsidian5.Setting(contentEl).setName(t2("publishModal.postTitleName")).addText((tx) => tx.setValue(this.postTitle).onChange((v) => {
       this.postTitle = v;
     }));
-    new import_obsidian4.Setting(contentEl).setName(t2("publishModal.postStatusName")).addDropdown((d) => d.addOption("draft", t2("publishModal.postStatus.draft")).addOption("pending", t2("publishModal.postStatus.pending")).addOption("publish", t2("publishModal.postStatus.publish")).setValue(this.postStatus).onChange((v) => {
+    new import_obsidian5.Setting(contentEl).setName(t2("publishModal.postStatusName")).addDropdown((d) => d.addOption("draft", t2("publishModal.postStatus.draft")).addOption("pending", t2("publishModal.postStatus.pending")).addOption("publish", t2("publishModal.postStatus.publish")).setValue(this.postStatus).onChange((v) => {
       this.postStatus = v;
     }));
     const site = this.getSite();
@@ -10036,7 +10046,7 @@ var PublishModal = class extends import_obsidian4.Modal {
       this.categories = await this.plugin.wpClient.getCategories(site);
     }
     if (this.categories.length > 0) {
-      new import_obsidian4.Setting(contentEl).setName(t2("publishModal.categoryName"));
+      new import_obsidian5.Setting(contentEl).setName(t2("publishModal.categoryName"));
       const catList = contentEl.createDiv("ws-publish-categories");
       for (const cat of this.categories) {
         const label = catList.createEl("label", { cls: "ws-publish-cat-label" });
@@ -10052,13 +10062,13 @@ var PublishModal = class extends import_obsidian4.Modal {
         label.createSpan({ text: ` ${cat.name} (${cat.count})` });
       }
     }
-    new import_obsidian4.Setting(contentEl).setName(t2("publishModal.tagsName")).setDesc(t2("publishModal.tagsDesc")).addText((tx) => tx.setValue(this.tags.join(", ")).onChange((v) => {
+    new import_obsidian5.Setting(contentEl).setName(t2("publishModal.tagsName")).setDesc(t2("publishModal.tagsDesc")).addText((tx) => tx.setValue(this.tags.join(", ")).onChange((v) => {
       this.tags = v.split(",").map((s) => s.trim()).filter(Boolean);
     }));
-    new import_obsidian4.Setting(contentEl).setName(t2("publishModal.excerptName")).addTextArea((tx) => tx.setValue(this.excerpt).onChange((v) => {
+    new import_obsidian5.Setting(contentEl).setName(t2("publishModal.excerptName")).addTextArea((tx) => tx.setValue(this.excerpt).onChange((v) => {
       this.excerpt = v;
     }));
-    new import_obsidian4.Setting(contentEl).setName(t2("publishModal.scheduleName")).setDesc(t2("publishModal.scheduleDesc")).addText((tx) => tx.setPlaceholder(t2("publishModal.schedulePlaceholder")).setValue(this.scheduledDate).onChange((v) => {
+    new import_obsidian5.Setting(contentEl).setName(t2("publishModal.scheduleName")).setDesc(t2("publishModal.scheduleDesc")).addText((tx) => tx.setPlaceholder(t2("publishModal.schedulePlaceholder")).setValue(this.scheduledDate).onChange((v) => {
       this.scheduledDate = v;
     }));
     if (this.existingPostId) {
@@ -10092,7 +10102,7 @@ var PublishModal = class extends import_obsidian4.Modal {
   }
   async loadExistingMeta() {
     const file = this.app.vault.getAbstractFileByPath(this.filePath);
-    if (!(file instanceof import_obsidian4.TFile)) return;
+    if (!(file instanceof import_obsidian5.TFile)) return;
     const content = await this.app.vault.read(file);
     const fm = this.plugin.fmManager.parseFrontmatter(content);
     if (fm) {
@@ -10119,12 +10129,12 @@ var PublishModal = class extends import_obsidian4.Modal {
   async doPublish(updateExisting) {
     const site = this.getSite();
     if (!site) {
-      new import_obsidian4.Notice(t2("publishModal.noSiteSelected"));
+      new import_obsidian5.Notice(t2("publishModal.noSiteSelected"));
       return;
     }
     const file = this.app.vault.getAbstractFileByPath(this.filePath);
-    if (!(file instanceof import_obsidian4.TFile)) {
-      new import_obsidian4.Notice(t2("publishModal.fileNotFound"));
+    if (!(file instanceof import_obsidian5.TFile)) {
+      new import_obsidian5.Notice(t2("publishModal.fileNotFound"));
       return;
     }
     try {
@@ -10146,15 +10156,15 @@ var PublishModal = class extends import_obsidian4.Modal {
           wpPostId: result.postId,
           wpUrl: result.url,
           wpStatus: result.status,
-          wpPublished: result.scheduledDate ? void 0 : (/* @__PURE__ */ new Date()).toISOString().split("T")[0],
+          wpPublished: result.scheduledDate ? void 0 : localDateString(),
           wpScheduled: result.scheduledDate
         });
       });
       const action = this.scheduledDate ? t2("publishModal.scheduled") : t2("publishModal.published");
-      new import_obsidian4.Notice(t2("publishModal.actionNotice", { action, url: result.url }), 1e4);
+      new import_obsidian5.Notice(t2("publishModal.actionNotice", { action, url: result.url }), 1e4);
       this.close();
     } catch (e) {
-      new import_obsidian4.Notice(t2("publishModal.publishFailed", { error: e instanceof Error ? e.message : String(e) }));
+      new import_obsidian5.Notice(t2("publishModal.publishFailed", { error: e instanceof Error ? e.message : String(e) }));
     }
   }
   onClose() {
@@ -10163,8 +10173,8 @@ var PublishModal = class extends import_obsidian4.Modal {
 };
 
 // modals/ScanFolderModal.ts
-var import_obsidian5 = require("obsidian");
-var ScanFolderModal = class extends import_obsidian5.Modal {
+var import_obsidian6 = require("obsidian");
+var ScanFolderModal = class extends import_obsidian6.Modal {
   constructor(app, files, onConfirm) {
     super(app);
     this.files = files;
@@ -10214,7 +10224,7 @@ var STATUS_DOT_KEY = {
   published: "targetsDashboard.status.published"
 };
 var BINDER_VIEW_TYPE = "writing-studio-binder";
-var BinderView = class extends import_obsidian6.ItemView {
+var BinderView = class extends import_obsidian7.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
     this.activeProject = null;
@@ -10270,7 +10280,7 @@ var BinderView = class extends import_obsidian6.ItemView {
       await this.refresh();
     };
     const newProjectBtn = projectRow.createEl("button", { cls: "ws-binder-btn", title: t2("binder.newProject") });
-    (0, import_obsidian6.setIcon)(newProjectBtn, "plus");
+    (0, import_obsidian7.setIcon)(newProjectBtn, "plus");
     newProjectBtn.onclick = () => {
       new ProjectModal(this.app, this.plugin, () => {
         void this.refresh();
@@ -10283,24 +10293,24 @@ var BinderView = class extends import_obsidian6.ItemView {
     });
     newDocBtn.onclick = async () => {
       if (!this.activeProject) {
-        new import_obsidian6.Notice(t2("binder.selectProjectFirst"));
+        new import_obsidian7.Notice(t2("binder.selectProjectFirst"));
         return;
       }
       await this.createNewDocument();
     };
     const scanBtn = toolbar.createEl("button", { cls: "ws-binder-btn" });
     scanBtn.ariaLabel = t2("binder.addFiles");
-    (0, import_obsidian6.setIcon)(scanBtn, "folder-sync");
-    (0, import_obsidian6.setTooltip)(scanBtn, t2("binder.addFiles"));
+    (0, import_obsidian7.setIcon)(scanBtn, "folder-sync");
+    (0, import_obsidian7.setTooltip)(scanBtn, t2("binder.addFiles"));
     scanBtn.onclick = async () => {
       if (!this.activeProject) {
-        new import_obsidian6.Notice(t2("binder.selectProjectFirst"));
+        new import_obsidian7.Notice(t2("binder.selectProjectFirst"));
         return;
       }
       await this.scanProjectFolder();
     };
     const dashBtn = toolbar.createEl("button", { cls: "ws-binder-btn", title: t2("binder.targetsDashboard") });
-    (0, import_obsidian6.setIcon)(dashBtn, "target");
+    (0, import_obsidian7.setIcon)(dashBtn, "target");
     dashBtn.onclick = () => {
       new TargetsDashboardModal(this.app, this.plugin).open();
     };
@@ -10366,10 +10376,10 @@ var BinderView = class extends import_obsidian6.ItemView {
       dot.title = t2(STATUS_DOT_KEY[item.status]);
       const titleEl = row.createSpan("ws-binder-title");
       const liveFile = this.app.vault.getAbstractFileByPath(item.filePath);
-      const displayTitle = liveFile instanceof import_obsidian6.TFile ? liveFile.basename : item.title;
+      const displayTitle = liveFile instanceof import_obsidian7.TFile ? liveFile.basename : item.title;
       titleEl.textContent = displayTitle;
       titleEl.contentEditable = "false";
-      if (liveFile instanceof import_obsidian6.TFile && item.title !== liveFile.basename) {
+      if (liveFile instanceof import_obsidian7.TFile && item.title !== liveFile.basename) {
         item.title = liveFile.basename;
         void this.saveBinder();
       }
@@ -10442,7 +10452,7 @@ var BinderView = class extends import_obsidian6.ItemView {
   }
   async loadWordCount(item, el) {
     const file = this.app.vault.getAbstractFileByPath(item.filePath);
-    if (!(file instanceof import_obsidian6.TFile)) {
+    if (!(file instanceof import_obsidian7.TFile)) {
       el.textContent = "0W";
       return;
     }
@@ -10485,8 +10495,8 @@ var BinderView = class extends import_obsidian6.ItemView {
   }
   async openDocument(item) {
     const file = this.app.vault.getAbstractFileByPath(item.filePath);
-    if (!(file instanceof import_obsidian6.TFile)) {
-      new import_obsidian6.Notice(t2("binder.cannotFindFile", { filePath: item.filePath }));
+    if (!(file instanceof import_obsidian7.TFile)) {
+      new import_obsidian7.Notice(t2("binder.cannotFindFile", { filePath: item.filePath }));
       return;
     }
     const leaf = this.app.workspace.getLeaf(false);
@@ -10506,13 +10516,13 @@ var BinderView = class extends import_obsidian6.ItemView {
       const newTitle = ((_a2 = el.textContent) == null ? void 0 : _a2.trim()) || item.title;
       if (newTitle !== item.title) {
         const file = this.app.vault.getAbstractFileByPath(item.filePath);
-        if (file instanceof import_obsidian6.TFile) {
+        if (file instanceof import_obsidian7.TFile) {
           await this.app.fileManager.processFrontMatter(file, (fm) => {
             fm["title"] = newTitle;
           });
           const parentPath = item.filePath.substring(0, item.filePath.lastIndexOf("/"));
           const sanitized = newTitle.replace(/[\\/:*?"<>|]/g, "-");
-          const newPath = (0, import_obsidian6.normalizePath)(`${parentPath}/${sanitized}.md`);
+          const newPath = (0, import_obsidian7.normalizePath)(`${parentPath}/${sanitized}.md`);
           await this.app.fileManager.renameFile(file, newPath);
           item.filePath = newPath;
         }
@@ -10533,7 +10543,7 @@ var BinderView = class extends import_obsidian6.ItemView {
     };
   }
   showContextMenu(e, item) {
-    const menu = new import_obsidian6.Menu();
+    const menu = new import_obsidian7.Menu();
     menu.addItem((i) => i.setTitle(t2("binder.menu.openDocument")).setIcon("file-text").onClick(() => {
       void this.openDocument(item);
     }));
@@ -10597,7 +10607,7 @@ var BinderView = class extends import_obsidian6.ItemView {
     );
     const srcFile = this.app.vault.getAbstractFileByPath(item.filePath);
     const dstFile = this.app.vault.getAbstractFileByPath(newItem.filePath);
-    if (srcFile instanceof import_obsidian6.TFile && dstFile instanceof import_obsidian6.TFile) {
+    if (srcFile instanceof import_obsidian7.TFile && dstFile instanceof import_obsidian7.TFile) {
       const content = await this.app.vault.read(srcFile);
       await this.app.vault.modify(dstFile, content);
     }
@@ -10605,11 +10615,11 @@ var BinderView = class extends import_obsidian6.ItemView {
   }
   async moveToResearch(item) {
     if (!this.activeProject) return;
-    const researchDir = (0, import_obsidian6.normalizePath)(`${this.activeProject.folderPath}/Research`);
+    const researchDir = (0, import_obsidian7.normalizePath)(`${this.activeProject.folderPath}/Research`);
     const fileName = item.filePath.split("/").pop() || "note.md";
-    const newPath = (0, import_obsidian6.normalizePath)(`${researchDir}/${fileName}`);
+    const newPath = (0, import_obsidian7.normalizePath)(`${researchDir}/${fileName}`);
     const file = this.app.vault.getAbstractFileByPath(item.filePath);
-    if (file instanceof import_obsidian6.TFile) {
+    if (file instanceof import_obsidian7.TFile) {
       await this.app.vault.rename(file, newPath);
     }
     item.filePath = newPath;
@@ -10620,7 +10630,7 @@ var BinderView = class extends import_obsidian6.ItemView {
   async deleteItem(item) {
     if (!this.activeProject) return;
     const file = this.app.vault.getAbstractFileByPath(item.filePath);
-    if (file instanceof import_obsidian6.TFile) {
+    if (file instanceof import_obsidian7.TFile) {
       await this.app.fileManager.trashFile(file);
     }
     await this.plugin.projectManager.removeItemFromBinder(this.activeProject, item.id);
@@ -10751,10 +10761,10 @@ var BinderView = class extends import_obsidian6.ItemView {
   }
   async scanProjectFolder() {
     if (!this.activeProject) {
-      new import_obsidian6.Notice(t2("binder.selectProjectFirst"));
+      new import_obsidian7.Notice(t2("binder.selectProjectFirst"));
       return;
     }
-    const projectFolder = (0, import_obsidian6.normalizePath)(this.activeProject.folderPath);
+    const projectFolder = (0, import_obsidian7.normalizePath)(this.activeProject.folderPath);
     const existingPaths = new Set(
       this.plugin.projectManager.flattenBinder(this.binderItems).map((i) => i.filePath)
     );
@@ -10762,7 +10772,7 @@ var BinderView = class extends import_obsidian6.ItemView {
       (f) => f.extension === "md" && f.path.startsWith(projectFolder + "/") && !f.name.startsWith("_") && !existingPaths.has(f.path)
     );
     if (untracked.length === 0) {
-      new import_obsidian6.Notice(t2("binder.noNewFiles"));
+      new import_obsidian7.Notice(t2("binder.noNewFiles"));
       return;
     }
     new ScanFolderModal(this.app, untracked, async (selected) => {
@@ -10797,11 +10807,11 @@ var BinderView = class extends import_obsidian6.ItemView {
 };
 
 // src/CompilePreview.ts
-var import_obsidian8 = require("obsidian");
+var import_obsidian9 = require("obsidian");
 
 // modals/ExportModal.ts
-var import_obsidian7 = require("obsidian");
-var ExportModal = class extends import_obsidian7.Modal {
+var import_obsidian8 = require("obsidian");
+var ExportModal = class extends import_obsidian8.Modal {
   constructor(app, plugin, initialScope = "current") {
     super(app);
     this.exportScope = "current";
@@ -10822,32 +10832,32 @@ var ExportModal = class extends import_obsidian7.Modal {
     contentEl.createEl("h2", { text: t2("exportModal.title") });
     let coverSetting;
     let contactSetting;
-    new import_obsidian7.Setting(contentEl).setName(t2("exportModal.formatName")).addDropdown((d) => d.addOption("md", t2("exportModal.format.md")).addOption("html", t2("exportModal.format.html")).addOption("manuscript", t2("exportModal.format.manuscript")).addOption("epub", t2("exportModal.format.epub")).addOption("pdf", t2("exportModal.format.pdf")).addOption("docx", t2("exportModal.format.docx")).addOption("rtf", t2("exportModal.format.rtf")).setValue(this.format).onChange((v) => {
+    new import_obsidian8.Setting(contentEl).setName(t2("exportModal.formatName")).addDropdown((d) => d.addOption("md", t2("exportModal.format.md")).addOption("html", t2("exportModal.format.html")).addOption("manuscript", t2("exportModal.format.manuscript")).addOption("epub", t2("exportModal.format.epub")).addOption("pdf", t2("exportModal.format.pdf")).addOption("docx", t2("exportModal.format.docx")).addOption("rtf", t2("exportModal.format.rtf")).setValue(this.format).onChange((v) => {
       this.format = v;
       coverSetting.settingEl.toggleClass("ws-hidden", v !== "epub");
       contactSetting.settingEl.toggleClass("ws-hidden", v !== "manuscript");
     }));
-    coverSetting = new import_obsidian7.Setting(contentEl).setName(t2("exportModal.coverImageName")).setDesc(t2("exportModal.coverImageDesc")).addText((tx) => tx.setValue(this.coverImagePath).setPlaceholder(t2("exportModal.coverImagePlaceholder")).onChange((v) => {
+    coverSetting = new import_obsidian8.Setting(contentEl).setName(t2("exportModal.coverImageName")).setDesc(t2("exportModal.coverImageDesc")).addText((tx) => tx.setValue(this.coverImagePath).setPlaceholder(t2("exportModal.coverImagePlaceholder")).onChange((v) => {
       this.coverImagePath = v.trim();
     }));
     coverSetting.settingEl.toggleClass("ws-hidden", this.format !== "epub");
-    contactSetting = new import_obsidian7.Setting(contentEl).setName(t2("exportModal.contactInfoName")).setDesc(t2("exportModal.contactInfoDesc")).addTextArea((tx) => tx.setValue(this.authorContact).setPlaceholder(t2("exportModal.contactInfoPlaceholder")).onChange((v) => {
+    contactSetting = new import_obsidian8.Setting(contentEl).setName(t2("exportModal.contactInfoName")).setDesc(t2("exportModal.contactInfoDesc")).addTextArea((tx) => tx.setValue(this.authorContact).setPlaceholder(t2("exportModal.contactInfoPlaceholder")).onChange((v) => {
       this.authorContact = v;
     }));
     contactSetting.settingEl.toggleClass("ws-hidden", this.format !== "manuscript");
-    new import_obsidian7.Setting(contentEl).setName(t2("exportModal.scopeName")).addDropdown((d) => d.addOption("current", t2("exportModal.scopeCurrent")).addOption("project", t2("exportModal.scopeProject")).setValue(this.exportScope).onChange((v) => {
+    new import_obsidian8.Setting(contentEl).setName(t2("exportModal.scopeName")).addDropdown((d) => d.addOption("current", t2("exportModal.scopeCurrent")).addOption("project", t2("exportModal.scopeProject")).setValue(this.exportScope).onChange((v) => {
       this.exportScope = v;
     }));
-    new import_obsidian7.Setting(contentEl).setName(t2("exportModal.includeFrontmatter")).addToggle((tx) => tx.setValue(this.includeFrontmatter).onChange((v) => {
+    new import_obsidian8.Setting(contentEl).setName(t2("exportModal.includeFrontmatter")).addToggle((tx) => tx.setValue(this.includeFrontmatter).onChange((v) => {
       this.includeFrontmatter = v;
     }));
-    new import_obsidian7.Setting(contentEl).setName(t2("exportModal.includeResearch")).addToggle((tx) => tx.setValue(this.includeResearch).onChange((v) => {
+    new import_obsidian8.Setting(contentEl).setName(t2("exportModal.includeResearch")).addToggle((tx) => tx.setValue(this.includeResearch).onChange((v) => {
       this.includeResearch = v;
     }));
-    new import_obsidian7.Setting(contentEl).setName(t2("exportModal.includeTitlesAsHeadings")).addToggle((tx) => tx.setValue(this.includeTitlesAsHeadings).onChange((v) => {
+    new import_obsidian8.Setting(contentEl).setName(t2("exportModal.includeTitlesAsHeadings")).addToggle((tx) => tx.setValue(this.includeTitlesAsHeadings).onChange((v) => {
       this.includeTitlesAsHeadings = v;
     }));
-    new import_obsidian7.Setting(contentEl).setName(t2("exportModal.addTitlePage")).setDesc(t2("exportModal.addTitlePageDesc")).addToggle((tx) => tx.setValue(this.addTitlePage).onChange((v) => {
+    new import_obsidian8.Setting(contentEl).setName(t2("exportModal.addTitlePage")).setDesc(t2("exportModal.addTitlePageDesc")).addToggle((tx) => tx.setValue(this.addTitlePage).onChange((v) => {
       this.addTitlePage = v;
     }));
     const previewBtn = contentEl.createEl("button", {
@@ -10879,7 +10889,7 @@ var ExportModal = class extends import_obsidian7.Modal {
         });
         this.close();
       } catch (e) {
-        new import_obsidian7.Notice(t2("exportModal.exportFailed", { error: e instanceof Error ? e.message : String(e) }));
+        new import_obsidian8.Notice(t2("exportModal.exportFailed", { error: e instanceof Error ? e.message : String(e) }));
         exportBtn.disabled = false;
         exportBtn.textContent = t2("exportModal.exportBtn");
       }
@@ -10894,7 +10904,7 @@ var ExportModal = class extends import_obsidian7.Modal {
 
 // src/CompilePreview.ts
 var COMPILE_PREVIEW_VIEW_TYPE = "writing-studio-compile-preview";
-var CompilePreviewView = class extends import_obsidian8.ItemView {
+var CompilePreviewView = class extends import_obsidian9.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
     this.content = "";
@@ -10990,7 +11000,7 @@ var CompilePreviewView = class extends import_obsidian8.ItemView {
         const id = h1[1].toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
         sectionDiv.setAttribute("data-section-id", id);
       }
-      void import_obsidian8.MarkdownRenderer.render(this.app, section, sectionDiv, "", this);
+      void import_obsidian9.MarkdownRenderer.render(this.app, section, sectionDiv, "", this);
     }
   }
   async onClose() {
@@ -10998,11 +11008,11 @@ var CompilePreviewView = class extends import_obsidian8.ItemView {
 };
 
 // src/LauncherView.ts
-var import_obsidian11 = require("obsidian");
+var import_obsidian12 = require("obsidian");
 
 // modals/WritingDashboardModal.ts
-var import_obsidian9 = require("obsidian");
-var WritingDashboardModal = class extends import_obsidian9.Modal {
+var import_obsidian10 = require("obsidian");
+var WritingDashboardModal = class extends import_obsidian10.Modal {
   constructor(app, plugin) {
     super(app);
     this.plugin = plugin;
@@ -11093,7 +11103,7 @@ var WritingDashboardModal = class extends import_obsidian9.Modal {
         if (item.type === "group" || item.type === "part") continue;
         const file = this.app.vault.getAbstractFileByPath(item.filePath);
         let wc = 0;
-        if (file instanceof import_obsidian9.TFile) {
+        if (file instanceof import_obsidian10.TFile) {
           const content = await this.app.vault.read(file);
           wc = this.plugin.fmManager.countWords(content);
         }
@@ -11103,7 +11113,7 @@ var WritingDashboardModal = class extends import_obsidian9.Modal {
         link.href = "#";
         link.onclick = async (e) => {
           e.preventDefault();
-          if (file instanceof import_obsidian9.TFile) {
+          if (file instanceof import_obsidian10.TFile) {
             const leaf = this.app.workspace.getLeaf(false);
             await leaf.openFile(file);
             this.close();
@@ -11127,8 +11137,8 @@ var WritingDashboardModal = class extends import_obsidian9.Modal {
 };
 
 // modals/SprintModal.ts
-var import_obsidian10 = require("obsidian");
-var SprintModal = class extends import_obsidian10.Modal {
+var import_obsidian11 = require("obsidian");
+var SprintModal = class extends import_obsidian11.Modal {
   constructor(app, plugin) {
     super(app);
     this.sprintScope = "file";
@@ -11141,7 +11151,7 @@ var SprintModal = class extends import_obsidian10.Modal {
     contentEl.empty();
     contentEl.addClass("ws-sprint-modal");
     contentEl.createEl("h2", { text: t2("sprintModal.setupTitle") });
-    new import_obsidian10.Setting(contentEl).setName(t2("sprintModal.durationName")).setDesc(t2("sprintModal.durationDesc")).addDropdown((d) => {
+    new import_obsidian11.Setting(contentEl).setName(t2("sprintModal.durationName")).setDesc(t2("sprintModal.durationDesc")).addDropdown((d) => {
       [10, 15, 25, 30, 45, 60].forEach((m) => {
         d.addOption(String(m), `${m} min`);
       });
@@ -11154,10 +11164,10 @@ var SprintModal = class extends import_obsidian10.Modal {
     }).addText((tx) => tx.setPlaceholder(t2("sprintModal.durationCustomPlaceholder")).onChange((v) => {
       this.duration = parseInt(v) || this.duration;
     }));
-    new import_obsidian10.Setting(contentEl).setName(t2("sprintModal.wordGoalName")).setDesc(t2("sprintModal.wordGoalDesc")).addText((tx) => tx.setPlaceholder("0").setValue(String(this.wordGoal || "")).onChange((v) => {
+    new import_obsidian11.Setting(contentEl).setName(t2("sprintModal.wordGoalName")).setDesc(t2("sprintModal.wordGoalDesc")).addText((tx) => tx.setPlaceholder("0").setValue(String(this.wordGoal || "")).onChange((v) => {
       this.wordGoal = parseInt(v) || 0;
     }));
-    new import_obsidian10.Setting(contentEl).setName(t2("sprintModal.scopeName")).addDropdown((d) => d.addOption("file", t2("sprintModal.scopeFile")).addOption("project", t2("sprintModal.scopeProject")).setValue(this.sprintScope).onChange((v) => {
+    new import_obsidian11.Setting(contentEl).setName(t2("sprintModal.scopeName")).addDropdown((d) => d.addOption("file", t2("sprintModal.scopeFile")).addOption("project", t2("sprintModal.scopeProject")).setValue(this.sprintScope).onChange((v) => {
       this.sprintScope = v;
     }));
     const btnRow = contentEl.createDiv("ws-modal-btn-row");
@@ -11167,7 +11177,7 @@ var SprintModal = class extends import_obsidian10.Modal {
     });
     startBtn.onclick = () => {
       if (!this.duration || this.duration <= 0) {
-        new import_obsidian10.Notice(t2("sprintModal.errorDuration"));
+        new import_obsidian11.Notice(t2("sprintModal.errorDuration"));
         return;
       }
       this.plugin.sprintTimer.setup(this.duration, this.wordGoal || void 0, this.sprintScope);
@@ -11183,7 +11193,7 @@ var SprintModal = class extends import_obsidian10.Modal {
 
 // src/LauncherView.ts
 var LAUNCHER_VIEW_TYPE = "writing-studio-launcher";
-var LauncherView = class extends import_obsidian11.ItemView {
+var LauncherView = class extends import_obsidian12.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
     this.refreshTimer = null;
@@ -11231,7 +11241,7 @@ var LauncherView = class extends import_obsidian11.ItemView {
     const header = root.createDiv("ws-launcher-header");
     header.createSpan({ text: t2("launcher.title"), cls: "ws-launcher-title" });
     const settingsBtn = header.createEl("button", { cls: "ws-launcher-icon-btn", title: t2("launcher.settings") });
-    (0, import_obsidian11.setIcon)(settingsBtn, "settings");
+    (0, import_obsidian12.setIcon)(settingsBtn, "settings");
     settingsBtn.onclick = () => {
       var _a2, _b2;
       (_a2 = this.app.setting) == null ? void 0 : _a2.open();
@@ -11419,11 +11429,11 @@ var LauncherView = class extends import_obsidian11.ItemView {
         action: () => {
           const leaf = this.app.workspace.getMostRecentLeaf();
           const view = leaf == null ? void 0 : leaf.view;
-          const file = view instanceof import_obsidian11.MarkdownView ? view.file : null;
-          if (file instanceof import_obsidian11.TFile) {
+          const file = view instanceof import_obsidian12.MarkdownView ? view.file : null;
+          if (file instanceof import_obsidian12.TFile) {
             new PublishModal(this.app, this.plugin, file.path).open();
           } else {
-            new import_obsidian11.Notice(t2("launcher.openDocumentFirst"));
+            new import_obsidian12.Notice(t2("launcher.openDocumentFirst"));
           }
         }
       }
@@ -11432,7 +11442,7 @@ var LauncherView = class extends import_obsidian11.ItemView {
     for (const a of actions) {
       const btn = grid.createEl("button", { cls: "ws-launcher-action-grid-btn", title: a.label });
       const iconEl = btn.createDiv("ws-launcher-grid-icon");
-      (0, import_obsidian11.setIcon)(iconEl, a.icon);
+      (0, import_obsidian12.setIcon)(iconEl, a.icon);
       btn.createDiv({ text: a.label, cls: "ws-launcher-grid-label" });
       btn.onclick = a.action;
     }
@@ -11499,7 +11509,7 @@ var LauncherView = class extends import_obsidian11.ItemView {
 };
 
 // src/FocusMode.ts
-var import_obsidian12 = require("obsidian");
+var import_obsidian13 = require("obsidian");
 var import_view = require("@codemirror/view");
 var import_state = require("@codemirror/state");
 var FOCUS_CLASS = "writing-studio-focus-mode";
@@ -11620,7 +11630,7 @@ var FocusMode = class {
     const leaf = this.app.workspace.getMostRecentLeaf();
     if (!leaf) return 0;
     const view = leaf.view;
-    if (view instanceof import_obsidian12.MarkdownView) {
+    if (view instanceof import_obsidian13.MarkdownView) {
       const content = ((_a2 = view.editor) == null ? void 0 : _a2.getValue()) || "";
       return this.plugin.fmManager.countWords(content);
     }
@@ -11787,7 +11797,7 @@ var TypographyMode = class {
 };
 
 // src/WritingModes.ts
-var import_obsidian13 = require("obsidian");
+var import_obsidian14 = require("obsidian");
 
 // models/WritingMode.ts
 var WRITING_MODE_CONFIGS = {
@@ -11869,7 +11879,7 @@ var WritingModes = class {
     await this.plugin.saveSettings();
     if (!silent) {
       const modeLabel = mode === "none" ? t2("writingModes.normal") : t2(`launcher.mode.${mode}`);
-      new import_obsidian13.Notice(t2("writingModes.switchedTo", { mode: modeLabel }));
+      new import_obsidian14.Notice(t2("writingModes.switchedTo", { mode: modeLabel }));
     }
   }
   collapseSidebars() {
@@ -11886,7 +11896,7 @@ var WritingModes = class {
   }
   forceReadingView() {
     const leaf = this.app.workspace.getMostRecentLeaf();
-    if (!leaf || !(leaf.view instanceof import_obsidian13.MarkdownView)) return;
+    if (!leaf || !(leaf.view instanceof import_obsidian14.MarkdownView)) return;
     const mode = leaf.view.getMode();
     if (mode !== "preview") {
       this.reviewPrior = { leaf, mode };
@@ -11896,7 +11906,7 @@ var WritingModes = class {
   restoreEditorViewMode() {
     const prior = this.reviewPrior;
     this.reviewPrior = null;
-    if (!prior || !(prior.leaf.view instanceof import_obsidian13.MarkdownView)) return;
+    if (!prior || !(prior.leaf.view instanceof import_obsidian14.MarkdownView)) return;
     void this.setLeafMode(prior.leaf, prior.mode);
   }
   async setLeafMode(leaf, mode) {
@@ -11932,7 +11942,7 @@ var WritingModes = class {
 };
 
 // src/SprintTimer.ts
-var import_obsidian14 = require("obsidian");
+var import_obsidian15 = require("obsidian");
 function computeSprintWords(scope, primaryFile, baselines, currents, projectPrefix) {
   var _a2, _b2, _c;
   if (scope === "project") {
@@ -11975,7 +11985,7 @@ var SprintTimer = class {
   setup(durationMinutes, wordCountGoal, projectScope = "file") {
     var _a2;
     if (((_a2 = this.state) == null ? void 0 : _a2.active) && !this.state.ready) {
-      new import_obsidian14.Notice(t2("sprint.alreadyRunning"));
+      new import_obsidian15.Notice(t2("sprint.alreadyRunning"));
       return;
     }
     this.state = {
@@ -12018,7 +12028,7 @@ var SprintTimer = class {
     this.startInterval();
     this.updateDisplay();
     if (wasReady) {
-      new import_obsidian14.Notice(t2("sprint.started", { minutes: this.state.durationMinutes }));
+      new import_obsidian15.Notice(t2("sprint.started", { minutes: this.state.durationMinutes }));
     }
   }
   stop() {
@@ -12070,7 +12080,7 @@ var SprintTimer = class {
     var _a2;
     if (((_a2 = this.state) == null ? void 0 : _a2.projectScope) !== "project") return null;
     const project = this.plugin.projectManager.getActiveProject();
-    return project ? (0, import_obsidian14.normalizePath)(project.folderPath) + "/" : null;
+    return project ? (0, import_obsidian15.normalizePath)(project.folderPath) + "/" : null;
   }
   getElapsedMs() {
     if (!this.state) return 0;
@@ -12114,7 +12124,7 @@ var SprintTimer = class {
     if (this.plugin.settings.soundNotifications) {
       this.playBell();
     }
-    new import_obsidian14.Notice(t2("sprint.complete"), 5e3);
+    new import_obsidian15.Notice(t2("sprint.complete"), 5e3);
     const session = this.buildSession();
     this.state = null;
     this.hideFloating();
@@ -12242,7 +12252,7 @@ var SprintTimer = class {
     const leaf = this.app.workspace.getMostRecentLeaf();
     if (!leaf) return;
     const view = leaf.view;
-    if (!(view instanceof import_obsidian14.MarkdownView) || !view.file) return;
+    if (!(view instanceof import_obsidian15.MarkdownView) || !view.file) return;
     const path = view.file.path;
     const count = this.plugin.fmManager.countWords(((_a2 = view.editor) == null ? void 0 : _a2.getValue()) || "");
     if (!s.baselines.has(path)) {
@@ -12254,7 +12264,7 @@ var SprintTimer = class {
     var _a2, _b2;
     const leaf = this.app.workspace.getMostRecentLeaf();
     const view = leaf == null ? void 0 : leaf.view;
-    return view instanceof import_obsidian14.MarkdownView ? (_b2 = (_a2 = view.file) == null ? void 0 : _a2.path) != null ? _b2 : null : null;
+    return view instanceof import_obsidian15.MarkdownView ? (_b2 = (_a2 = view.file) == null ? void 0 : _a2.path) != null ? _b2 : null : null;
   }
   destroy() {
     this.stopInterval();
@@ -12263,12 +12273,12 @@ var SprintTimer = class {
 };
 
 // src/ExportEngine.ts
-var import_obsidian16 = require("obsidian");
+var import_obsidian17 = require("obsidian");
 var import_child_process = require("child_process");
 var import_util = require("util");
 
 // src/EpubEngine.ts
-var import_obsidian15 = require("obsidian");
+var import_obsidian16 = require("obsidian");
 
 // node_modules/fflate/esm/browser.js
 var u8 = Uint8Array;
@@ -12993,7 +13003,7 @@ var EpubEngine = class {
     let coverImageMime = "image/jpeg";
     if (opts.coverImagePath) {
       const vaultFile = this.app.vault.getAbstractFileByPath(opts.coverImagePath);
-      if (vaultFile instanceof import_obsidian15.TFile) {
+      if (vaultFile instanceof import_obsidian16.TFile) {
         const raw = await this.app.vault.readBinary(vaultFile);
         const isPng = opts.coverImagePath.toLowerCase().endsWith(".png");
         coverImageMime = isPng ? "image/png" : "image/jpeg";
@@ -13013,7 +13023,7 @@ var EpubEngine = class {
     const data = new ArrayBuffer(compressed.byteLength);
     new Uint8Array(data).set(compressed);
     const existing = this.app.vault.getAbstractFileByPath(outputVaultPath);
-    if (existing instanceof import_obsidian15.TFile) {
+    if (existing instanceof import_obsidian16.TFile) {
       await this.app.vault.modifyBinary(existing, data);
     } else {
       await this.app.vault.createBinary(outputVaultPath, data);
@@ -13347,11 +13357,11 @@ var ExportEngine = class {
   }
   async export(opts) {
     const project = this.plugin.projectManager.getActiveProject();
-    const outputDir = project ? (0, import_obsidian16.normalizePath)(`${project.folderPath}/Exports`) : (0, import_obsidian16.normalizePath)("Exports");
+    const outputDir = project ? (0, import_obsidian17.normalizePath)(`${project.folderPath}/Exports`) : (0, import_obsidian17.normalizePath)("Exports");
     await this.ensureFolder(outputDir);
     const timestamp = (/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-").slice(0, 19);
     const projectTitle = (project == null ? void 0 : project.title.replace(/[\\/:*?"<>|]/g, "-")) || "export";
-    const baseFile = (0, import_obsidian16.normalizePath)(`${outputDir}/${projectTitle}-${timestamp}`);
+    const baseFile = (0, import_obsidian17.normalizePath)(`${outputDir}/${projectTitle}-${timestamp}`);
     if (opts.format === "epub") {
       return this.exportEpub(opts, baseFile);
     }
@@ -13380,13 +13390,13 @@ var ExportEngine = class {
     const title = (project == null ? void 0 : project.title) || "Untitled";
     const author = (project == null ? void 0 : project.author) || this.plugin.settings.authorName || "";
     const language = this.plugin.settings.epubLanguage || "en";
-    const date = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
+    const date = localDateString();
     const chapters = [];
     if (opts.scope === "current") {
       const leaf = this.app.workspace.getMostRecentLeaf();
       const view = leaf == null ? void 0 : leaf.view;
-      const file = view instanceof import_obsidian16.MarkdownView ? view.file : null;
-      if (!(file instanceof import_obsidian16.TFile)) {
+      const file = view instanceof import_obsidian17.MarkdownView ? view.file : null;
+      if (!(file instanceof import_obsidian17.TFile)) {
         throw new Error(t2("exportEngine.noActiveDocument"));
       }
       let content = await this.app.vault.read(file);
@@ -13405,7 +13415,7 @@ var ExportEngine = class {
         if (!item.filePath) continue;
         if (!opts.includeResearch && item.filePath.includes("/Research/")) continue;
         const file = this.app.vault.getAbstractFileByPath(item.filePath);
-        if (!(file instanceof import_obsidian16.TFile)) continue;
+        if (!(file instanceof import_obsidian17.TFile)) continue;
         let content = await this.app.vault.read(file);
         if (!opts.includeFrontmatter) {
           content = content.replace(/^---\n[\s\S]*?\n---\n?/, "");
@@ -13426,7 +13436,7 @@ var ExportEngine = class {
       coverImagePath: opts.coverImagePath,
       chapters
     }, outputPath);
-    new import_obsidian16.Notice(t2("exportEngine.epubExported", { path: outputPath }));
+    new import_obsidian17.Notice(t2("exportEngine.epubExported", { path: outputPath }));
     return outputPath;
   }
   preprocessObsidianMarkdown(md) {
@@ -13449,8 +13459,8 @@ ${today}`);
     if (opts.scope === "current") {
       const leaf = this.app.workspace.getMostRecentLeaf();
       const view = leaf == null ? void 0 : leaf.view;
-      const file = view instanceof import_obsidian16.MarkdownView ? view.file : null;
-      if (!(file instanceof import_obsidian16.TFile)) {
+      const file = view instanceof import_obsidian17.MarkdownView ? view.file : null;
+      if (!(file instanceof import_obsidian17.TFile)) {
         throw new Error(t2("exportEngine.noActiveDocument"));
       }
       parts.push(await this.processFile(file, opts));
@@ -13462,7 +13472,7 @@ ${today}`);
         if (!item.filePath) continue;
         if (!opts.includeResearch && item.filePath.includes("/Research/")) continue;
         const file = this.app.vault.getAbstractFileByPath(item.filePath);
-        if (!(file instanceof import_obsidian16.TFile)) continue;
+        if (!(file instanceof import_obsidian17.TFile)) continue;
         const content = await this.processFile(file, opts);
         if (opts.includeTitlesAsHeadings) {
           const body = content.replace(/^# [^\n]*\n+/, "").trim();
@@ -13476,7 +13486,7 @@ ${body}`);
     } else if (opts.scope === "selected" && opts.selectedFiles) {
       for (const filePath of opts.selectedFiles) {
         const file = this.app.vault.getAbstractFileByPath(filePath);
-        if (!(file instanceof import_obsidian16.TFile)) continue;
+        if (!(file instanceof import_obsidian17.TFile)) continue;
         const content = await this.processFile(file, opts);
         if (opts.includeTitlesAsHeadings) {
           const body = content.replace(/^# [^\n]*\n+/, "").trim();
@@ -13551,12 +13561,12 @@ ${bodyHtml}
 </body>
 </html>`;
     await this.writeFile(outputPath, fullHtml);
-    new import_obsidian16.Notice(t2("exportEngine.manuscriptExported", { path: outputPath }));
+    new import_obsidian17.Notice(t2("exportEngine.manuscriptExported", { path: outputPath }));
     return outputPath;
   }
   async exportMarkdown(content, outputPath) {
     await this.writeFile(outputPath, content);
-    new import_obsidian16.Notice(t2("exportEngine.exportedTo", { path: outputPath }));
+    new import_obsidian17.Notice(t2("exportEngine.exportedTo", { path: outputPath }));
     return outputPath;
   }
   async exportHtml(content, outputPath, title, opts) {
@@ -13586,7 +13596,7 @@ ${this.markdownToHtml(content)}
 </body>
 </html>`;
     await this.writeFile(outputPath, html);
-    new import_obsidian16.Notice(t2("exportEngine.exportedHtmlTo", { path: outputPath }));
+    new import_obsidian17.Notice(t2("exportEngine.exportedHtmlTo", { path: outputPath }));
     return outputPath;
   }
   async exportPandoc(content, outputPath, opts) {
@@ -13602,13 +13612,13 @@ ${this.markdownToHtml(content)}
         args.push("-V", `mainfont=${safeFont}`);
       }
       await execFileAsync(pandocPath, args);
-      new import_obsidian16.Notice(t2("exportEngine.exportedTo", { path: outputPath }));
+      new import_obsidian17.Notice(t2("exportEngine.exportedTo", { path: outputPath }));
       return outputPath;
     } catch (e) {
       throw new Error(`Pandoc export failed: ${e instanceof Error ? e.message : String(e)}
 Ensure pandoc is installed.`);
     } finally {
-      if (this.app.vault.getAbstractFileByPath(tempMdPath) instanceof import_obsidian16.TFile) {
+      if (this.app.vault.getAbstractFileByPath(tempMdPath) instanceof import_obsidian17.TFile) {
         await this.app.vault.adapter.remove(tempMdPath);
       }
     }
@@ -13617,13 +13627,13 @@ Ensure pandoc is installed.`);
     try {
       return await this.exportPandoc(content, outputPath, opts);
     } catch (e) {
-      new import_obsidian16.Notice(t2("exportEngine.pdfRequiresPandoc"));
+      new import_obsidian17.Notice(t2("exportEngine.pdfRequiresPandoc"));
       throw e;
     }
   }
   async writeFile(vaultPath, content) {
     const existing = this.app.vault.getAbstractFileByPath(vaultPath);
-    if (existing instanceof import_obsidian16.TFile) {
+    if (existing instanceof import_obsidian17.TFile) {
       await this.app.vault.modify(existing, content);
     } else {
       await this.app.vault.create(vaultPath, content);
@@ -13757,7 +13767,7 @@ ${listItems.map((i) => `  <li>${i}</li>`).join("\n")}
 };
 
 // src/WordPressClient.ts
-var import_obsidian17 = require("obsidian");
+var import_obsidian18 = require("obsidian");
 var WordPressClient = class {
   authHeaders(site) {
     const credentials = `${site.username}:${site.appPassword}`;
@@ -13774,7 +13784,7 @@ var WordPressClient = class {
   async testConnection(site) {
     var _a2;
     try {
-      const resp = await (0, import_obsidian17.requestUrl)({
+      const resp = await (0, import_obsidian18.requestUrl)({
         url: this.apiUrl(site, "users/me"),
         method: "GET",
         headers: this.authHeaders(site),
@@ -13789,7 +13799,7 @@ var WordPressClient = class {
       const data = resp.json;
       let siteName = site.url;
       try {
-        const siteResp = await (0, import_obsidian17.requestUrl)({
+        const siteResp = await (0, import_obsidian18.requestUrl)({
           url: `${site.url.replace(/\/$/, "")}/wp-json/`,
           method: "GET",
           headers: this.authHeaders(site),
@@ -13812,7 +13822,7 @@ var WordPressClient = class {
   }
   async getCategories(site) {
     try {
-      const resp = await (0, import_obsidian17.requestUrl)({
+      const resp = await (0, import_obsidian18.requestUrl)({
         url: this.apiUrl(site, "categories?per_page=100"),
         method: "GET",
         headers: this.authHeaders(site),
@@ -13826,7 +13836,7 @@ var WordPressClient = class {
         count: c.count
       }));
     } catch (e) {
-      new import_obsidian17.Notice(t2("wpClient.fetchCategoriesFailed", { error: e instanceof Error ? e.message : String(e) }));
+      new import_obsidian18.Notice(t2("wpClient.fetchCategoriesFailed", { error: e instanceof Error ? e.message : String(e) }));
       return [];
     }
   }
@@ -13846,7 +13856,7 @@ var WordPressClient = class {
     if (opts.featuredMediaId) body.featured_media = opts.featuredMediaId;
     if (opts.scheduledDate) body.date = opts.scheduledDate;
     const url = opts.existingPostId ? this.apiUrl(site, `posts/${opts.existingPostId}`) : this.apiUrl(site, "posts");
-    const resp = await (0, import_obsidian17.requestUrl)({
+    const resp = await (0, import_obsidian18.requestUrl)({
       url,
       method: opts.existingPostId ? "PUT" : "POST",
       headers: this.authHeaders(site),
@@ -13869,7 +13879,7 @@ var WordPressClient = class {
     const ids = [];
     for (const name of tagNames) {
       try {
-        const searchResp = await (0, import_obsidian17.requestUrl)({
+        const searchResp = await (0, import_obsidian18.requestUrl)({
           url: this.apiUrl(site, `tags?search=${encodeURIComponent(name)}`),
           method: "GET",
           headers: this.authHeaders(site),
@@ -13883,7 +13893,7 @@ var WordPressClient = class {
             continue;
           }
         }
-        const createResp = await (0, import_obsidian17.requestUrl)({
+        const createResp = await (0, import_obsidian18.requestUrl)({
           url: this.apiUrl(site, "tags"),
           method: "POST",
           headers: this.authHeaders(site),
@@ -13918,17 +13928,17 @@ var WordPressClient = class {
 };
 
 // src/ProjectManager.ts
-var import_obsidian23 = require("obsidian");
+var import_obsidian24 = require("obsidian");
 
 // templates/BookTemplate.ts
-var import_obsidian18 = require("obsidian");
+var import_obsidian19 = require("obsidian");
 var BookTemplate = class _BookTemplate {
   static async apply(app, project) {
-    const now = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
-    const chaptersPath = (0, import_obsidian18.normalizePath)(`${project.folderPath}/Chapters`);
-    const frontMatterFile = (0, import_obsidian18.normalizePath)(`${chaptersPath}/Front Matter.md`);
-    const chapter1File = (0, import_obsidian18.normalizePath)(`${chaptersPath}/Part 1 - Chapter 1.md`);
-    const backMatterFile = (0, import_obsidian18.normalizePath)(`${chaptersPath}/Back Matter.md`);
+    const now = localDateString();
+    const chaptersPath = (0, import_obsidian19.normalizePath)(`${project.folderPath}/Chapters`);
+    const frontMatterFile = (0, import_obsidian19.normalizePath)(`${chaptersPath}/Front Matter.md`);
+    const chapter1File = (0, import_obsidian19.normalizePath)(`${chaptersPath}/Part 1 - Chapter 1.md`);
+    const backMatterFile = (0, import_obsidian19.normalizePath)(`${chaptersPath}/Back Matter.md`);
     await _BookTemplate.createFile(app, frontMatterFile, _BookTemplate.frontMatterDoc(now));
     await _BookTemplate.createFile(app, chapter1File, _BookTemplate.chapter1Doc(project.title, now));
     await _BookTemplate.createFile(app, backMatterFile, _BookTemplate.backMatterDoc(now));
@@ -14039,13 +14049,13 @@ tags: [writing-studio]
 };
 
 // templates/ArticleSeriesTemplate.ts
-var import_obsidian19 = require("obsidian");
+var import_obsidian20 = require("obsidian");
 var ArticleSeriesTemplate = class _ArticleSeriesTemplate {
   static async apply(app, project) {
-    const now = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
-    const chaptersPath = (0, import_obsidian19.normalizePath)(`${project.folderPath}/Chapters`);
-    const seriesMetaFile = (0, import_obsidian19.normalizePath)(`${chaptersPath}/Series Overview.md`);
-    const article1File = (0, import_obsidian19.normalizePath)(`${chaptersPath}/Article 1.md`);
+    const now = localDateString();
+    const chaptersPath = (0, import_obsidian20.normalizePath)(`${project.folderPath}/Chapters`);
+    const seriesMetaFile = (0, import_obsidian20.normalizePath)(`${chaptersPath}/Series Overview.md`);
+    const article1File = (0, import_obsidian20.normalizePath)(`${chaptersPath}/Article 1.md`);
     await _ArticleSeriesTemplate.createFile(app, seriesMetaFile, _ArticleSeriesTemplate.seriesOverviewDoc(project.title, now));
     await _ArticleSeriesTemplate.createFile(app, article1File, _ArticleSeriesTemplate.article1Doc(project.title, now));
     const items = [
@@ -14131,14 +14141,14 @@ tags: [writing-studio]
 };
 
 // templates/BlogCollectionTemplate.ts
-var import_obsidian20 = require("obsidian");
+var import_obsidian21 = require("obsidian");
 var BlogCollectionTemplate = class _BlogCollectionTemplate {
   static async apply(app, project) {
-    const now = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
-    const chaptersPath = (0, import_obsidian20.normalizePath)(`${project.folderPath}/Chapters`);
+    const now = localDateString();
+    const chaptersPath = (0, import_obsidian21.normalizePath)(`${project.folderPath}/Chapters`);
     const year = (/* @__PURE__ */ new Date()).getFullYear();
-    await _BlogCollectionTemplate.createFolder(app, (0, import_obsidian20.normalizePath)(`${chaptersPath}/${year}`));
-    const firstPostFile = (0, import_obsidian20.normalizePath)(`${chaptersPath}/${year}/${now}-first-post.md`);
+    await _BlogCollectionTemplate.createFolder(app, (0, import_obsidian21.normalizePath)(`${chaptersPath}/${year}`));
+    const firstPostFile = (0, import_obsidian21.normalizePath)(`${chaptersPath}/${year}/${now}-first-post.md`);
     await _BlogCollectionTemplate.createFile(app, firstPostFile, _BlogCollectionTemplate.firstPostDoc(now));
     const items = [
       {
@@ -14200,11 +14210,11 @@ tags: [writing-studio]
 };
 
 // templates/JournalArticleTemplate.ts
-var import_obsidian21 = require("obsidian");
+var import_obsidian22 = require("obsidian");
 var JournalArticleTemplate = class _JournalArticleTemplate {
   static async apply(app, project) {
-    const now = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
-    const p = (name) => (0, import_obsidian21.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
+    const now = localDateString();
+    const p = (name) => (0, import_obsidian22.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
     const docs = [
       [p("Title Page"), _JournalArticleTemplate.titlePageDoc(project.title, project.author, now)],
       [p("Abstract"), _JournalArticleTemplate.standardDoc("Abstract", "abstract", 2, 250, now, "Write a concise summary of the article in 150\u2013250 words. Include research question, methodology, key findings, and conclusion.")],
@@ -14290,11 +14300,11 @@ ${_JournalArticleTemplate.hint(hintText)}
 };
 
 // templates/MagazineArticleTemplate.ts
-var import_obsidian22 = require("obsidian");
+var import_obsidian23 = require("obsidian");
 var MagazineArticleTemplate = class _MagazineArticleTemplate {
   static async apply(app, project) {
-    const now = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
-    const p = (name) => (0, import_obsidian22.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
+    const now = localDateString();
+    const p = (name) => (0, import_obsidian23.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
     const docs = [
       [p("Pitch - Query Notes"), _MagazineArticleTemplate.notesDoc(
         "Pitch / Query Notes",
@@ -14401,22 +14411,22 @@ var ProjectManager = class {
     this.projects.clear();
     const rootFolder = this.plugin.settings.defaultProjectFolder;
     if (!rootFolder) return;
-    const folder = this.app.vault.getAbstractFileByPath((0, import_obsidian23.normalizePath)(rootFolder));
-    if (!(folder instanceof import_obsidian23.TFolder)) return;
-    const subfolders = folder.children.filter((c) => c instanceof import_obsidian23.TFolder);
+    const folder = this.app.vault.getAbstractFileByPath((0, import_obsidian24.normalizePath)(rootFolder));
+    if (!(folder instanceof import_obsidian24.TFolder)) return;
+    const subfolders = folder.children.filter((c) => c instanceof import_obsidian24.TFolder);
     await Promise.all(subfolders.map((f) => this.loadProject(f.path)));
   }
   async loadProject(folderPath) {
-    const projectFilePath = (0, import_obsidian23.normalizePath)(`${folderPath}/_project.json`);
+    const projectFilePath = (0, import_obsidian24.normalizePath)(`${folderPath}/_project.json`);
     const file = this.app.vault.getAbstractFileByPath(projectFilePath);
-    if (!(file instanceof import_obsidian23.TFile)) return null;
+    if (!(file instanceof import_obsidian24.TFile)) return null;
     try {
       const content = await this.app.vault.read(file);
       const project = JSON.parse(content);
       this.projects.set(project.id, project);
       return project;
     } catch (e) {
-      new import_obsidian23.Notice(t2("projectManager.corruptProject", { folder: folderPath }));
+      new import_obsidian24.Notice(t2("projectManager.corruptProject", { folder: folderPath }));
       return null;
     }
   }
@@ -14424,15 +14434,15 @@ var ProjectManager = class {
     const rootFolder = this.plugin.settings.defaultProjectFolder || "Writing Projects";
     const id = `project-${Date.now()}`;
     const folderName = title.replace(/[\\/:*?"<>|]/g, "-");
-    const folderPath = (0, import_obsidian23.normalizePath)(`${rootFolder}/${folderName}`);
+    const folderPath = (0, import_obsidian24.normalizePath)(`${rootFolder}/${folderName}`);
     if (this.app.vault.getAbstractFileByPath(folderPath)) {
       throw new Error(t2("projectManager.errorFolderExists", { folder: folderName }));
     }
     await this.ensureFolder(folderPath);
-    await this.ensureFolder((0, import_obsidian23.normalizePath)(`${folderPath}/Chapters`));
-    await this.ensureFolder((0, import_obsidian23.normalizePath)(`${folderPath}/Research`));
-    await this.ensureFolder((0, import_obsidian23.normalizePath)(`${folderPath}/Exports`));
-    const now = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
+    await this.ensureFolder((0, import_obsidian24.normalizePath)(`${folderPath}/Chapters`));
+    await this.ensureFolder((0, import_obsidian24.normalizePath)(`${folderPath}/Research`));
+    await this.ensureFolder((0, import_obsidian24.normalizePath)(`${folderPath}/Exports`));
+    const now = localDateString();
     const project = {
       id,
       title,
@@ -14478,17 +14488,17 @@ var ProjectManager = class {
     };
   }
   async saveProject(project) {
-    project.modified = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
-    const path = (0, import_obsidian23.normalizePath)(`${project.folderPath}/_project.json`);
+    project.modified = localDateString();
+    const path = (0, import_obsidian24.normalizePath)(`${project.folderPath}/_project.json`);
     await this.writeJson(path, project);
     this.projects.set(project.id, project);
   }
   async loadBinder(project) {
     const cached = this.binderCache.get(project.id);
     if (cached) return cached;
-    const path = (0, import_obsidian23.normalizePath)(`${project.folderPath}/_binder.json`);
+    const path = (0, import_obsidian24.normalizePath)(`${project.folderPath}/_binder.json`);
     const file = this.app.vault.getAbstractFileByPath(path);
-    if (!(file instanceof import_obsidian23.TFile)) {
+    if (!(file instanceof import_obsidian24.TFile)) {
       return { version: "2.0", projectId: project.id, items: [] };
     }
     let content;
@@ -14502,8 +14512,8 @@ var ProjectManager = class {
       this.binderCache.set(project.id, data);
       return data;
     } catch (e) {
-      await this.writeRaw((0, import_obsidian23.normalizePath)(`${project.folderPath}/_binder.json.bak`), content);
-      new import_obsidian23.Notice(t2("projectManager.corruptBinder", { project: project.title }));
+      await this.writeRaw((0, import_obsidian24.normalizePath)(`${project.folderPath}/_binder.json.bak`), content);
+      new import_obsidian24.Notice(t2("projectManager.corruptBinder", { project: project.title }));
       return { version: "2.0", projectId: project.id, items: [] };
     }
   }
@@ -14511,17 +14521,17 @@ var ProjectManager = class {
     const project = this.projects.get(binder.projectId);
     if (!project) return;
     this.binderCache.delete(binder.projectId);
-    const path = (0, import_obsidian23.normalizePath)(`${project.folderPath}/_binder.json`);
+    const path = (0, import_obsidian24.normalizePath)(`${project.folderPath}/_binder.json`);
     await this.writeJson(path, binder);
     this.plugin.statsTracker.invalidateWordCountCache();
   }
   async addDocumentToBinder(project, title, type, parentId) {
     const binder = await this.loadBinder(project);
-    const now = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
+    const now = localDateString();
     const baseName = title.replace(/[\\/:*?"<>|]/g, "-");
-    let filePath = (0, import_obsidian23.normalizePath)(`${project.folderPath}/Chapters/${baseName}.md`);
+    let filePath = (0, import_obsidian24.normalizePath)(`${project.folderPath}/Chapters/${baseName}.md`);
     for (let n = 2; this.app.vault.getAbstractFileByPath(filePath); n++) {
-      filePath = (0, import_obsidian23.normalizePath)(`${project.folderPath}/Chapters/${baseName} ${n}.md`);
+      filePath = (0, import_obsidian24.normalizePath)(`${project.folderPath}/Chapters/${baseName} ${n}.md`);
     }
     const item = {
       id: `item-${Date.now()}`,
@@ -14598,10 +14608,10 @@ tags: [writing-studio]
     }
   }
   async logSprintSession(project, session) {
-    const logPath = (0, import_obsidian23.normalizePath)(`${project.folderPath}/_writing-log.json`);
+    const logPath = (0, import_obsidian24.normalizePath)(`${project.folderPath}/_writing-log.json`);
     let log = [];
     const file = this.app.vault.getAbstractFileByPath(logPath);
-    if (file instanceof import_obsidian23.TFile) {
+    if (file instanceof import_obsidian24.TFile) {
       try {
         const content = await this.app.vault.read(file);
         log = JSON.parse(content);
@@ -14616,9 +14626,9 @@ tags: [writing-studio]
     await this.writeJson(logPath, log);
   }
   async getWritingLog(project) {
-    const logPath = (0, import_obsidian23.normalizePath)(`${project.folderPath}/_writing-log.json`);
+    const logPath = (0, import_obsidian24.normalizePath)(`${project.folderPath}/_writing-log.json`);
     const file = this.app.vault.getAbstractFileByPath(logPath);
-    if (!(file instanceof import_obsidian23.TFile)) return [];
+    if (!(file instanceof import_obsidian24.TFile)) return [];
     try {
       const content = await this.app.vault.read(file);
       return JSON.parse(content);
@@ -14627,7 +14637,7 @@ tags: [writing-studio]
     }
   }
   async initWritingLog(project) {
-    const logPath = (0, import_obsidian23.normalizePath)(`${project.folderPath}/_writing-log.json`);
+    const logPath = (0, import_obsidian24.normalizePath)(`${project.folderPath}/_writing-log.json`);
     await this.writeJson(logPath, []);
   }
   async writeJson(path, data) {
@@ -14635,7 +14645,7 @@ tags: [writing-studio]
   }
   async writeRaw(path, content) {
     const existing = this.app.vault.getAbstractFileByPath(path);
-    if (existing instanceof import_obsidian23.TFile) {
+    if (existing instanceof import_obsidian24.TFile) {
       await this.app.vault.modify(existing, content);
     } else {
       await this.app.vault.create(path, content);
@@ -14697,7 +14707,7 @@ tags: [writing-studio]
 };
 
 // src/StatsTracker.ts
-var import_obsidian24 = require("obsidian");
+var import_obsidian25 = require("obsidian");
 var StatsTracker = class {
   constructor(plugin) {
     this.sessionBaselines = /* @__PURE__ */ new Map();
@@ -14710,7 +14720,7 @@ var StatsTracker = class {
   }
   newDailyStats() {
     return {
-      date: (/* @__PURE__ */ new Date()).toISOString().split("T")[0],
+      date: localDateString(),
       wordsWritten: 0,
       sprintsCompleted: 0,
       totalMinutes: 0,
@@ -14718,6 +14728,9 @@ var StatsTracker = class {
     };
   }
   recordSprint(session) {
+    if (this.sessionStats.date !== localDateString()) {
+      this.sessionStats = this.newDailyStats();
+    }
     this.sessionStats.wordsWritten += session.wordsWritten;
     this.sessionStats.sprintsCompleted++;
     this.sessionStats.totalMinutes += session.duration;
@@ -14731,8 +14744,7 @@ var StatsTracker = class {
     }
   }
   async appendToDailyNote(session) {
-    const today = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
-    const dailyNotePath = this.getDailyNotePath(today);
+    const dailyNotePath = this.getDailyNotePath();
     const project = this.plugin.projectManager.getActiveProject();
     const projectName = (project == null ? void 0 : project.title) || t2("statsTracker.unknownProject");
     const docNames = session.documents.map((p) => {
@@ -14749,26 +14761,22 @@ ${t2("statsTracker.dailyNote.heading")}
 - ${t2("statsTracker.dailyNote.wpm")} ${wpm}
 - ${t2("statsTracker.dailyNote.sessionTotal")} ${t2("statsTracker.dailyNote.sessionTotalValue", { duration: session.duration })}
 `;
-    let dailyFile = this.app.vault.getAbstractFileByPath(dailyNotePath);
-    if (dailyFile instanceof import_obsidian24.TFile) {
-      const content = await this.app.vault.read(dailyFile);
-      await this.app.vault.modify(dailyFile, content + "\n" + entry);
-    } else {
-      const activeProject = this.plugin.projectManager.getActiveProject();
-      if (activeProject) {
-        await this.plugin.projectManager.logSprintSession(activeProject, session);
-      }
+    const dailyFile = this.app.vault.getAbstractFileByPath(dailyNotePath);
+    if (dailyFile instanceof import_obsidian25.TFile) {
+      await this.app.vault.append(dailyFile, "\n" + entry);
+      return;
+    }
+    try {
+      await this.app.vault.create(dailyNotePath, entry);
+    } catch (e) {
     }
   }
-  getDailyNotePath(date) {
+  getDailyNotePath() {
     var _a2, _b2, _c, _d;
-    const dailyNotesPlugin = (_b2 = (_a2 = this.app.internalPlugins) == null ? void 0 : _a2.plugins) == null ? void 0 : _b2["daily-notes"];
-    const folder = ((_d = (_c = dailyNotesPlugin == null ? void 0 : dailyNotesPlugin.instance) == null ? void 0 : _c.options) == null ? void 0 : _d.folder) || "";
-    const fileName = date;
-    if (folder) {
-      return (0, import_obsidian24.normalizePath)(`${folder}/${fileName}.md`);
-    }
-    return (0, import_obsidian24.normalizePath)(`${fileName}.md`);
+    const options = (_d = (_c = (_b2 = (_a2 = this.app.internalPlugins) == null ? void 0 : _a2.plugins) == null ? void 0 : _b2["daily-notes"]) == null ? void 0 : _c.instance) == null ? void 0 : _d.options;
+    const fileName = moment().format((options == null ? void 0 : options.format) || "YYYY-MM-DD");
+    const folder = (options == null ? void 0 : options.folder) || "";
+    return (0, import_obsidian25.normalizePath)(folder ? `${folder}/${fileName}.md` : `${fileName}.md`);
   }
   updateFileWordCount(path, wordCount) {
     if (!this.sessionBaselines.has(path)) {
@@ -14808,7 +14816,7 @@ ${t2("statsTracker.dailyNote.heading")}
     let total = 0;
     for (const item of items) {
       const file = this.app.vault.getAbstractFileByPath(item.filePath);
-      if (file instanceof import_obsidian24.TFile) {
+      if (file instanceof import_obsidian25.TFile) {
         const content = await this.app.vault.read(file);
         total += this.plugin.fmManager.countWords(content);
       }
@@ -14832,7 +14840,7 @@ ${t2("statsTracker.dailyNote.heading")}
     if (project) {
       const log = await this.plugin.projectManager.getWritingLog(project);
       for (const session of log) {
-        const date = session.date.split("T")[0];
+        const date = localDateString(session.date);
         const existing = byDate.get(date);
         if (existing) {
           existing.wordsWritten += session.wordsWritten;
@@ -14853,7 +14861,7 @@ ${t2("statsTracker.dailyNote.heading")}
     for (let i = days - 1; i >= 0; i--) {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
-      const dateStr = d.toISOString().split("T")[0];
+      const dateStr = localDateString(d);
       result.push((_a2 = byDate.get(dateStr)) != null ? _a2 : {
         date: dateStr,
         wordsWritten: 0,
@@ -14868,13 +14876,13 @@ ${t2("statsTracker.dailyNote.heading")}
     if (!project) return 0;
     const log = await this.plugin.projectManager.getWritingLog(project);
     if (log.length === 0) return 0;
-    const dates = new Set(log.map((s) => s.date.split("T")[0]));
+    const dates = new Set(log.map((s) => localDateString(s.date)));
     let streak = 0;
     const today = /* @__PURE__ */ new Date();
     for (let i = 0; i < 365; i++) {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
-      const dateStr = d.toISOString().split("T")[0];
+      const dateStr = localDateString(d);
       if (dates.has(dateStr)) {
         streak++;
       } else if (i > 0) {
@@ -14886,7 +14894,7 @@ ${t2("statsTracker.dailyNote.heading")}
 };
 
 // src/FrontmatterManager.ts
-var import_obsidian25 = require("obsidian");
+var import_obsidian26 = require("obsidian");
 var FrontmatterManager = class {
   constructor(plugin) {
     this.pendingUpdates = /* @__PURE__ */ new Map();
@@ -14914,14 +14922,14 @@ var FrontmatterManager = class {
     if (file.extension !== "md") return false;
     const projectFolder = this.plugin.settings.defaultProjectFolder;
     if (!projectFolder) return false;
-    return file.path.startsWith((0, import_obsidian25.normalizePath)(projectFolder) + "/");
+    return file.path.startsWith((0, import_obsidian26.normalizePath)(projectFolder) + "/");
   }
   async updateFrontmatter(file) {
     this.writingFiles.add(file.path);
     try {
       const content = await this.app.vault.read(file);
       const wordCount = this.countWords(content);
-      const now = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
+      const now = localDateString();
       await this.app.fileManager.processFrontMatter(file, (fm) => {
         fm["word-count"] = wordCount;
         fm["modified"] = now;
@@ -15040,7 +15048,7 @@ ${fm}
 };
 
 // src/SettingsTab.ts
-var import_obsidian26 = require("obsidian");
+var import_obsidian27 = require("obsidian");
 
 // README.md
 var README_default = '<p align="center">\r\n  <img src="assets/logo.png" width="120" alt="Writing Studio logo">\r\n</p>\r\n\r\n# Writing Studio\r\n\r\n**Version 2.5.2** \xB7 Desktop only\r\n\r\n![GitHub all releases](https://img.shields.io/github/downloads/writerP-777/obsidian-writing-studio/total)\r\n[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12832/badge)](https://www.bestpractices.dev/projects/12832)\r\n\r\nWriting Studio turns Obsidian into a dedicated environment for serious nonfiction work \u2014 from your first research notes to a finished, exported manuscript. It bundles a project binder, writing modes, focus and typography tools, sprint timer, progress tracking, manuscript export, and WordPress publishing into a single plugin. A built-in sidebar file explorer lets you browse, preview, and pull content from anywhere in your vault without leaving your draft.\r\n\r\n<p align="center">\r\n  <img src="assets/sidebar-explorer-screenshot.png" alt="Writing Studio with the Launcher panel open on the left, an active draft in the center, and the Folder Sidebar Explorer open to a research folder on the right" width="900">\r\n  <br>\r\n  <em>Writing Studio in use \u2014 Launcher (left), active draft with word count goal banner (center), Folder Sidebar Explorer open to a research folder (right).</em>\r\n</p>\r\n\r\n<p align="center">\r\n  <a href="https://buymeacoffee.com/writerp777">\r\n    <img src="https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&slug=writerp777&button_colour=c9a84c&font_colour=000000&font_family=Georgia&outline_colour=000000&coffee_colour=ffffff" alt="Buy me a coffee" height="40">\r\n  </a>\r\n</p>\r\n\r\n## Contents\r\n\r\n- [Features](#features)\r\n- [Language support](#language-support)\r\n- [Writing Studio Launcher](#writing-studio-launcher)\r\n- [Folder Sidebar Explorer](#folder-sidebar-explorer)\r\n- [Your Project](#your-project)\r\n- [Your Writing Environment](#your-writing-environment)\r\n- [Tracking Your Progress](#tracking-your-progress)\r\n- [Getting Your Work Out](#getting-your-work-out)\r\n- [Supporting Tools](#supporting-tools)\r\n- [Context Menus](#context-menus)\r\n- [Commands Reference](#commands-reference)\r\n- [Settings Overview](#settings-overview)\r\n- [Ribbon Icon](#ribbon-icon)\r\n- [Installation](#installation)\r\n- [Requirements](#requirements)\r\n- [Reporting a Bug](#reporting-a-bug)\r\n- [Security](#security)\r\n\r\n---\r\n\r\n## Features\r\n\r\n**Writing Binder** \u2014 Organize your manuscript as an ordered collection of documents with per-item status, word count, and export flags. Drag chapters into order, toggle items in or out of export, and add files from anywhere in your vault.\r\n\r\n**Project Manager** \u2014 Create projects from six templates (blank, book, article series, blog collection, journal article, magazine article), set a total word count goal, and switch between projects from the Launcher.\r\n\r\n**Compile Preview** \u2014 Concatenate all binder documents in order and render them as a finished manuscript in a split pane, without exporting.\r\n\r\n**Writing Modes** \u2014 Switch between Draft (distraction-free), Edit (full tooling), and Review (read-only) modes from the status bar, command palette, context menu, or Launcher.\r\n\r\n**Focus Mode** \u2014 Dim everything except the paragraph or sentence you are writing. Configurable dim level, font size override, sidebar collapse, and typewriter scroll.\r\n\r\n**Typography Mode** \u2014 Apply a curated font, constrained line length, and controlled line height to the editor. Fourteen font options including iA Writer fonts, Google Fonts, and custom system fonts.\r\n\r\n**Sprint Timer** \u2014 Run timed writing sessions with a draggable floating overlay. Set duration, word goal, and scope (file or project). Quick-start presets (10 m, 15 m, 25 m) available from the Launcher.\r\n\r\n**Progress Tracking** \u2014 Live word counts in the status bar and Launcher, session delta tracking, per-document and per-project word count goals with inline progress banners, and a 30-day writing log with streak tracking.\r\n\r\n**Export Engine** \u2014 Export to Manuscript (HTML), PDF, Word (.docx), RTF, HTML, Markdown, and EPUB. Manuscript format produces industry-standard layout with no external tools; other formats require Pandoc.\r\n\r\n**WordPress Publishing** \u2014 Publish directly to WordPress from Obsidian. Set post title, status, categories, tags, excerpt, and scheduled date. Supports multiple sites with per-site credentials and connection testing.\r\n\r\n**Folder Sidebar Explorer** \u2014 Browse any vault folder in a sidebar panel. Search by name or file content, preview Markdown files and images inline, and insert selected text directly into the active editor.\r\n\r\n## Language support\r\n\r\nWriting Studio is available in the following languages in addition to English:\r\n\r\n- Arabic\r\n- Chinese (Simplified)\r\n- French\r\n- German\r\n- Japanese\r\n- Korean\r\n- Portuguese (Brazil)\r\n- Russian\r\n- Spanish\r\n\r\n**To change the language:** Open **Settings \u2192 General** in Obsidian, scroll to **Language**, and select your preferred language from the list. Restart Obsidian for the change to take effect. Writing Studio will display in the selected language if it is supported.\r\n\r\n**Found a translation error or missing text?** Please open an issue on GitHub \u2014 [Submit a bug report or enhancement request](https://github.com/writerP-777/obsidian-writing-studio/issues/new) \u2014 and include the language, the location in the plugin where the text appears, and what it currently says. We will address it in the next release.\r\n\r\n### Writing Studio Launcher\r\n\r\nThe Launcher is your home base in Writing Studio \u2014 a sidebar panel that shows your active project, progress toward your goals, and one-click access to every major feature.\r\n\r\nBy default it opens automatically when Obsidian loads. To disable this, turn off **Open on startup** in **Settings \u2192 General**.\r\n\r\n**To open manually:** Click the feather ribbon icon, or assign a hotkey to **Open launcher** in Settings \u2192 Hotkeys.\r\n\r\n**The Launcher includes:**\r\n- Active project name, total word count, and progress toward your project word count goal\r\n- Writing mode selector (Draft / Edit / Review)\r\n- Focus Mode and Typography Mode toggles\r\n- Sprint timer with "Set up sprint" button and Quick Sprint Options presets (10 m, 15 m, 25 m)\r\n- Today card showing words written, sprints completed, session word count, and streak\r\n- Quick-action buttons: Targets Dashboard, Writing Dashboard, Preview manuscript, Export, Writing Log, Publish to WordPress\r\n\r\n---\r\n\r\n### Folder Sidebar Explorer\r\n\r\nThe Folder Sidebar Explorer opens any vault folder in a right-sidebar panel, letting you browse reference material, research notes, or any folder outside your active project without leaving your draft. Unlike the Binder \u2014 which is scoped to your writing project \u2014 the sidebar explorer works with any folder in your vault.\r\n\r\n**To open:**\r\n- Use the command **Open folder in sidebar explorer** from the command palette \u2014 a folder picker appears so you can choose which folder to explore.\r\n- Right-click any folder in the file explorer and choose **Open in sidebar explorer** under **Writing studio options**.\r\n- Right-click any folder in [Notebook Navigator](https://github.com/johansan/notebook-navigator) and choose **Open in sidebar explorer** (requires Notebook Navigator to be installed).\r\n- Assign a hotkey in Settings \u2192 Hotkeys.\r\n\r\nThe panel opens in the **right sidebar**. The folder you open becomes the **root folder** for that session \u2014 the breadcrumb trail, the \u2302 root button, and search all operate relative to it.\r\n\r\n**Browsing and navigation:**\r\n\r\n| Feature | How to use |\r\n|---------|-----------|\r\n| Browse into a subfolder | Click the folder |\r\n| Preview a Markdown file | Click the file \u2014 the folder listing is replaced by a rendered preview inside the panel |\r\n| Preview an image | Click the file \u2014 displayed inline |\r\n| Preview audio | Click the file \u2014 player appears inline |\r\n| Other file types | Click the file \u2014 an **Open in editor** button appears |\r\n| Go back | Click **\u2190 back**, or press `Backspace` when the list has keyboard focus |\r\n| Return to root folder | Click **\u2302 root** to jump back to the folder you originally opened |\r\n| Keyboard navigation | Tab to focus the list, then `\u2191` / `\u2193` to move, `Enter` to open, `Backspace` to go back |\r\n| Breadcrumb navigation | Click any segment in the breadcrumb trail to jump directly to that folder |\r\n\r\n**Search:**\r\n\r\nA search bar appears at the top of the folder list. Type your query and press **Enter** to run the search.\r\n\r\n- Searches **both folder/file names and file contents** (`.md` and `.txt` files).\r\n- Frontmatter is excluded from content search to avoid false positives from YAML fields.\r\n- Name matches show the matched term highlighted in the result title.\r\n- Content matches show a text snippet around the match with the term highlighted, plus a **CONTENT** badge to distinguish them from name matches.\r\n- Results always search from the root folder, regardless of which subfolder you are currently browsing.\r\n- Click **\xD7** to clear the search and return to the normal folder view.\r\n\r\n**Sort:**\r\n\r\nA sort dropdown sits next to the search bar. Options:\r\n\r\n| Option | Description |\r\n|--------|-------------|\r\n| Folders \u2191 A-Z | Folders first, then files, both alphabetical (default) |\r\n| Folders \u2191 Z-A | Folders first, then files, both reverse-alphabetical |\r\n| Name A-Z | All items alphabetical, folders and files mixed |\r\n| Name Z-A | All items reverse-alphabetical, mixed |\r\n| Newest first | Sort by last-modified date, newest at top |\r\n| Oldest first | Sort by last-modified date, oldest at top |\r\n\r\n**Copy content to the editor:**\r\n\r\nWhen a Markdown file is open in preview mode (after clicking it in the file list), its text is selectable. To insert a passage into the active editor:\r\n\r\n1. Click a file in the list \u2014 the panel switches to preview mode showing the rendered file.\r\n2. Select the text you want in the preview pane.\r\n3. Click the **\u21A9 insert selection** button in the nav bar.\r\n4. The selected text is inserted at the cursor position in the active editor.\r\n\r\nThe preview is read-only \u2014 you cannot edit the file from the sidebar.\r\n\r\n**Hover tooltips:**\r\n\r\nHover over any file or folder in the list to see an information card:\r\n\r\n| Item type | Information shown |\r\n|-----------|------------------|\r\n| Markdown / text file | Last modified date and time \xB7 File size \xB7 Word count (frontmatter excluded) |\r\n| Image / audio / other file | Last modified date and time \xB7 File size |\r\n| Folder | Total file count \xB7 Subfolder count |\r\n\r\nThe word count updates asynchronously from Obsidian\'s file cache and appears within a moment of hover.\r\n\r\n---\r\n\r\n### Your Project\r\n\r\n#### Project Manager\r\n\r\nProjects group a set of documents (binder items) and act as the scope for export, statistics, and the word count goal banner.\r\n\r\n**To create a project:** Use the command **New writing project** from the command palette, or click **+ New** in the Launcher panel.\r\n\r\n**To switch projects:** Use the Launcher panel or the project selector at the top of the Binder panel.\r\n\r\nEach project stores:\r\n- Title, type, author, and description\r\n- Ordered binder with chapters, sections, articles, and notes\r\n- Per-item word count goals, statuses, and export flags\r\n- Optional total word count goal (shown in the Launcher and status bar)\r\n\r\n**Project templates available at creation:**\r\n\r\n| Template | Structure created |\r\n|----------|------------------|\r\n| Blank | Empty \u2014 build your own structure |\r\n| Book | Front Matter, Part 1 / Chapter 1, Back Matter |\r\n| Article series | Series folder, Article 1 placeholder, series metadata |\r\n| Blog collection | Date-organized folder, first post placeholder |\r\n| Journal article | Title Page, Abstract, Keywords, Introduction, Literature Review, Methodology, Findings / Analysis, Discussion, Conclusion, References, Appendices |\r\n| Magazine article | Pitch / Query Notes, Headline & Deck, Lede, Nut Graf, Body, Quotes & Sources, Kicker, Fact-Check Notes, Author Bio |\r\n\r\n---\r\n\r\n#### Writing Binder\r\n\r\nKeeping a book-length manuscript organized means knowing at a glance which chapters are drafted, which are in progress, and how each contributes to your total word count. The Binder is a sidebar panel that shows all of that for your active project.\r\n\r\nEach document shows its title, type (Chapter, Section, Article, Note), status (Draft, In Progress, Complete), and live word count. Documents can be reordered by drag-and-drop and toggled in or out of export.\r\n\r\n**To open:** Use the command **Open binder** from the command palette, or assign a hotkey in Settings \u2192 Hotkeys.\r\n\r\n**Adding a file to a project:**\r\n1. Right-click any Markdown file in the file explorer and choose **Add to writing project** under **Writing studio options**.\r\n2. A modal appears with a dropdown listing all your writing projects.\r\n3. Select the target project and click **Add to project**.\r\n\r\n**Adding files copied directly to the project folder:**\r\n\r\nIf you copied or moved files into the project folder outside of Obsidian and they do not appear in the binder, use the **Add files copied to this folder** button in the binder toolbar (immediately to the right of the **+ document** button). The plugin scans the project folder, lists any files not yet in the binder, and lets you select which ones to add before making any changes.\r\n\r\n---\r\n\r\n#### Compile Preview\r\n\r\nThe Compile Preview opens a split pane showing all binder documents for the active project concatenated in order, rendered as a finished manuscript.\r\n\r\n**To open:** Use the command **Preview compiled manuscript** from the command palette, or click the **Preview manuscript** button in the Launcher panel.\r\n\r\n---\r\n\r\n### Your Writing Environment\r\n\r\n#### Writing Modes\r\n\r\nThree modes shape how the editor behaves. The current mode is always shown in the status bar. Click the mode pill in the status bar to switch modes.\r\n\r\n| Mode | Purpose |\r\n|------|---------|\r\n| **Draft** | Distraction-free drafting; spell-check and formatting hints suppressed |\r\n| **Edit** | Revision pass; full editor tooling active |\r\n| **Review** | Read-only style; ideal for a final proofread |\r\n| **None** | Normal Obsidian behavior |\r\n\r\n**To switch modes:**\r\n- Click the mode indicator in the status bar.\r\n- Right-click inside the editor, then choose **Switch writing mode \u2192** under **Writing studio options**.\r\n- Assign hotkeys to **Switch to draft mode / Edit mode / Review mode** in Settings \u2192 Hotkeys.\r\n- Use the Writing Studio Launcher panel.\r\n\r\nThe active mode persists across Obsidian restarts.\r\n\r\n---\r\n\r\n#### Focus Mode\r\n\r\nFocus Mode dims everything in the editor except the paragraph or sentence you are currently writing, reducing visual noise and keeping attention on the active thought.\r\n\r\n**To toggle:** Assign a hotkey to **Toggle focus mode** in Settings \u2192 Hotkeys, or use the toggle in the Launcher panel. Press `Escape` to exit.\r\n\r\n**Settings (Settings \u2192 Focus mode):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Focus unit | Highlight at the **paragraph** or **sentence (line)** level |\r\n| Dim opacity | How opaque the dimmed text appears (10\u201350%) |\r\n| Font size override | Override the editor font size while focused; 0 = use theme default. Takes precedence over Typography Mode\'s font size while Focus Mode is active |\r\n| Auto-hide sidebars | Collapse left and right sidebars when Focus Mode activates |\r\n| Typewriter scroll | Keep the active line vertically centered as you type |\r\n\r\n---\r\n\r\n#### Typography Mode\r\n\r\nTypography Mode applies a consistent, reader-friendly text treatment to the editor: a curated font, constrained line length, controlled line height, and optional letter spacing.\r\n\r\n**To toggle:** Assign a hotkey to **Toggle typography mode** in Settings \u2192 Hotkeys, or use the toggle in the Launcher panel.\r\n\r\n**To change the font while Typography Mode is active:** Right-click inside the editor and choose **Typography font \u2192** under **Writing studio options**. A font picker menu appears with all available fonts; the active font is shown with a checkmark. Selecting a font applies it immediately and saves the setting.\r\n\r\n> **Note on fonts:** Typography fonts are loaded from Google Fonts and require an internet connection the first time each font is used. After the initial load they are cached and work offline.\r\n\r\n**Settings (Settings \u2192 Typography):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Font family | Choose from the curated font list or enter a custom font name |\r\n| Custom font name | Used when **Custom font name\u2026** is selected above |\r\n| Max line length | Characters per line (55\u201380); constrains the editor column width |\r\n| Font size | Editor font size in pixels |\r\n| Line height | Multiplier; default 1.7 |\r\n| Letter spacing | CSS `letter-spacing` value (e.g. `normal`, `0.02em`) |\r\n| Persist across sessions | Keep Typography Mode active when Obsidian reopens |\r\n\r\n**Available fonts:**\r\n\r\n| Option | Font |\r\n|--------|------|\r\n| Monospaced | iA Writer Mono (falls back to Roboto Mono / Courier New) |\r\n| Serif | iA Writer Duo Serif (falls back to Georgia) |\r\n| Sans-serif | iA Writer Quattro (falls back to system sans-serif) |\r\n| Cormorant Garamond | Elegant display serif |\r\n| Crimson Text | Classic book serif |\r\n| EB Garamond | Traditional Garamond revival |\r\n| Libre Baskerville | Readable web serif |\r\n| Libre Caslon Text | Clean slab serif |\r\n| Literata | Designed for long-form reading |\r\n| Lora | Contemporary calligraphic serif |\r\n| Inter | Modern humanist sans-serif |\r\n| Lato | Friendly rounded sans-serif |\r\n| Source Sans 3 | Clean UI sans-serif |\r\n| Custom font name\u2026 | Use any font installed on your system |\r\n\r\n---\r\n\r\n### Tracking Your Progress\r\n\r\n#### Writing Sprint Timer\r\n\r\nThe Sprint Timer runs a timed writing session. When a sprint is active, a floating overlay displays the countdown and gives you full control \u2014 without requiring you to stay on the dashboard.\r\n\r\n**To set up a sprint:**\r\n\r\n- Click **Set up sprint** in the Launcher panel to open the sprint configuration modal.\r\n- Or click one of the **Quick Sprint Options** preset buttons (10 m, 15 m, 25 m) in the Launcher panel to load a duration directly.\r\n\r\nEither path opens the floating overlay in a ready state \u2014 the timer does not start until you press \u25B6 on the overlay itself. This gives you time to navigate to your draft or open the Binder before the clock begins.\r\n\r\n**Sprint configuration modal:**\r\n\r\nThe modal lets you set:\r\n\r\n- Duration (preset or custom, in minutes)\r\n- Word count goal for the session\r\n- Scope (current file or entire project)\r\n\r\nClick **Launch sprint timer** to open the overlay in ready state.\r\n\r\n**Using the floating overlay:**\r\n\r\n| Control | Action |\r\n|---------|--------|\r\n| \u25B6 | Start or resume the sprint |\r\n| \u23F8 | Pause the sprint |\r\n| \u25A0 | Stop and end the sprint |\r\n\r\nThe overlay is draggable \u2014 click and drag the header to reposition it anywhere on screen. It stays on top regardless of writing mode or Focus Mode. The current countdown is also shown in the Obsidian status bar (`\u23F1 MM:SS`) and, when Focus Mode is active, in the focus toolbar.\r\n\r\nWhen the sprint ends, a summary modal shows words written, duration, and words-per-minute. The session is logged to sprint history and optionally appended to your Daily Note.\r\n\r\n**Settings (Settings \u2192 Sprint & goals):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Default sprint duration | Starting value in the sprint modal (minutes) |\r\n| Default daily word goal | Target used in the Writing Dashboard and Launcher |\r\n| Sound notifications | Play a tone when the sprint ends |\r\n| Sprint history retention | Days to keep sprint records before purging |\r\n| Inline goal banner | Show a progress bar below the editor toolbar when a document has a word count goal set |\r\n\r\n---\r\n\r\n#### Word Count Goal\r\n\r\nA per-document word count goal can be set and tracked inline.\r\n\r\n**To set a goal:**\r\n- Use the command **Set word count goal** from the command palette.\r\n- Right-click inside the editor and choose **Set word count goal** under **Writing studio options**.\r\n\r\nWhen a goal is set and **Inline goal banner** is enabled, a progress bar appears below the editor toolbar showing current words, goal, and percentage. It updates in real time as you type.\r\n\r\n---\r\n\r\n#### Session Word Count\r\n\r\nThe status bar shows a `(+N)` delta next to the current file\'s word count, indicating how many words you have added since opening that file this session. The Launcher\'s **Today** card also shows a cumulative session total across all files opened during the current Obsidian session. Both counts reset when Obsidian restarts.\r\n\r\n---\r\n\r\n#### Project Word Count Goal\r\n\r\nWhen an active project has a total word count goal set, a dedicated status bar item shows `{current} / {goal} project words`. This updates automatically as you write. Set a project goal in the Project modal when creating or editing a project.\r\n\r\n---\r\n\r\n#### Writing Dashboard\r\n\r\nThe Writing Dashboard shows session statistics (words written, sprints completed, time), sprint history, daily progress toward your goal, and per-project word counts with reading time.\r\n\r\n**To open:** Use the command **Open writing dashboard** from the command palette, or click the **Writing dashboard** button in the Launcher panel.\r\n\r\n---\r\n\r\n#### Targets Dashboard\r\n\r\nThe Targets Dashboard lets you assign word count goals to individual documents in the active project\'s binder and track progress across the whole project at a glance. Goals can be edited inline in the table. Rows are sortable and filterable by status.\r\n\r\n**To open:** Use the command **Open targets dashboard**, click the **Targets dashboard** button in the Launcher panel, or assign a hotkey in Settings \u2192 Hotkeys.\r\n\r\n---\r\n\r\n#### Daily Writing Log\r\n\r\nThe Writing Log is a sidebar panel that shows your writing history at a glance.\r\n\r\n**To open:** Use the command **Open writing log** from the command palette, or click the **Writing log** button in the Launcher panel.\r\n\r\n**The Writing Log shows:**\r\n- Current streak (days in a row with at least one sprint)\r\n- This session: total session words, sprint words, sprints completed, and minutes written\r\n- Last 30 days: a bar chart with one row per day showing word count, sprints completed, and a visual bar proportional to the day\'s output\r\n\r\nWhen **Append to daily note** is enabled (Settings \u2192 Writing log), a summary of each completed sprint is also appended to today\'s Daily Note.\r\n\r\n---\r\n\r\n### Getting Your Work Out\r\n\r\n#### Export Engine\r\n\r\nWhen your draft is ready, the Export Engine converts it to a finished file in your chosen format \u2014 no reformatting required.\r\n\r\n**Supported formats:** Manuscript (HTML) \xB7 PDF \xB7 Word (.docx) \xB7 RTF \xB7 HTML \xB7 Markdown \xB7 EPUB\r\n\r\n**To export:**\r\n- Right-click inside the editor and choose **Export this document** under **Writing studio options**.\r\n- Use the command **Export document** from the command palette.\r\n- Click the **Export** button in the Launcher panel.\r\n- Assign a hotkey to **Export document** in Settings \u2192 Hotkeys.\r\n\r\n**Manuscript format**\r\n\r\nThe Manuscript format produces a self-contained HTML file formatted to industry-standard manuscript conventions:\r\n- Courier New 12 pt, double-spaced, 1-inch margins\r\n- Title page with project title, author name, approximate word count, and optional contact information\r\n- Chapter headings in uppercase, page-break before each\r\n- Scene breaks rendered as `\xB7 \xB7 \xB7`\r\n\r\nNo external tools are required for manuscript export.\r\n\r\n**Settings (Settings \u2192 Export):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Default export format | Pre-selected format in the export modal |\r\n| Default paper size | Letter (US) or A4 |\r\n| Export font | Font name used in PDF/DOCX output (e.g. `Georgia`) |\r\n| Export font size | Point size for PDF/DOCX output |\r\n| Pandoc path | Full path to the `pandoc` binary if it is not on your system PATH |\r\n| EPUB language | BCP 47 language tag (e.g. `en`, `fr`, `de`) |\r\n| EPUB include cover | Generate a text cover page when no cover image is provided |\r\n\r\n> **Requirement:** Pandoc must be installed for PDF, DOCX, RTF, HTML, and EPUB export. Download from [pandoc.org](https://pandoc.org/installing.html). For PDF export, a LaTeX distribution (e.g. TeX Live or MiKTeX) is also required. Manuscript (HTML) export does not require Pandoc.\r\n\r\n---\r\n\r\n#### WordPress Publishing\r\n\r\nPublish your finished draft directly to WordPress without leaving Obsidian. The modal lets you choose the target site, set the post title, status, categories, tags, excerpt, and an optional scheduled publication date.\r\n\r\n**To publish:**\r\n- Right-click inside the editor and choose **Publish to WordPress** under **Writing studio options**.\r\n- Use the command **Publish to wordpress** from the command palette.\r\n- Click the **Publish to WordPress** button in the Launcher panel.\r\n- Assign a hotkey to **Publish to wordpress** in Settings \u2192 Hotkeys.\r\n\r\n**Setting up a site (Settings \u2192 WordPress):**\r\n\r\n1. Click **+ add WordPress site**.\r\n2. Enter a nickname, the site URL (e.g. `https://yourblog.com`), and your WordPress username.\r\n3. Generate an application password in WordPress under **Users \u2192 Profile \u2192 Application passwords** and paste it into the **Application password** field.\r\n4. Click **Test connection** to verify.\r\n\r\n**Per-site options:**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Default post status | Draft \xB7 Pending Review \xB7 Published |\r\n| Wikilink handling | **Strip** removes `[[...]]` syntax, leaving plain text \xB7 **Convert** turns wikilinks into URLs |\r\n\r\n**Preserving your credentials across updates**\r\n\r\nWriting Studio stores your WordPress site credentials in your vault\'s `.obsidian/plugins/writing-studio/data.json` file. Obsidian\'s in-app update process does not touch this file \u2014 your credentials are preserved automatically. However, if you uninstall and reinstall the plugin manually, or if a vault sync conflict overwrites `data.json`, credentials will be lost and will need to be re-entered. To avoid this, always use Obsidian\'s built-in Update button rather than uninstalling manually.\r\n\r\n---\r\n\r\n### Supporting Tools\r\n\r\n#### Frontmatter Manager\r\n\r\nWriting Studio automatically manages YAML frontmatter in your documents when **Frontmatter auto-update** is enabled. On every save it updates:\r\n\r\n- `word-count` \u2014 current word count\r\n- `modified` \u2014 last-modified date\r\n\r\nThe `word-count-goal` frontmatter field is read by the inline goal banner and the Word Count Goal modal.\r\n\r\n---\r\n\r\n## Context Menus\r\n\r\nWriting Studio adds items to Obsidian\'s right-click context menus. All Writing Studio items are grouped together under the heading **Writing studio options** to distinguish them from other plugins and Obsidian\'s built-in options.\r\n\r\n### Right-click inside an open document (editor menu)\r\n\r\n| Option | Action |\r\n|--------|--------|\r\n| Export this document | Open the export modal for the current file |\r\n| Publish to WordPress | Open the WordPress publish modal for the current file |\r\n| Set word count goal | Set a word count target for the current document |\r\n| Switch writing mode \u2192 | Open a mode-switcher menu (Draft / Edit / Review / None) |\r\n| Typography font \u2192 | Open a font picker menu to change the typography font (visible only when Typography Mode is active) |\r\n\r\n### Right-click a Markdown file in the file explorer\r\n\r\n| Option | Action |\r\n|--------|--------|\r\n| Add to writing project | Open a project picker and add the file to the selected project |\r\n\r\n### Right-click a folder in the file explorer\r\n\r\n| Option | Action |\r\n|--------|--------|\r\n| Open in sidebar explorer | Open the folder in the Folder Sidebar Explorer panel |\r\n\r\n---\r\n\r\n## Commands Reference\r\n\r\nNo default hotkeys are assigned. All commands can be given a hotkey in **Settings \u2192 Hotkeys**.\r\n\r\n| Command | Description |\r\n|---------|-------------|\r\n| Open launcher | Open the launcher sidebar panel |\r\n| Open binder | Open the writing binder sidebar panel |\r\n| Open writing log | Open the daily writing log panel |\r\n| Toggle focus mode | Enable or disable focus mode |\r\n| Toggle typography mode | Enable or disable typography mode |\r\n| Switch to draft mode | Activate draft writing mode |\r\n| Switch to edit mode | Activate edit writing mode |\r\n| Switch to review mode | Activate review writing mode |\r\n| Start writing sprint | Open the sprint timer modal |\r\n| Export document | Export the current document |\r\n| Export project | Export the full project |\r\n| Preview compiled manuscript | Open the compile preview pane |\r\n| Publish to wordpress | Publish the current document to WordPress |\r\n| New writing project | Create a new writing project |\r\n| Open writing dashboard | Open the statistics dashboard |\r\n| Open targets dashboard | Open the word count targets panel |\r\n| Set word count goal | Set a per-document word count goal |\r\n| Open folder in sidebar explorer | Search and open a vault folder in the sidebar |\r\n| Add files copied to project folder | Scan the active project folder for files not in the binder and import selected files |\r\n\r\n---\r\n\r\n## Settings Overview\r\n\r\nOpen via **Settings \u2192 Writing Studio**.\r\n\r\n| Tab | What it controls |\r\n|-----|-----------------|\r\n| General | Open on startup, default project folder, author name, document type, frontmatter auto-update |\r\n| Focus mode | Focus unit, dim opacity, font override, sidebar behavior, typewriter scroll |\r\n| Typography | Font family, custom font name, line length, font size, line height, letter spacing, persistence |\r\n| Sprint & goals | Sprint duration, daily goal, sound notifications, history retention, inline banner |\r\n| Export | Format, paper size, font, font size, Pandoc path, EPUB language, EPUB cover |\r\n| Writing log | Append sprint summaries to Daily Note |\r\n| WordPress | Site credentials, default post status, wikilink handling |\r\n\r\n---\r\n\r\n## Ribbon Icon\r\n\r\nWriting Studio adds a single icon to the Obsidian ribbon.\r\n\r\n| Icon | Action |\r\n|------|--------|\r\n| Feather | Open the Writing Studio Launcher panel |\r\n\r\nAll other features are accessible from the Launcher panel, the command palette, context menus, or assigned hotkeys.\r\n\r\n---\r\n\r\n## Installation\r\n\r\n1. Download `main.js`, `manifest.json`, and `styles.css` from the latest [GitHub release](../../releases/latest).\r\n2. Create the folder `<vault>/.obsidian/plugins/obsidian-writing-studio/` if it does not exist.\r\n3. Copy the three files into that folder.\r\n4. In Obsidian, go to **Settings \u2192 Community Plugins**, find **Writing Studio**, and enable it.\r\n\r\n> **Building from source:** Clone the repository, run `npm install`, then `npm run build`. Copy the three output files as above.\r\n\r\n---\r\n\r\n## Requirements\r\n\r\nMost features work out of the box. A few require additional software for specific functions, noted below.\r\n\r\n| Requirement | When needed |\r\n|-------------|-------------|\r\n| Obsidian 1.7.2 or later | Always |\r\n| Desktop (Windows, macOS, Linux) | Always \u2014 this plugin does not run on mobile |\r\n| Internet connection | First use of each Typography Mode font (cached after that) |\r\n| [Pandoc](https://pandoc.org/installing.html) | Export to PDF, DOCX, RTF, HTML, EPUB |\r\n| LaTeX (TeX Live / MiKTeX) | Export to PDF only |\r\n| WordPress 5.6+ with REST API enabled | WordPress publishing |\r\n| WordPress Application Password | WordPress publishing |\r\n\r\n---\r\n\r\n## Reporting a Bug\r\n\r\nIf something isn\'t working, please open an issue on GitHub:\r\n\r\n**[Submit a bug report](https://github.com/writerP-777/obsidian-writing-studio/issues/new)**\r\n\r\nInclude the following when you report:\r\n\r\n- Writing Studio version (visible in **Settings \u2192 Community Plugins**)\r\n- Obsidian version (visible in **Settings \u2192 About**)\r\n- Operating system (Windows / macOS / Linux) and version\r\n- What you expected to happen\r\n- What actually happened, and any steps to reproduce it\r\n\r\nFeature requests are welcome in the same place \u2014 please label them as **[Feature Request]** in the issue title.\r\n\r\n---\r\n\r\n## Security\r\n\r\n[![CodeQL](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml)\r\n[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/writerP-777/obsidian-writing-studio/badge)](https://securityscorecards.dev/viewer/?uri=github.com/writerP-777/obsidian-writing-studio)\r\n[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12832/baseline)](https://www.bestpractices.dev/projects/12832)\r\n[![ESLint](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml)\r\n[![ORCID](https://img.shields.io/badge/ORCID-0009--0009--8598--2069-brightgreen?logo=orcid&logoColor=white)](https://orcid.org/0009-0009-8598-2069)\r\n\r\nEvery push and pull request is scanned automatically:\r\n\r\n| Tool | What it checks |\r\n|------|----------------|\r\n| **CodeQL** | Static analysis for security vulnerabilities (XSS, injection, unsafe patterns) in TypeScript/JavaScript source |\r\n| **OpenSSF Scorecard** | Supply-chain security posture: dependency hygiene, branch protection, signed releases, and more |\r\n| **ESLint** (`eslint-plugin-obsidianmd`) | Obsidian plugin guideline compliance \u2014 fails on any warning or error |\r\n\r\nResults are published to the **Security** tab of this repository (GitHub code scanning).\r\n\r\nFor local development, a pre-commit hook runs ESLint (blocking) and a pre-push hook runs a full CodeQL scan (blocks the push if any HIGH or CRITICAL findings are present). Install the [CodeQL CLI](https://github.com/github/codeql-cli-binaries/releases) to enable local scanning (`winget install GitHub.CodeQL` on Windows).\r\n';
@@ -15050,7 +15058,7 @@ var featuresIndex = README_default.indexOf("\n## Features");
 var HELP_CONTENT = featuresIndex !== -1 ? README_default.slice(featuresIndex).trimStart() : README_default;
 
 // src/SettingsTab.ts
-var WritingStudioSettingsTab = class extends import_obsidian26.PluginSettingTab {
+var WritingStudioSettingsTab = class extends import_obsidian27.PluginSettingTab {
   constructor(app, plugin) {
     super(app, plugin);
     this.activeTab = "general";
@@ -15121,55 +15129,55 @@ var WritingStudioSettingsTab = class extends import_obsidian26.PluginSettingTab 
     }
   }
   renderGeneral(el) {
-    new import_obsidian26.Setting(el).setName(t2("settings.general.openOnStartup")).setDesc(t2("settings.general.openOnStartupDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.openOnStartup).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.general.openOnStartup")).setDesc(t2("settings.general.openOnStartupDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.openOnStartup).onChange(async (v) => {
       this.plugin.settings.openOnStartup = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.general.defaultProjectFolder")).setDesc(t2("settings.general.defaultProjectFolderDesc")).addText((text) => text.setPlaceholder(t2("settings.general.defaultProjectFolderPlaceholder")).setValue(this.plugin.settings.defaultProjectFolder).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.general.defaultProjectFolder")).setDesc(t2("settings.general.defaultProjectFolderDesc")).addText((text) => text.setPlaceholder(t2("settings.general.defaultProjectFolderPlaceholder")).setValue(this.plugin.settings.defaultProjectFolder).onChange(async (v) => {
       this.plugin.settings.defaultProjectFolder = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.general.authorName")).setDesc(t2("settings.general.authorNameDesc")).addText((text) => text.setPlaceholder(t2("settings.general.authorNamePlaceholder")).setValue(this.plugin.settings.authorName).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.general.authorName")).setDesc(t2("settings.general.authorNameDesc")).addText((text) => text.setPlaceholder(t2("settings.general.authorNamePlaceholder")).setValue(this.plugin.settings.authorName).onChange(async (v) => {
       this.plugin.settings.authorName = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.general.defaultDocumentType")).addDropdown((d) => d.addOption("chapter", t2("settings.general.docType.chapter")).addOption("section", t2("settings.general.docType.section")).addOption("article", t2("settings.general.docType.article")).addOption("note", t2("settings.general.docType.note")).setValue(this.plugin.settings.defaultDocumentType).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.general.defaultDocumentType")).addDropdown((d) => d.addOption("chapter", t2("settings.general.docType.chapter")).addOption("section", t2("settings.general.docType.section")).addOption("article", t2("settings.general.docType.article")).addOption("note", t2("settings.general.docType.note")).setValue(this.plugin.settings.defaultDocumentType).onChange(async (v) => {
       this.plugin.settings.defaultDocumentType = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.general.frontmatterAutoUpdate")).setDesc(t2("settings.general.frontmatterAutoUpdateDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.frontmatterAutoUpdate).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.general.frontmatterAutoUpdate")).setDesc(t2("settings.general.frontmatterAutoUpdateDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.frontmatterAutoUpdate).onChange(async (v) => {
       this.plugin.settings.frontmatterAutoUpdate = v;
       await this.plugin.saveSettings();
     }));
   }
   renderFocusMode(el) {
-    new import_obsidian26.Setting(el).setName(t2("settings.focus.heading")).setHeading();
-    new import_obsidian26.Setting(el).setName(t2("settings.focus.focusUnit")).setDesc(t2("settings.focus.focusUnitDesc")).addDropdown((d) => d.addOption("paragraph", t2("settings.focus.paragraph")).addOption("sentence", t2("settings.focus.sentence")).setValue(this.plugin.settings.focusUnit).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.focus.heading")).setHeading();
+    new import_obsidian27.Setting(el).setName(t2("settings.focus.focusUnit")).setDesc(t2("settings.focus.focusUnitDesc")).addDropdown((d) => d.addOption("paragraph", t2("settings.focus.paragraph")).addOption("sentence", t2("settings.focus.sentence")).setValue(this.plugin.settings.focusUnit).onChange(async (v) => {
       this.plugin.settings.focusUnit = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.focus.dimOpacity")).setDesc(t2("settings.focus.dimOpacityDesc")).addSlider((s) => s.setLimits(10, 50, 5).setValue(this.plugin.settings.dimOpacity).setDynamicTooltip().onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.focus.dimOpacity")).setDesc(t2("settings.focus.dimOpacityDesc")).addSlider((s) => s.setLimits(10, 50, 5).setValue(this.plugin.settings.dimOpacity).setDynamicTooltip().onChange(async (v) => {
       this.plugin.settings.dimOpacity = v;
       await this.plugin.saveSettings();
       activeDocument.documentElement.style.setProperty("--ws-focus-dim-opacity", String(v / 100));
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.focus.fontSizeOverride")).setDesc(t2("settings.focus.fontSizeOverrideDesc")).addText((text) => text.setValue(String(this.plugin.settings.focusFontSize || 0)).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.focus.fontSizeOverride")).setDesc(t2("settings.focus.fontSizeOverrideDesc")).addText((text) => text.setValue(String(this.plugin.settings.focusFontSize || 0)).onChange(async (v) => {
       this.plugin.settings.focusFontSize = parseInt(v) || 0;
       await this.plugin.saveSettings();
       this.plugin.focusMode.applyFontSize();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.focus.autoHideSidebars")).addToggle((toggle) => toggle.setValue(this.plugin.settings.focusAutoHideSidebars).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.focus.autoHideSidebars")).addToggle((toggle) => toggle.setValue(this.plugin.settings.focusAutoHideSidebars).onChange(async (v) => {
       this.plugin.settings.focusAutoHideSidebars = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.focus.typewriterScroll")).setDesc(t2("settings.focus.typewriterScrollDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.typewriterScroll).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.focus.typewriterScroll")).setDesc(t2("settings.focus.typewriterScrollDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.typewriterScroll).onChange(async (v) => {
       this.plugin.settings.typewriterScroll = v;
       await this.plugin.saveSettings();
     }));
   }
   renderTypography(el) {
-    new import_obsidian26.Setting(el).setName(t2("settings.typography.heading")).setHeading();
-    new import_obsidian26.Setting(el).setName(t2("settings.typography.fontFamily")).addDropdown((d) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.typography.heading")).setHeading();
+    new import_obsidian27.Setting(el).setName(t2("settings.typography.fontFamily")).addDropdown((d) => {
       d.addOption("mono", t2("settings.typography.font.mono"));
       d.addOption("serif", t2("settings.typography.font.serif"));
       d.addOption("sans", t2("settings.typography.font.sans"));
@@ -15191,100 +15199,100 @@ var WritingStudioSettingsTab = class extends import_obsidian26.PluginSettingTab 
         if (this.plugin.typographyMode.isActive()) this.plugin.typographyMode.refreshStyles();
       });
     });
-    new import_obsidian26.Setting(el).setName(t2("settings.typography.customFontName")).setDesc(t2("settings.typography.customFontNameDesc")).addText((text) => text.setPlaceholder(t2("settings.typography.customFontNamePlaceholder")).setValue(this.plugin.settings.customFontName).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.typography.customFontName")).setDesc(t2("settings.typography.customFontNameDesc")).addText((text) => text.setPlaceholder(t2("settings.typography.customFontNamePlaceholder")).setValue(this.plugin.settings.customFontName).onChange(async (v) => {
       this.plugin.settings.customFontName = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.typography.maxLineLength")).setDesc(t2("settings.typography.maxLineLengthDesc")).addSlider((s) => s.setLimits(55, 80, 1).setValue(this.plugin.settings.maxLineLength).setDynamicTooltip().onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.typography.maxLineLength")).setDesc(t2("settings.typography.maxLineLengthDesc")).addSlider((s) => s.setLimits(55, 80, 1).setValue(this.plugin.settings.maxLineLength).setDynamicTooltip().onChange(async (v) => {
       this.plugin.settings.maxLineLength = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.typography.fontSize")).addText((text) => text.setValue(String(this.plugin.settings.typographyFontSize)).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.typography.fontSize")).addText((text) => text.setValue(String(this.plugin.settings.typographyFontSize)).onChange(async (v) => {
       this.plugin.settings.typographyFontSize = parseInt(v) || 18;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.typography.lineHeight")).setDesc(t2("settings.typography.lineHeightDesc")).addText((text) => text.setValue(String(this.plugin.settings.lineHeight)).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.typography.lineHeight")).setDesc(t2("settings.typography.lineHeightDesc")).addText((text) => text.setValue(String(this.plugin.settings.lineHeight)).onChange(async (v) => {
       this.plugin.settings.lineHeight = parseFloat(v) || 1.7;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.typography.letterSpacing")).setDesc(t2("settings.typography.letterSpacingDesc")).addText((text) => text.setValue(this.plugin.settings.letterSpacing).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.typography.letterSpacing")).setDesc(t2("settings.typography.letterSpacingDesc")).addText((text) => text.setValue(this.plugin.settings.letterSpacing).onChange(async (v) => {
       this.plugin.settings.letterSpacing = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.typography.persistAcrossSessions")).setDesc(t2("settings.typography.persistAcrossSessionsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.persistTypography).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.typography.persistAcrossSessions")).setDesc(t2("settings.typography.persistAcrossSessionsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.persistTypography).onChange(async (v) => {
       this.plugin.settings.persistTypography = v;
       await this.plugin.saveSettings();
     }));
   }
   renderSprint(el) {
-    new import_obsidian26.Setting(el).setName(t2("settings.sprint.heading")).setHeading();
-    new import_obsidian26.Setting(el).setName(t2("settings.sprint.defaultDuration")).addText((text) => text.setValue(String(this.plugin.settings.defaultSprintDuration)).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.sprint.heading")).setHeading();
+    new import_obsidian27.Setting(el).setName(t2("settings.sprint.defaultDuration")).addText((text) => text.setValue(String(this.plugin.settings.defaultSprintDuration)).onChange(async (v) => {
       this.plugin.settings.defaultSprintDuration = parseInt(v) || 25;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.sprint.defaultDailyGoal")).addText((text) => text.setValue(String(this.plugin.settings.defaultDailyWordGoal)).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.sprint.defaultDailyGoal")).addText((text) => text.setValue(String(this.plugin.settings.defaultDailyWordGoal)).onChange(async (v) => {
       this.plugin.settings.defaultDailyWordGoal = parseInt(v) || 0;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.sprint.soundNotifications")).setDesc(t2("settings.sprint.soundNotificationsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.soundNotifications).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.sprint.soundNotifications")).setDesc(t2("settings.sprint.soundNotificationsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.soundNotifications).onChange(async (v) => {
       this.plugin.settings.soundNotifications = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.sprint.historyRetention")).addText((text) => text.setValue(String(this.plugin.settings.sprintHistoryRetention)).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.sprint.historyRetention")).addText((text) => text.setValue(String(this.plugin.settings.sprintHistoryRetention)).onChange(async (v) => {
       this.plugin.settings.sprintHistoryRetention = parseInt(v) || 90;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.sprint.inlineGoalBanner")).setDesc(t2("settings.sprint.inlineGoalBannerDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.inlineGoalBanner).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.sprint.inlineGoalBanner")).setDesc(t2("settings.sprint.inlineGoalBannerDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.inlineGoalBanner).onChange(async (v) => {
       this.plugin.settings.inlineGoalBanner = v;
       await this.plugin.saveSettings();
     }));
   }
   renderExport(el) {
-    new import_obsidian26.Setting(el).setName(t2("settings.export.heading")).setHeading();
-    new import_obsidian26.Setting(el).setName(t2("settings.export.defaultFormat")).addDropdown((d) => d.addOption("md", t2("settings.export.format.md")).addOption("html", t2("settings.export.format.html")).addOption("pdf", t2("settings.export.format.pdf")).addOption("docx", t2("settings.export.format.docx")).addOption("rtf", t2("settings.export.format.rtf")).setValue(this.plugin.settings.defaultExportFormat).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.export.heading")).setHeading();
+    new import_obsidian27.Setting(el).setName(t2("settings.export.defaultFormat")).addDropdown((d) => d.addOption("md", t2("settings.export.format.md")).addOption("html", t2("settings.export.format.html")).addOption("pdf", t2("settings.export.format.pdf")).addOption("docx", t2("settings.export.format.docx")).addOption("rtf", t2("settings.export.format.rtf")).setValue(this.plugin.settings.defaultExportFormat).onChange(async (v) => {
       this.plugin.settings.defaultExportFormat = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.export.defaultPaperSize")).addDropdown((d) => d.addOption("letter", t2("settings.export.paperSize.letter")).addOption("a4", t2("settings.export.paperSize.a4")).setValue(this.plugin.settings.defaultPaperSize).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.export.defaultPaperSize")).addDropdown((d) => d.addOption("letter", t2("settings.export.paperSize.letter")).addOption("a4", t2("settings.export.paperSize.a4")).setValue(this.plugin.settings.defaultPaperSize).onChange(async (v) => {
       this.plugin.settings.defaultPaperSize = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.export.exportFont")).addText((text) => text.setPlaceholder("Georgia").setValue(this.plugin.settings.defaultExportFont).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.export.exportFont")).addText((text) => text.setPlaceholder("Georgia").setValue(this.plugin.settings.defaultExportFont).onChange(async (v) => {
       this.plugin.settings.defaultExportFont = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.export.exportFontSize")).addText((text) => text.setValue(String(this.plugin.settings.defaultExportFontSize)).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.export.exportFontSize")).addText((text) => text.setValue(String(this.plugin.settings.defaultExportFontSize)).onChange(async (v) => {
       this.plugin.settings.defaultExportFontSize = parseInt(v) || 12;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.export.pandocPath")).setDesc(t2("settings.export.pandocPathDesc")).addText((text) => text.setPlaceholder("Pandoc").setValue(this.plugin.settings.pandocPath).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.export.pandocPath")).setDesc(t2("settings.export.pandocPathDesc")).addText((text) => text.setPlaceholder("Pandoc").setValue(this.plugin.settings.pandocPath).onChange(async (v) => {
       this.plugin.settings.pandocPath = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.export.epubHeading")).setHeading();
-    new import_obsidian26.Setting(el).setName(t2("settings.export.epubLanguage")).setDesc(t2("settings.export.epubLanguageDesc")).addText((text) => text.setPlaceholder("en").setValue(this.plugin.settings.epubLanguage).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.export.epubHeading")).setHeading();
+    new import_obsidian27.Setting(el).setName(t2("settings.export.epubLanguage")).setDesc(t2("settings.export.epubLanguageDesc")).addText((text) => text.setPlaceholder("en").setValue(this.plugin.settings.epubLanguage).onChange(async (v) => {
       this.plugin.settings.epubLanguage = v.trim() || "en";
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.export.includeCover")).setDesc(t2("settings.export.includeCoverDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.epubIncludeCover).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.export.includeCover")).setDesc(t2("settings.export.includeCoverDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.epubIncludeCover).onChange(async (v) => {
       this.plugin.settings.epubIncludeCover = v;
       await this.plugin.saveSettings();
     }));
   }
   renderLog(el) {
-    new import_obsidian26.Setting(el).setName(t2("settings.log.heading")).setHeading();
-    new import_obsidian26.Setting(el).setName(t2("settings.log.appendToDailyNote")).setDesc(t2("settings.log.appendToDailyNoteDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.appendToDailyNote).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.log.heading")).setHeading();
+    new import_obsidian27.Setting(el).setName(t2("settings.log.appendToDailyNote")).setDesc(t2("settings.log.appendToDailyNoteDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.appendToDailyNote).onChange(async (v) => {
       this.plugin.settings.appendToDailyNote = v;
       await this.plugin.saveSettings();
     }));
   }
   renderWordPress(el) {
-    new import_obsidian26.Setting(el).setName(t2("settings.wordpress.sitesHeading")).setHeading();
+    new import_obsidian27.Setting(el).setName(t2("settings.wordpress.sitesHeading")).setHeading();
     const sites = this.plugin.settings.wordPressSites;
     for (let i = 0; i < sites.length; i++) {
       this.renderSiteConfig(el, sites[i], i);
     }
-    new import_obsidian26.Setting(el).addButton((b) => b.setButtonText(t2("settings.wordpress.addSite")).onClick(async () => {
+    new import_obsidian27.Setting(el).addButton((b) => b.setButtonText(t2("settings.wordpress.addSite")).onClick(async () => {
       this.plugin.settings.wordPressSites.push({
         id: `site-${Date.now()}`,
         nickname: "New Site",
@@ -15301,8 +15309,8 @@ var WritingStudioSettingsTab = class extends import_obsidian26.PluginSettingTab 
         this.renderWordPress(contentEl);
       }
     }));
-    new import_obsidian26.Setting(el).setName(t2("settings.wordpress.wikilinksHeading")).setHeading();
-    new import_obsidian26.Setting(el).setName(t2("settings.wordpress.defaultWikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkStrip")).addOption("convert", t2("settings.wordpress.wikilinkConvert")).setValue(this.plugin.settings.wikilinkHandling).onChange(async (v) => {
+    new import_obsidian27.Setting(el).setName(t2("settings.wordpress.wikilinksHeading")).setHeading();
+    new import_obsidian27.Setting(el).setName(t2("settings.wordpress.defaultWikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkStrip")).addOption("convert", t2("settings.wordpress.wikilinkConvert")).setValue(this.plugin.settings.wikilinkHandling).onChange(async (v) => {
       this.plugin.settings.wikilinkHandling = v;
       await this.plugin.saveSettings();
     }));
@@ -15310,35 +15318,35 @@ var WritingStudioSettingsTab = class extends import_obsidian26.PluginSettingTab 
   renderSiteConfig(container, site, index) {
     const siteEl = container.createDiv("ws-wp-site-config");
     const heading = t2("settings.wordpress.siteHeading", { nickname: site.nickname || t2("settings.wordpress.siteUnnamed") });
-    new import_obsidian26.Setting(siteEl).setName(heading).setHeading();
-    new import_obsidian26.Setting(siteEl).setName(t2("settings.wordpress.nickname")).addText((text) => text.setValue(site.nickname).onChange(async (v) => {
+    new import_obsidian27.Setting(siteEl).setName(heading).setHeading();
+    new import_obsidian27.Setting(siteEl).setName(t2("settings.wordpress.nickname")).addText((text) => text.setValue(site.nickname).onChange(async (v) => {
       site.nickname = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(siteEl).setName(t2("settings.wordpress.siteUrl")).addText((text) => text.setPlaceholder("https://example.com").setValue(site.url).onChange(async (v) => {
+    new import_obsidian27.Setting(siteEl).setName(t2("settings.wordpress.siteUrl")).addText((text) => text.setPlaceholder("https://example.com").setValue(site.url).onChange(async (v) => {
       site.url = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(siteEl).setName(t2("settings.wordpress.username")).addText((text) => text.setValue(site.username).onChange(async (v) => {
+    new import_obsidian27.Setting(siteEl).setName(t2("settings.wordpress.username")).addText((text) => text.setValue(site.username).onChange(async (v) => {
       site.username = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(siteEl).setName(t2("settings.wordpress.appPassword")).setDesc(t2("settings.wordpress.appPasswordDesc")).addText((text) => {
+    new import_obsidian27.Setting(siteEl).setName(t2("settings.wordpress.appPassword")).setDesc(t2("settings.wordpress.appPasswordDesc")).addText((text) => {
       text.inputEl.type = "password";
       text.setValue(site.appPassword).onChange(async (v) => {
         site.appPassword = v;
         await this.plugin.saveSettings();
       });
     });
-    new import_obsidian26.Setting(siteEl).setName(t2("settings.wordpress.defaultPostStatus")).addDropdown((d) => d.addOption("draft", t2("settings.wordpress.postStatus.draft")).addOption("pending", t2("settings.wordpress.postStatus.pending")).addOption("publish", t2("settings.wordpress.postStatus.publish")).setValue(site.defaultStatus).onChange(async (v) => {
+    new import_obsidian27.Setting(siteEl).setName(t2("settings.wordpress.defaultPostStatus")).addDropdown((d) => d.addOption("draft", t2("settings.wordpress.postStatus.draft")).addOption("pending", t2("settings.wordpress.postStatus.pending")).addOption("publish", t2("settings.wordpress.postStatus.publish")).setValue(site.defaultStatus).onChange(async (v) => {
       site.defaultStatus = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian26.Setting(siteEl).setName(t2("settings.wordpress.wikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkHandlingStrip")).addOption("convert", t2("settings.wordpress.wikilinkHandlingConvert")).setValue(site.wikilinkHandling).onChange(async (v) => {
+    new import_obsidian27.Setting(siteEl).setName(t2("settings.wordpress.wikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkHandlingStrip")).addOption("convert", t2("settings.wordpress.wikilinkHandlingConvert")).setValue(site.wikilinkHandling).onChange(async (v) => {
       site.wikilinkHandling = v;
       await this.plugin.saveSettings();
     }));
-    const testRow = new import_obsidian26.Setting(siteEl).setName(t2("settings.wordpress.testConnection")).setDesc(t2("settings.wordpress.testConnectionDesc"));
+    const testRow = new import_obsidian27.Setting(siteEl).setName(t2("settings.wordpress.testConnection")).setDesc(t2("settings.wordpress.testConnectionDesc"));
     const statusEl = siteEl.createDiv("ws-wp-test-status");
     testRow.addButton((b) => b.setButtonText(t2("settings.wordpress.testConnection")).onClick(async () => {
       statusEl.textContent = t2("settings.wordpress.testing");
@@ -15347,7 +15355,7 @@ var WritingStudioSettingsTab = class extends import_obsidian26.PluginSettingTab 
       statusEl.textContent = result.message;
       statusEl.className = `ws-wp-test-status ${result.success ? "ws-wp-test-ok" : "ws-wp-test-err"}`;
     }));
-    new import_obsidian26.Setting(siteEl).addButton((b) => {
+    new import_obsidian27.Setting(siteEl).addButton((b) => {
       b.setButtonText(t2("settings.wordpress.removeSite"));
       b.buttonEl.addClass("mod-warning");
       b.onClick(async () => {
@@ -15362,10 +15370,10 @@ var WritingStudioSettingsTab = class extends import_obsidian26.PluginSettingTab 
     });
   }
   async renderHelp(el) {
-    this.helpComponent = new import_obsidian26.Component();
+    this.helpComponent = new import_obsidian27.Component();
     this.helpComponent.load();
     el.addClass("ws-help-content");
-    await import_obsidian26.MarkdownRenderer.render(this.app, HELP_CONTENT, el, "", this.helpComponent);
+    await import_obsidian27.MarkdownRenderer.render(this.app, HELP_CONTENT, el, "", this.helpComponent);
     const supportDiv = el.createDiv({ cls: "ws-support-footer" });
     supportDiv.createEl("a", {
       href: "https://buymeacoffee.com/writerp777",
@@ -15381,9 +15389,9 @@ var WritingStudioSettingsTab = class extends import_obsidian26.PluginSettingTab 
 };
 
 // src/FolderSidebarView.ts
-var import_obsidian27 = require("obsidian");
+var import_obsidian28 = require("obsidian");
 var FOLDER_SIDEBAR_VIEW_TYPE = "folder-sidebar-explorer-view";
-var FolderSidebarView = class extends import_obsidian27.ItemView {
+var FolderSidebarView = class extends import_obsidian28.ItemView {
   constructor(leaf) {
     super(leaf);
     this.rootFolder = null;
@@ -15437,7 +15445,7 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
     if (active) return active;
     for (const leaf of this.app.workspace.getLeavesOfType("markdown")) {
       const view = leaf.view;
-      if (view instanceof import_obsidian27.MarkdownView) return view.editor;
+      if (view instanceof import_obsidian28.MarkdownView) return view.editor;
     }
     return null;
   }
@@ -15467,7 +15475,7 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
     if (this.historyStack.length === 0) return;
     const prevPath = this.historyStack.pop();
     const prev = this.app.vault.getAbstractFileByPath(prevPath);
-    if (prev instanceof import_obsidian27.TFolder) {
+    if (prev instanceof import_obsidian28.TFolder) {
       this.currentFolder = prev;
       this.searchQuery = "";
       this.searchResults = null;
@@ -15504,10 +15512,10 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
     const results = [];
     const walk = (f) => {
       for (const child of f.children) {
-        if (child instanceof import_obsidian27.TFolder) {
+        if (child instanceof import_obsidian28.TFolder) {
           results.push(child);
           walk(child);
-        } else if (child instanceof import_obsidian27.TFile) {
+        } else if (child instanceof import_obsidian28.TFile) {
           results.push(child);
         }
       }
@@ -15553,7 +15561,7 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
       }
     }
     const textFiles = allItems.filter(
-      (item) => item instanceof import_obsidian27.TFile && ["md", "txt"].includes(item.extension.toLowerCase()) && !nameMatched.has(item)
+      (item) => item instanceof import_obsidian28.TFile && ["md", "txt"].includes(item.extension.toLowerCase()) && !nameMatched.has(item)
     );
     for (const file of textFiles) {
       try {
@@ -15601,7 +15609,7 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
     tip.style.left = `${Math.round(left)}px`;
     tip.createDiv({ cls: "ws-tooltip-name", text: item.name });
     tip.createDiv({ cls: "ws-tooltip-divider" });
-    if (item instanceof import_obsidian27.TFile) {
+    if (item instanceof import_obsidian28.TFile) {
       const modDate = new Date(item.stat.mtime);
       const modStr = modDate.toLocaleDateString(void 0, {
         year: "numeric",
@@ -15630,8 +15638,8 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
       let folderCount = 0;
       const walk = (f) => {
         for (const child of f.children) {
-          if (child instanceof import_obsidian27.TFile) fileCount++;
-          else if (child instanceof import_obsidian27.TFolder) {
+          if (child instanceof import_obsidian28.TFile) fileCount++;
+          else if (child instanceof import_obsidian28.TFolder) {
             folderCount++;
             walk(child);
           }
@@ -15710,8 +15718,8 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
   // ── Sort helpers ──────────────────────────────────────────────────────────
   sortItems(items) {
     return [...items].sort((a, b) => {
-      const aIsFolder = a instanceof import_obsidian27.TFolder;
-      const bIsFolder = b instanceof import_obsidian27.TFolder;
+      const aIsFolder = a instanceof import_obsidian28.TFolder;
+      const bIsFolder = b instanceof import_obsidian28.TFolder;
       switch (this.sortMode) {
         case "folders-az":
           if (aIsFolder && !bIsFolder) return -1;
@@ -15726,13 +15734,13 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
         case "za":
           return b.name.localeCompare(a.name);
         case "modified-new": {
-          const aMtime = a instanceof import_obsidian27.TFile ? a.stat.mtime : 0;
-          const bMtime = b instanceof import_obsidian27.TFile ? b.stat.mtime : 0;
+          const aMtime = a instanceof import_obsidian28.TFile ? a.stat.mtime : 0;
+          const bMtime = b instanceof import_obsidian28.TFile ? b.stat.mtime : 0;
           return bMtime - aMtime;
         }
         case "modified-old": {
-          const aMtime = a instanceof import_obsidian27.TFile ? a.stat.mtime : 0;
-          const bMtime = b instanceof import_obsidian27.TFile ? b.stat.mtime : 0;
+          const aMtime = a instanceof import_obsidian28.TFile ? a.stat.mtime : 0;
+          const bMtime = b instanceof import_obsidian28.TFile ? b.stat.mtime : 0;
           return aMtime - bMtime;
         }
       }
@@ -15741,8 +15749,8 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
   sortResults(results) {
     return [...results].sort((a, b) => {
       const aItem = a.item, bItem = b.item;
-      const aIsFolder = aItem instanceof import_obsidian27.TFolder;
-      const bIsFolder = bItem instanceof import_obsidian27.TFolder;
+      const aIsFolder = aItem instanceof import_obsidian28.TFolder;
+      const bIsFolder = bItem instanceof import_obsidian28.TFolder;
       switch (this.sortMode) {
         case "folders-az":
           if (aIsFolder && !bIsFolder) return -1;
@@ -15757,13 +15765,13 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
         case "za":
           return bItem.name.localeCompare(aItem.name);
         case "modified-new": {
-          const aMtime = aItem instanceof import_obsidian27.TFile ? aItem.stat.mtime : 0;
-          const bMtime = bItem instanceof import_obsidian27.TFile ? bItem.stat.mtime : 0;
+          const aMtime = aItem instanceof import_obsidian28.TFile ? aItem.stat.mtime : 0;
+          const bMtime = bItem instanceof import_obsidian28.TFile ? bItem.stat.mtime : 0;
           return bMtime - aMtime;
         }
         case "modified-old": {
-          const aMtime = aItem instanceof import_obsidian27.TFile ? aItem.stat.mtime : 0;
-          const bMtime = bItem instanceof import_obsidian27.TFile ? bItem.stat.mtime : 0;
+          const aMtime = aItem instanceof import_obsidian28.TFile ? aItem.stat.mtime : 0;
+          const bMtime = bItem instanceof import_obsidian28.TFile ? bItem.stat.mtime : 0;
           return aMtime - bMtime;
         }
       }
@@ -15846,7 +15854,7 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
     const toolbar = container.createDiv({ cls: "ws-folder-toolbar" });
     const searchWrap = toolbar.createDiv({ cls: "ws-folder-search-wrap" });
     const searchIcon = searchWrap.createSpan({ cls: "ws-folder-search-icon" });
-    (0, import_obsidian27.setIcon)(searchIcon, "search");
+    (0, import_obsidian28.setIcon)(searchIcon, "search");
     const searchInput = searchWrap.createEl("input", {
       cls: "ws-folder-search-input",
       type: "text",
@@ -15903,7 +15911,7 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
     const ext = file.extension.toLowerCase();
     if (ext === "md") {
       const text = await this.app.vault.read(file);
-      await import_obsidian27.MarkdownRenderer.render(this.app, text, content, file.path, this);
+      await import_obsidian28.MarkdownRenderer.render(this.app, text, content, file.path, this);
       if (this.searchQuery) this.highlightTextInElement(content, this.searchQuery);
     } else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) {
       const img = content.createEl("img", { cls: "ws-folder-img" });
@@ -15946,14 +15954,14 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
         const itemEl = list.createDiv({ cls: "ws-folder-item ws-folder-item--column" });
         const topRow = itemEl.createDiv({ cls: "ws-folder-item-row" });
         const iconEl = topRow.createSpan({ cls: "ws-folder-item-icon" });
-        if (item instanceof import_obsidian27.TFolder) {
-          (0, import_obsidian27.setIcon)(iconEl, "folder");
+        if (item instanceof import_obsidian28.TFolder) {
+          (0, import_obsidian28.setIcon)(iconEl, "folder");
         } else {
           const ext = item.extension.toLowerCase();
-          if (ext === "md") (0, import_obsidian27.setIcon)(iconEl, "file-text");
-          else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian27.setIcon)(iconEl, "image");
-          else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian27.setIcon)(iconEl, "file-audio");
-          else (0, import_obsidian27.setIcon)(iconEl, "file");
+          if (ext === "md") (0, import_obsidian28.setIcon)(iconEl, "file-text");
+          else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian28.setIcon)(iconEl, "image");
+          else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian28.setIcon)(iconEl, "file-audio");
+          else (0, import_obsidian28.setIcon)(iconEl, "file");
         }
         const isAtRoot = ((_a2 = item.parent) == null ? void 0 : _a2.path) === ((_c = (_b2 = this.rootFolder) == null ? void 0 : _b2.path) != null ? _c : current.path);
         const label = !isAtRoot && item.path.startsWith(rootPath) ? item.path.slice(rootPath.length) : item.name;
@@ -15971,8 +15979,8 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
           this.renderHighlightedText(snippetEl, snippet, lowerQuery);
         }
         itemEl.addEventListener("click", () => {
-          if (item instanceof import_obsidian27.TFolder) this.navigateTo(item);
-          else if (item instanceof import_obsidian27.TFile) this.openFile(item);
+          if (item instanceof import_obsidian28.TFolder) this.navigateTo(item);
+          else if (item instanceof import_obsidian28.TFile) this.openFile(item);
         });
         this.addTooltip(itemEl, item);
         items2.push(itemEl);
@@ -16009,7 +16017,7 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
       return;
     }
     const displayItems = current.children.filter(
-      (c) => c instanceof import_obsidian27.TFolder || c instanceof import_obsidian27.TFile
+      (c) => c instanceof import_obsidian28.TFolder || c instanceof import_obsidian28.TFile
     );
     const sorted = this.sortItems(displayItems);
     if (sorted.length === 0) {
@@ -16021,19 +16029,19 @@ var FolderSidebarView = class extends import_obsidian27.ItemView {
     for (const child of sorted) {
       const item = list.createDiv({ cls: "ws-folder-item" });
       const iconEl = item.createSpan({ cls: "ws-folder-item-icon" });
-      if (child instanceof import_obsidian27.TFolder) {
-        (0, import_obsidian27.setIcon)(iconEl, "folder");
-      } else if (child instanceof import_obsidian27.TFile) {
+      if (child instanceof import_obsidian28.TFolder) {
+        (0, import_obsidian28.setIcon)(iconEl, "folder");
+      } else if (child instanceof import_obsidian28.TFile) {
         const ext = child.extension.toLowerCase();
-        if (ext === "md") (0, import_obsidian27.setIcon)(iconEl, "file-text");
-        else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian27.setIcon)(iconEl, "image");
-        else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian27.setIcon)(iconEl, "file-audio");
-        else (0, import_obsidian27.setIcon)(iconEl, "file");
+        if (ext === "md") (0, import_obsidian28.setIcon)(iconEl, "file-text");
+        else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian28.setIcon)(iconEl, "image");
+        else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian28.setIcon)(iconEl, "file-audio");
+        else (0, import_obsidian28.setIcon)(iconEl, "file");
       }
       item.createSpan({ text: child.name });
       item.addEventListener("click", () => {
-        if (child instanceof import_obsidian27.TFolder) this.navigateTo(child);
-        else if (child instanceof import_obsidian27.TFile) this.openFile(child);
+        if (child instanceof import_obsidian28.TFolder) this.navigateTo(child);
+        else if (child instanceof import_obsidian28.TFile) this.openFile(child);
       });
       this.addTooltip(item, child);
       items.push(item);
@@ -16075,7 +16083,7 @@ function applyFocus(items, index) {
     if (i === index) item.scrollIntoView({ block: "nearest" });
   });
 }
-var FolderPickerModal = class extends import_obsidian27.FuzzySuggestModal {
+var FolderPickerModal = class extends import_obsidian28.FuzzySuggestModal {
   constructor(app, onChoose) {
     super(app);
     this.onChoose = onChoose;
@@ -16086,7 +16094,7 @@ var FolderPickerModal = class extends import_obsidian27.FuzzySuggestModal {
     const walk = (folder) => {
       folders.push(folder);
       for (const child of folder.children) {
-        if (child instanceof import_obsidian27.TFolder) walk(child);
+        if (child instanceof import_obsidian28.TFolder) walk(child);
       }
     };
     walk(this.app.vault.getRoot());
@@ -16101,9 +16109,9 @@ var FolderPickerModal = class extends import_obsidian27.FuzzySuggestModal {
 };
 
 // src/WritingLogView.ts
-var import_obsidian28 = require("obsidian");
+var import_obsidian29 = require("obsidian");
 var WRITING_LOG_VIEW_TYPE = "writing-studio-writing-log";
-var WritingLogView = class extends import_obsidian28.ItemView {
+var WritingLogView = class extends import_obsidian29.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
     this.plugin = plugin;
@@ -16130,7 +16138,7 @@ var WritingLogView = class extends import_obsidian28.ItemView {
     const root = this.containerEl.children[1];
     root.empty();
     root.addClass("ws-log-root");
-    const lang = (0, import_obsidian28.getLanguage)();
+    const lang = (0, import_obsidian29.getLanguage)();
     const header = root.createDiv("ws-log-header");
     header.createDiv({ text: t2("log.title"), cls: "ws-log-title" });
     header.createDiv({
@@ -16178,7 +16186,7 @@ var WritingLogView = class extends import_obsidian28.ItemView {
     histSection.createDiv({ text: t2("log.last30Days"), cls: "ws-log-section-label" });
     const history = await this.plugin.statsTracker.getWritingHistory(30);
     const maxWords = Math.max(...history.map((d) => d.wordsWritten), 1);
-    const todayStr = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
+    const todayStr = localDateString();
     const list = histSection.createDiv("ws-log-day-list");
     for (const entry of [...history].reverse()) {
       const row = list.createDiv("ws-log-day-row");
@@ -16205,8 +16213,8 @@ var WritingLogView = class extends import_obsidian28.ItemView {
 };
 
 // modals/AddToProjectModal.ts
-var import_obsidian29 = require("obsidian");
-var AddToProjectModal = class extends import_obsidian29.Modal {
+var import_obsidian30 = require("obsidian");
+var AddToProjectModal = class extends import_obsidian30.Modal {
   constructor(app, plugin, file, onConfirm) {
     super(app);
     this.selectedProjectId = "";
@@ -16228,7 +16236,7 @@ var AddToProjectModal = class extends import_obsidian29.Modal {
     }
     this.selectedProjectId = projects[0].id;
     contentEl.createEl("p", { text: t2("addToProject.file", { path: this.file.path }), cls: "ws-add-to-project-path" });
-    new import_obsidian29.Setting(contentEl).setName(t2("addToProject.projectName")).setDesc(t2("addToProject.projectDesc")).addDropdown((d) => {
+    new import_obsidian30.Setting(contentEl).setName(t2("addToProject.projectName")).setDesc(t2("addToProject.projectDesc")).addDropdown((d) => {
       projects.forEach((p) => {
         d.addOption(p.id, p.title);
       });
@@ -16304,7 +16312,7 @@ var DEFAULT_SETTINGS = {
   activeProjectId: null,
   currentWritingMode: "none"
 };
-var WritingStudioPlugin = class extends import_obsidian30.Plugin {
+var WritingStudioPlugin = class extends import_obsidian31.Plugin {
   constructor() {
     super(...arguments);
     this.wordCountUpdateTimer = null;
@@ -16497,7 +16505,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
     );
     this.registerEvent(
       this.app.workspace.on("file-menu", (menu, file) => {
-        if (file instanceof import_obsidian30.TFile && file.extension === "md") {
+        if (file instanceof import_obsidian31.TFile && file.extension === "md") {
           menu.addItem((i) => i.setTitle(t2("main.menu.studioOptions")).setSection("writing-studio").setDisabled(true));
           menu.addItem(
             (i) => i.setTitle(t2("main.menu.addToProject")).setIcon("book-open").setSection("writing-studio").onClick(() => {
@@ -16505,7 +16513,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
             })
           );
         }
-        if (file instanceof import_obsidian30.TFolder) {
+        if (file instanceof import_obsidian31.TFolder) {
           menu.addItem((i) => i.setTitle(t2("main.menu.studioOptions")).setSection("writing-studio").setDisabled(true));
           menu.addItem(
             (i) => i.setTitle(t2("main.menu.openSidebar")).setIcon("folder").setSection("writing-studio").onClick(() => {
@@ -16517,7 +16525,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
     );
     this.registerEvent(
       this.app.vault.on("modify", (file) => {
-        if (file instanceof import_obsidian30.TFile) {
+        if (file instanceof import_obsidian31.TFile) {
           this.fmManager.scheduleUpdate(file);
           this.scheduleWordCountUpdate();
           this.scheduleProjectGoalUpdate();
@@ -16527,7 +16535,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
     );
     this.registerEvent(
       this.app.vault.on("rename", (file, oldPath) => {
-        if (!(file instanceof import_obsidian30.TFile)) return;
+        if (!(file instanceof import_obsidian31.TFile)) return;
         if (file.extension === "md") {
           void this.repairBinderPaths(oldPath, file.path, file.basename);
         }
@@ -16715,9 +16723,9 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
   publishCurrentFile() {
     const leaf = this.app.workspace.getMostRecentLeaf();
     const view = leaf == null ? void 0 : leaf.view;
-    const file = view instanceof import_obsidian30.MarkdownView ? view.file : null;
-    if (!(file instanceof import_obsidian30.TFile)) {
-      new import_obsidian30.Notice(t2("main.notice.noMarkdownOpen"));
+    const file = view instanceof import_obsidian31.MarkdownView ? view.file : null;
+    if (!(file instanceof import_obsidian31.TFile)) {
+      new import_obsidian31.Notice(t2("main.notice.noMarkdownOpen"));
       return;
     }
     new PublishModal(this.app, this, file.path).open();
@@ -16727,7 +16735,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
     new WordCountGoalModal(this.app, this, file).open();
   }
   showModeSwitcher(e) {
-    const menu = new import_obsidian30.Menu();
+    const menu = new import_obsidian31.Menu();
     menu.addItem((i) => i.setTitle(t2("main.menu.draftMode")).setIcon("pencil").onClick(() => this.writingModes.switchMode("draft")));
     menu.addItem((i) => i.setTitle(t2("main.menu.editMode")).setIcon("edit-3").onClick(() => this.writingModes.switchMode("edit")));
     menu.addItem((i) => i.setTitle(t2("main.menu.reviewMode")).setIcon("eye").onClick(() => this.writingModes.switchMode("review")));
@@ -16736,7 +16744,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
     if (e instanceof MouseEvent) menu.showAtMouseEvent(e);
   }
   showFontPicker(e) {
-    const menu = new import_obsidian30.Menu();
+    const menu = new import_obsidian31.Menu();
     TYPOGRAPHY_FONT_OPTIONS.forEach(({ key }) => {
       menu.addItem((i) => {
         i.setTitle(t2(`settings.typography.font.${key}`)).onClick(() => {
@@ -16754,7 +16762,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
   addFileToProject(file) {
     const projects = this.projectManager.getProjects();
     if (projects.length === 0) {
-      new import_obsidian30.Notice(t2("addToProject.noProjects"));
+      new import_obsidian31.Notice(t2("addToProject.noProjects"));
       return;
     }
     new AddToProjectModal(this.app, this, file, async (projectId) => {
@@ -16773,7 +16781,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
       binder.items.push(item);
       await this.projectManager.saveBinder(binder);
       await this.refreshBinder();
-      new import_obsidian30.Notice(t2("main.notice.addedToProject", { file: file.basename, project: project.title }));
+      new import_obsidian31.Notice(t2("main.notice.addedToProject", { file: file.basename, project: project.title }));
     }).open();
   }
   scheduleLauncherRefresh() {
@@ -16795,7 +16803,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
       return;
     }
     const view = leaf.view;
-    if (!(view instanceof import_obsidian30.MarkdownView)) {
+    if (!(view instanceof import_obsidian31.MarkdownView)) {
       this.statusBarWordCount.textContent = "";
       return;
     }
@@ -16846,7 +16854,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
     const leaf = this.app.workspace.getMostRecentLeaf();
     if (!leaf) return;
     const view = leaf.view;
-    if (!(view instanceof import_obsidian30.MarkdownView)) return;
+    if (!(view instanceof import_obsidian31.MarkdownView)) return;
     const file = view.file;
     if (!file) return;
     const goal = await this.projectManager.getWordCountGoalForFile(file);
@@ -16872,7 +16880,7 @@ var WritingStudioPlugin = class extends import_obsidian30.Plugin {
   registerIcons() {
   }
 };
-var SprintSummaryModal = class extends import_obsidian30.Modal {
+var SprintSummaryModal = class extends import_obsidian31.Modal {
   constructor(app, session) {
     super(app);
     this.session = session;
@@ -16903,7 +16911,7 @@ var SprintSummaryModal = class extends import_obsidian30.Modal {
     this.contentEl.empty();
   }
 };
-var WordCountGoalModal = class extends import_obsidian30.Modal {
+var WordCountGoalModal = class extends import_obsidian31.Modal {
   constructor(app, plugin, file) {
     super(app);
     this.goal = 0;
@@ -16918,7 +16926,7 @@ var WordCountGoalModal = class extends import_obsidian30.Modal {
     const content = await this.app.vault.read(this.file);
     const fm = this.plugin.fmManager.parseFrontmatter(content);
     this.goal = (fm == null ? void 0 : fm["word-count-goal"]) || 0;
-    new import_obsidian30.Setting(contentEl).setName(t2("wordCountGoal.name")).setDesc(t2("wordCountGoal.desc")).addText((tx) => tx.setValue(String(this.goal || "")).setPlaceholder(t2("wordCountGoal.placeholder")).onChange((v) => {
+    new import_obsidian31.Setting(contentEl).setName(t2("wordCountGoal.name")).setDesc(t2("wordCountGoal.desc")).addText((tx) => tx.setValue(String(this.goal || "")).setPlaceholder(t2("wordCountGoal.placeholder")).onChange((v) => {
       this.goal = parseInt(v) || 0;
     }));
     const btnRow = contentEl.createDiv("ws-modal-btn-row");

--- a/modals/PublishModal.ts
+++ b/modals/PublishModal.ts
@@ -2,6 +2,7 @@ import { App, Modal, Setting, Notice, TFile } from 'obsidian';
 import type WritingStudioPlugin from '../main';
 import { WordPressSite, WPCategory, WPPostStatus } from '../models/WordPressSite';
 import { t } from '../src/i18n';
+import { localDateString } from '../src/dates';
 
 export class PublishModal extends Modal {
   private plugin: WritingStudioPlugin;
@@ -215,7 +216,7 @@ export class PublishModal extends Modal {
           wpPostId: result.postId,
           wpUrl: result.url,
           wpStatus: result.status,
-          wpPublished: result.scheduledDate ? undefined : new Date().toISOString().split('T')[0],
+          wpPublished: result.scheduledDate ? undefined : localDateString(),
           wpScheduled: result.scheduledDate,
         });
       });

--- a/src/ExportEngine.ts
+++ b/src/ExportEngine.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 import type WritingStudioPlugin from '../main';
 import { EpubEngine, EpubChapter } from './EpubEngine';
 import { t } from './i18n';
+import { localDateString } from './dates';
 
 interface FileSystemAdapter {
   getFullPath?(vaultPath: string): string;
@@ -170,7 +171,7 @@ export class ExportEngine {
     const title = project?.title || 'Untitled';
     const author = project?.author || this.plugin.settings.authorName || '';
     const language = this.plugin.settings.epubLanguage || 'en';
-    const date = new Date().toISOString().split('T')[0];
+    const date = localDateString();
 
     const chapters: EpubChapter[] = [];
 

--- a/src/FrontmatterManager.ts
+++ b/src/FrontmatterManager.ts
@@ -1,5 +1,6 @@
 import { App, TFile, normalizePath } from 'obsidian';
 import { WPPostMeta } from '../models/WordPressSite';
+import { localDateString } from './dates';
 import type WritingStudioPlugin from '../main';
 
 export class FrontmatterManager {
@@ -50,7 +51,7 @@ export class FrontmatterManager {
     try {
       const content = await this.app.vault.read(file);
       const wordCount = this.countWords(content);
-      const now = new Date().toISOString().split('T')[0];
+      const now = localDateString();
 
       await this.app.fileManager.processFrontMatter(file, (fm: Record<string, unknown>) => {
         fm['word-count'] = wordCount;

--- a/src/ProjectManager.ts
+++ b/src/ProjectManager.ts
@@ -1,6 +1,7 @@
 import { App, Notice, TFolder, TFile, normalizePath } from 'obsidian';
 import type WritingStudioPlugin from '../main';
 import { t } from './i18n';
+import { localDateString } from './dates';
 import { WritingProject, ProjectType } from '../models/Project';
 import { BinderData, BinderItem } from '../models/BinderItem';
 import { SprintSession } from '../models/SprintSession';
@@ -80,7 +81,7 @@ export class ProjectManager {
     await this.ensureFolder(normalizePath(`${folderPath}/Research`));
     await this.ensureFolder(normalizePath(`${folderPath}/Exports`));
 
-    const now = new Date().toISOString().split('T')[0];
+    const now = localDateString();
     const project: WritingProject = {
       id,
       title,
@@ -132,7 +133,7 @@ export class ProjectManager {
   }
 
   async saveProject(project: WritingProject): Promise<void> {
-    project.modified = new Date().toISOString().split('T')[0];
+    project.modified = localDateString();
     const path = normalizePath(`${project.folderPath}/_project.json`);
     await this.writeJson(path, project);
     this.projects.set(project.id, project);
@@ -182,7 +183,7 @@ export class ProjectManager {
     parentId?: string
   ): Promise<BinderItem> {
     const binder = await this.loadBinder(project);
-    const now = new Date().toISOString().split('T')[0];
+    const now = localDateString();
     const baseName = title.replace(/[\\/:*?"<>|]/g, '-');
     let filePath = normalizePath(`${project.folderPath}/Chapters/${baseName}.md`);
     for (let n = 2; this.app.vault.getAbstractFileByPath(filePath); n++) {

--- a/src/StatsTracker.ts
+++ b/src/StatsTracker.ts
@@ -1,6 +1,7 @@
 import { App, TFile, normalizePath } from 'obsidian';
 import type WritingStudioPlugin from '../main';
 import { t } from './i18n';
+import { localDateString, moment } from './dates';
 import { SprintSession } from '../models/SprintSession';
 
 interface DailyStats {
@@ -35,7 +36,7 @@ export class StatsTracker {
 
   private newDailyStats(): DailyStats {
     return {
-      date: new Date().toISOString().split('T')[0],
+      date: localDateString(),
       wordsWritten: 0,
       sprintsCompleted: 0,
       totalMinutes: 0,
@@ -44,6 +45,11 @@ export class StatsTracker {
   }
 
   recordSprint(session: SprintSession): void {
+    // Roll the session stats over when the local day has changed since
+    // plugin load — sessions spanning midnight accrued to the old day
+    if (this.sessionStats.date !== localDateString()) {
+      this.sessionStats = this.newDailyStats();
+    }
     this.sessionStats.wordsWritten += session.wordsWritten;
     this.sessionStats.sprintsCompleted++;
     this.sessionStats.totalMinutes += session.duration;
@@ -60,8 +66,7 @@ export class StatsTracker {
   }
 
   private async appendToDailyNote(session: SprintSession): Promise<void> {
-    const today = new Date().toISOString().split('T')[0];
-    const dailyNotePath = this.getDailyNotePath(today);
+    const dailyNotePath = this.getDailyNotePath();
 
     const project = this.plugin.projectManager.getActiveProject();
     const projectName = project?.title || t('statsTracker.unknownProject');
@@ -78,31 +83,33 @@ ${t('statsTracker.dailyNote.heading')}
 - ${t('statsTracker.dailyNote.sessionTotal')} ${t('statsTracker.dailyNote.sessionTotalValue', { duration: session.duration })}
 `;
 
-    let dailyFile = this.app.vault.getAbstractFileByPath(dailyNotePath);
+    const dailyFile = this.app.vault.getAbstractFileByPath(dailyNotePath);
 
     if (dailyFile instanceof TFile) {
-      const content = await this.app.vault.read(dailyFile);
-      await this.app.vault.modify(dailyFile, content + '\n' + entry);
-    } else {
-      // Fall back to writing-log.json
-      const activeProject = this.plugin.projectManager.getActiveProject();
-      if (activeProject) {
-        await this.plugin.projectManager.logSprintSession(activeProject, session);
-      }
+      // Atomic append — read-then-modify could clobber concurrent edits
+      await this.app.vault.append(dailyFile, '\n' + entry);
+      return;
+    }
+    try {
+      // Documented behavior is "appended to your Daily Note" — create it if
+      // it doesn't exist yet. The session is already in _writing-log.json
+      // (main.ts logs every sprint), so no JSON fallback is needed here;
+      // the old fallback double-logged the session.
+      await this.app.vault.create(dailyNotePath, entry);
+    } catch {
+      // Parent folder missing or path invalid — the JSON log still has it
     }
   }
 
-  private getDailyNotePath(date: string): string {
-    // Try to get daily notes folder from Obsidian daily notes config
-    type AppInternal = App & { internalPlugins?: { plugins?: Record<string, { instance?: { options?: { folder?: string } } }> } };
-    const dailyNotesPlugin = (this.app as AppInternal).internalPlugins?.plugins?.['daily-notes'];
-    const folder = dailyNotesPlugin?.instance?.options?.folder || '';
-    // Use the date as-is (ISO format) since we can't easily format with moment here
-    const fileName = date;
-    if (folder) {
-      return normalizePath(`${folder}/${fileName}.md`);
-    }
-    return normalizePath(`${fileName}.md`);
+  private getDailyNotePath(): string {
+    // Read folder AND date format from the daily-notes core plugin options,
+    // formatting with moment (it ships with Obsidian) — the old hardcoded
+    // ISO filename silently missed every non-default daily-note format
+    type AppInternal = App & { internalPlugins?: { plugins?: Record<string, { instance?: { options?: { folder?: string; format?: string } } }> } };
+    const options = (this.app as AppInternal).internalPlugins?.plugins?.['daily-notes']?.instance?.options;
+    const fileName = moment().format(options?.format || 'YYYY-MM-DD');
+    const folder = options?.folder || '';
+    return normalizePath(folder ? `${folder}/${fileName}.md` : `${fileName}.md`);
   }
 
   updateFileWordCount(path: string, wordCount: number): void {
@@ -178,7 +185,8 @@ ${t('statsTracker.dailyNote.heading')}
     if (project) {
       const log = await this.plugin.projectManager.getWritingLog(project);
       for (const session of log) {
-        const date = session.date.split('T')[0];
+        // session.date is a UTC instant — group by its local calendar day
+        const date = localDateString(session.date);
         const existing = byDate.get(date);
         if (existing) {
           existing.wordsWritten += session.wordsWritten;
@@ -200,7 +208,7 @@ ${t('statsTracker.dailyNote.heading')}
     for (let i = days - 1; i >= 0; i--) {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
-      const dateStr = d.toISOString().split('T')[0];
+      const dateStr = localDateString(d);
       result.push(byDate.get(dateStr) ?? {
         date: dateStr,
         wordsWritten: 0,
@@ -218,14 +226,14 @@ ${t('statsTracker.dailyNote.heading')}
     const log = await this.plugin.projectManager.getWritingLog(project);
     if (log.length === 0) return 0;
 
-    const dates = new Set(log.map(s => s.date.split('T')[0]));
+    const dates = new Set(log.map(s => localDateString(s.date)));
     let streak = 0;
     const today = new Date();
 
     for (let i = 0; i < 365; i++) {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
-      const dateStr = d.toISOString().split('T')[0];
+      const dateStr = localDateString(d);
       if (dates.has(dateStr)) {
         streak++;
       } else if (i > 0) {

--- a/src/WritingLogView.ts
+++ b/src/WritingLogView.ts
@@ -1,6 +1,7 @@
 import { ItemView, WorkspaceLeaf, getLanguage } from 'obsidian';
 import type WritingStudioPlugin from '../main';
 import { t } from './i18n';
+import { localDateString } from './dates';
 
 export const WRITING_LOG_VIEW_TYPE = 'writing-studio-writing-log';
 
@@ -88,7 +89,7 @@ export class WritingLogView extends ItemView {
 
     const history = await this.plugin.statsTracker.getWritingHistory(30);
     const maxWords = Math.max(...history.map(d => d.wordsWritten), 1);
-    const todayStr = new Date().toISOString().split('T')[0];
+    const todayStr = localDateString();
 
     const list = histSection.createDiv('ws-log-day-list');
     for (const entry of [...history].reverse()) {

--- a/src/dates.ts
+++ b/src/dates.ts
@@ -1,0 +1,14 @@
+import { moment as obsidianMoment } from 'obsidian';
+
+// Obsidian's d.ts declares moment via `import * as Moment`, which drops the
+// call signature under our tsconfig. Retype just the surface we use.
+type MomentFn = (input?: Date | string) => { format(fmt: string): string };
+const momentUntyped: unknown = obsidianMoment;
+export const moment = momentUntyped as MomentFn;
+
+// Local calendar date for "today" logic. Never use toISOString().split('T')[0]
+// for this: it returns the UTC date, which shifts evening writing onto
+// tomorrow for every user west of UTC (streaks, Today card, daily notes).
+export function localDateString(date?: Date | string): string {
+  return moment(date).format('YYYY-MM-DD');
+}

--- a/templates/ArticleSeriesTemplate.ts
+++ b/templates/ArticleSeriesTemplate.ts
@@ -1,10 +1,11 @@
 import { App, normalizePath } from 'obsidian';
+import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
 import { BinderData, BinderItem } from '../models/BinderItem';
 
 export class ArticleSeriesTemplate {
   static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = new Date().toISOString().split('T')[0];
+    const now = localDateString();
     const chaptersPath = normalizePath(`${project.folderPath}/Chapters`);
 
     const seriesMetaFile = normalizePath(`${chaptersPath}/Series Overview.md`);

--- a/templates/BlogCollectionTemplate.ts
+++ b/templates/BlogCollectionTemplate.ts
@@ -1,10 +1,11 @@
 import { App, normalizePath } from 'obsidian';
+import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
 import { BinderData, BinderItem } from '../models/BinderItem';
 
 export class BlogCollectionTemplate {
   static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = new Date().toISOString().split('T')[0];
+    const now = localDateString();
     const chaptersPath = normalizePath(`${project.folderPath}/Chapters`);
     const year = new Date().getFullYear();
 

--- a/templates/BookTemplate.ts
+++ b/templates/BookTemplate.ts
@@ -1,10 +1,11 @@
 import { App, normalizePath } from 'obsidian';
+import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
 import { BinderData, BinderItem } from '../models/BinderItem';
 
 export class BookTemplate {
   static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = new Date().toISOString().split('T')[0];
+    const now = localDateString();
     const chaptersPath = normalizePath(`${project.folderPath}/Chapters`);
 
     const frontMatterFile = normalizePath(`${chaptersPath}/Front Matter.md`);

--- a/templates/JournalArticleTemplate.ts
+++ b/templates/JournalArticleTemplate.ts
@@ -1,10 +1,11 @@
 import { App, normalizePath } from 'obsidian';
+import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
 import { BinderData, BinderItem } from '../models/BinderItem';
 
 export class JournalArticleTemplate {
   static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = new Date().toISOString().split('T')[0];
+    const now = localDateString();
     const p = (name: string) => normalizePath(`${project.folderPath}/Chapters/${name}.md`);
 
     const docs: Array<[string, string]> = [

--- a/templates/MagazineArticleTemplate.ts
+++ b/templates/MagazineArticleTemplate.ts
@@ -1,10 +1,11 @@
 import { App, normalizePath } from 'obsidian';
+import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
 import { BinderData, BinderItem } from '../models/BinderItem';
 
 export class MagazineArticleTemplate {
   static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = new Date().toISOString().split('T')[0];
+    const now = localDateString();
     const p = (name: string) => normalizePath(`${project.folderPath}/Chapters/${name}.md`);
 
     const docs: Array<[string, string]> = [

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -17,6 +17,13 @@ export class TFolder {
   }
 }
 
+export function moment(input?: Date | string): { format(fmt?: string): string } {
+  const d = input !== undefined ? new Date(input) : new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  // Local date regardless of requested format — sufficient for tests
+  return { format: () => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` };
+}
+
 export class MarkdownView {}
 
 export class WorkspaceLeaf {}

--- a/tests/statsTracker.test.ts
+++ b/tests/statsTracker.test.ts
@@ -79,3 +79,77 @@ describe('StatsTracker word-count session tracking', () => {
     expect(tracker.getTotalSessionWords()).toBe(0);
   });
 });
+
+describe('StatsTracker local-date handling', () => {
+  function localToday(): string {
+    const d = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  }
+
+  function makeSession(words: number) {
+    return {
+      id: 's1',
+      // Local noon as a UTC instant: the ISO string's UTC date may differ
+      // from the local date, but grouping must land on the local day
+      date: new Date(new Date().setHours(12, 0, 0, 0)).toISOString(),
+      duration: 25,
+      wordsWritten: words,
+      startWordCount: 0,
+      documents: ['a.md'],
+      completed: true,
+    };
+  }
+
+  it('session stats use the local date', () => {
+    const tracker = new StatsTracker(mockPlugin);
+    expect(tracker.getSessionStats().date).toBe(localToday());
+  });
+
+  it('recordSprint rolls the session day over after local midnight', () => {
+    const tracker = new StatsTracker(mockPlugin);
+    (tracker as unknown as { sessionStats: { date: string; wordsWritten: number } })
+      .sessionStats = { date: '2000-01-01', wordsWritten: 999, sprintsCompleted: 9, totalMinutes: 90, documents: [] } as never;
+
+    tracker.recordSprint(makeSession(50) as never);
+
+    const stats = tracker.getSessionStats();
+    expect(stats.date).toBe(localToday());
+    expect(stats.wordsWritten).toBe(50); // old day's 999 not carried over
+    expect(stats.sprintsCompleted).toBe(1);
+  });
+
+  it('getWritingHistory groups a session under its local calendar day', async () => {
+    const session = makeSession(120);
+    const plugin = {
+      app: {},
+      settings: { appendToDailyNote: false, sprintHistoryRetention: 30 },
+      projectManager: {
+        getActiveProject: () => ({ id: 'p1', title: 'P', folderPath: 'Projects/P' }),
+        getWritingLog: () => Promise.resolve([session]),
+      },
+      fmManager: {},
+    } as never;
+    const tracker = new StatsTracker(plugin);
+
+    const history = await tracker.getWritingHistory(2);
+    const todayEntry = history.find(e => e.date === localToday());
+
+    expect(todayEntry?.wordsWritten).toBe(120);
+  });
+
+  it('getStreak counts a local-noon session as today', async () => {
+    const plugin = {
+      app: {},
+      settings: { appendToDailyNote: false, sprintHistoryRetention: 30 },
+      projectManager: {
+        getActiveProject: () => ({ id: 'p1', title: 'P', folderPath: 'Projects/P' }),
+        getWritingLog: () => Promise.resolve([makeSession(10)]),
+      },
+      fmManager: {},
+    } as never;
+    const tracker = new StatsTracker(plugin);
+
+    expect(await tracker.getStreak()).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #110 (audit unit 7/15 — the highest-value systemic fix). Released end-to-end including merge.

## Acceptance criteria (self-recorded)
Done when: no `toISOString().split('T')[0]` remains in shipped code; all "today" logic uses one local-date helper; daily-note append honors the user's daily-notes format/folder and creates the note when missing; session stats roll over at local midnight; sessions group by local calendar day in history and streaks; lint 0/0, tests pass, build clean, main.js committed.

## What changed
- **`src/dates.ts`** — `localDateString()` built on Obsidian's bundled moment. (Obsidian's d.ts declares `moment` via `import * as Moment`, which drops the call signature under our tsconfig; the helper retypes the narrow surface we use — no `any`.)
- **13 sites converted.** The audit listed StatsTracker/ProjectManager/WritingLogView/sprint dates; a repo-wide sweep found 7 more (5 template scaffolds, ExportEngine title-page date, PublishModal `wpPublished`). All now local.
- **Daily-note append rework (significant):** reads `folder` and `format` from the daily-notes core plugin options, formats with moment, appends with `vault.append` (atomic), and **creates** today's note when missing — the README-documented behavior. Previously, any non-default daily-note format silently diverted entries to the JSON log, and even default formats appended only if the note already existed.
- **Double-log fix (found during the rework):** the old missing-note fallback called `logSprintSession`, but `main.ts:236` already logs every sprint — users with daily-note append enabled and no note for the day got duplicate `_writing-log.json` entries, double-counting history and streaks. Fallback removed.
- **Midnight rollover (minor):** `recordSprint` resets session stats when the local day changes; previously frozen at plugin-load date.
- `SprintSession.date` remains a full UTC instant (it's a timestamp); `getWritingHistory`/`getStreak` convert to local day at read time, which also fixes grouping of existing history data.

## Tests
4 new tests: session stats use local date; midnight rollover resets and doesn't carry the old day's counts; history groups a local-noon session under the local day; streak counts it as today. Mock `moment` added to the obsidian test mock. 82/82 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)