### PR TITLE
Fix #112: read/render performance — cachedRead, render side effects, polling, search race

### DIFF
--- a/main.js
+++ b/main.js
@@ -10312,10 +10312,28 @@ var BinderView = class extends import_obsidian8.ItemView {
     if (this.activeProject) {
       const binder = await this.plugin.projectManager.loadBinder(this.activeProject);
       this.binderItems = binder.items;
+      await this.syncDriftedTitles();
     } else {
       this.binderItems = [];
     }
     this.render();
+  }
+  // Align binder titles with live filenames once per refresh — doing this
+  // during render() fired a concurrent saveBinder() per drifted row
+  async syncDriftedTitles() {
+    let drifted = false;
+    const walk = (items) => {
+      for (const item of items) {
+        const live = this.app.vault.getAbstractFileByPath(item.filePath);
+        if (live instanceof import_obsidian8.TFile && item.title !== live.basename) {
+          item.title = live.basename;
+          drifted = true;
+        }
+        if (item.children) walk(item.children);
+      }
+    };
+    walk(this.binderItems);
+    if (drifted) await this.saveBinder();
   }
   render() {
     var _a2;
@@ -10434,14 +10452,8 @@ var BinderView = class extends import_obsidian8.ItemView {
       dot.setCssProps({ "--ws-status-color": STATUS_COLORS[item.status] });
       dot.title = t2(STATUS_DOT_KEY[item.status]);
       const titleEl = row.createSpan("ws-binder-title");
-      const liveFile = this.app.vault.getAbstractFileByPath(item.filePath);
-      const displayTitle = liveFile instanceof import_obsidian8.TFile ? liveFile.basename : item.title;
-      titleEl.textContent = displayTitle;
+      titleEl.textContent = item.title;
       titleEl.contentEditable = "false";
-      if (liveFile instanceof import_obsidian8.TFile && item.title !== liveFile.basename) {
-        item.title = liveFile.basename;
-        void this.saveBinder();
-      }
       const wcEl = row.createSpan("ws-binder-wc");
       this.wcElements.set(item.filePath, { el: wcEl, item });
       void this.loadWordCount(item, wcEl);
@@ -10515,7 +10527,7 @@ var BinderView = class extends import_obsidian8.ItemView {
       el.textContent = "0W";
       return;
     }
-    const content = await this.app.vault.read(file);
+    const content = await this.app.vault.cachedRead(file);
     const wc = this.plugin.fmManager.countWords(content);
     const goal = item.wordCountGoal;
     if (goal) {
@@ -11249,6 +11261,8 @@ var LauncherView = class extends import_obsidian13.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
     this.refreshTimer = null;
+    this.todayVals = [];
+    this.renderedSprintActive = false;
     this.plugin = plugin;
   }
   getViewType() {
@@ -11263,8 +11277,25 @@ var LauncherView = class extends import_obsidian13.ItemView {
   async onOpen() {
     await this.render();
     this.refreshTimer = window.setInterval(() => {
-      void this.render();
+      void this.tickRefresh();
     }, 1e4);
+  }
+  async tickRefresh() {
+    const sprintActive = this.plugin.sprintTimer.isActive();
+    if (sprintActive !== this.renderedSprintActive) {
+      await this.render();
+      return;
+    }
+    await this.patchTodayCard();
+  }
+  async patchTodayCard() {
+    if (this.todayVals.length < 4) return;
+    const stats = this.plugin.statsTracker.getSessionStats();
+    const streak = await this.plugin.statsTracker.getStreak();
+    this.todayVals[0].textContent = stats.wordsWritten.toLocaleString();
+    this.todayVals[1].textContent = String(stats.sprintsCompleted);
+    this.todayVals[2].textContent = String(stats.totalMinutes);
+    this.todayVals[3].textContent = t2("launcher.stat.streakDays", { streak });
   }
   onClose() {
     if (this.refreshTimer !== null) {
@@ -11279,6 +11310,8 @@ var LauncherView = class extends import_obsidian13.ItemView {
   async render() {
     const root = this.containerEl.children[1];
     root.empty();
+    this.todayVals = [];
+    this.renderedSprintActive = this.plugin.sprintTimer.isActive();
     root.addClass("ws-launcher");
     this.renderHeader(root);
     await this.renderProjectCard(root);
@@ -11538,7 +11571,7 @@ var LauncherView = class extends import_obsidian13.ItemView {
     ];
     for (const [label, value] of items) {
       const stat = grid.createDiv("ws-launcher-today-stat");
-      stat.createDiv({ text: value, cls: "ws-launcher-today-val" });
+      this.todayVals.push(stat.createDiv({ text: value, cls: "ws-launcher-today-val" }));
       stat.createDiv({ text: label, cls: "ws-launcher-today-label" });
     }
     if (sessionWords > 0) {
@@ -14774,6 +14807,7 @@ var StatsTracker = class {
     this.sessionCurrents = /* @__PURE__ */ new Map();
     this.cachedTotalWordCount = null;
     this.cachedWordCountProjectId = null;
+    this.cachedStreak = null;
     this.plugin = plugin;
     this.app = plugin.app;
     this.sessionStats = this.newDailyStats();
@@ -14791,6 +14825,7 @@ var StatsTracker = class {
     if (this.sessionStats.date !== localDateString()) {
       this.sessionStats = this.newDailyStats();
     }
+    this.cachedStreak = null;
     this.sessionStats.wordsWritten += session.wordsWritten;
     this.sessionStats.sprintsCompleted++;
     this.sessionStats.totalMinutes += session.duration;
@@ -14873,14 +14908,13 @@ ${t2("statsTracker.dailyNote.heading")}
     }
     const binder = await this.plugin.projectManager.loadBinder(project);
     const items = this.plugin.projectManager.flattenBinder(binder.items);
-    let total = 0;
-    for (const item of items) {
+    const counts = await Promise.all(items.map(async (item) => {
       const file = this.app.vault.getAbstractFileByPath(item.filePath);
-      if (file instanceof import_obsidian26.TFile) {
-        const content = await this.app.vault.read(file);
-        total += this.plugin.fmManager.countWords(content);
-      }
-    }
+      if (!(file instanceof import_obsidian26.TFile)) return 0;
+      const content = await this.app.vault.cachedRead(file);
+      return this.plugin.fmManager.countWords(content);
+    }));
+    const total = counts.reduce((sum, n) => sum + n, 0);
     this.cachedTotalWordCount = total;
     this.cachedWordCountProjectId = project.id;
     return total;
@@ -14934,6 +14968,9 @@ ${t2("statsTracker.dailyNote.heading")}
   async getStreak() {
     const project = this.plugin.projectManager.getActiveProject();
     if (!project) return 0;
+    if (this.cachedStreak && this.cachedStreak.projectId === project.id) {
+      return this.cachedStreak.value;
+    }
     const log = await this.plugin.projectManager.getWritingLog(project);
     if (log.length === 0) return 0;
     const dates = new Set(log.map((s) => localDateString(s.date)));
@@ -14949,6 +14986,7 @@ ${t2("statsTracker.dailyNote.heading")}
         break;
       }
     }
+    this.cachedStreak = { projectId: project.id, value: streak };
     return streak;
   }
 };
@@ -15468,6 +15506,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
      * array = completed results (may be empty)
      */
     this.searchResults = null;
+    this.searchToken = 0;
   }
   getViewType() {
     return FOLDER_SIDEBAR_VIEW_TYPE;
@@ -15623,17 +15662,19 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     const textFiles = allItems.filter(
       (item) => item instanceof import_obsidian29.TFile && ["md", "txt"].includes(item.extension.toLowerCase()) && !nameMatched.has(item)
     );
-    for (const file of textFiles) {
+    const contentMatches = await Promise.all(textFiles.map(async (file) => {
       try {
-        const raw = await this.app.vault.read(file);
+        const raw = await this.app.vault.cachedRead(file);
         const body = this.stripFrontmatter(raw);
         const idx = body.toLowerCase().indexOf(q);
-        if (idx !== -1) {
-          const snippet = this.extractSnippet(body, idx, q.length);
-          results.push({ item: file, matchType: "content", snippet });
-        }
+        if (idx === -1) return null;
+        return { item: file, matchType: "content", snippet: this.extractSnippet(body, idx, q.length) };
       } catch (e) {
+        return null;
       }
+    }));
+    for (const match of contentMatches) {
+      if (match) results.push(match);
     }
     return results;
   }
@@ -15931,6 +15972,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     }
     const executeSearch = async () => {
       const query = searchInput.value.trim();
+      const token = ++this.searchToken;
       if (!query) {
         this.searchQuery = "";
         this.searchResults = null;
@@ -15940,7 +15982,9 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
       this.searchQuery = query;
       this.searchResults = null;
       this.render();
-      this.searchResults = await this.performSearch(query);
+      const results = await this.performSearch(query);
+      if (token !== this.searchToken) return;
+      this.searchResults = results;
       this.render();
     };
     searchInput.addEventListener("keydown", (e) => {
@@ -15971,7 +16015,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     const ext = file.extension.toLowerCase();
     if (ext === "md") {
       try {
-        const text = await this.app.vault.read(file);
+        const text = await this.app.vault.cachedRead(file);
         await import_obsidian29.MarkdownRenderer.render(this.app, text, content, file.path, this);
         if (this.searchQuery) this.highlightTextInElement(content, this.searchQuery);
       } catch (e) {

--- a/src/BinderView.ts
+++ b/src/BinderView.ts
@@ -54,10 +54,29 @@ export class BinderView extends ItemView {
     if (this.activeProject) {
       const binder = await this.plugin.projectManager.loadBinder(this.activeProject);
       this.binderItems = binder.items;
+      await this.syncDriftedTitles();
     } else {
       this.binderItems = [];
     }
     this.render();
+  }
+
+  // Align binder titles with live filenames once per refresh — doing this
+  // during render() fired a concurrent saveBinder() per drifted row
+  private async syncDriftedTitles(): Promise<void> {
+    let drifted = false;
+    const walk = (items: BinderItem[]) => {
+      for (const item of items) {
+        const live = this.app.vault.getAbstractFileByPath(item.filePath);
+        if (live instanceof TFile && item.title !== live.basename) {
+          item.title = live.basename;
+          drifted = true;
+        }
+        if (item.children) walk(item.children);
+      }
+    };
+    walk(this.binderItems);
+    if (drifted) await this.saveBinder();
   }
 
   private render(): void {
@@ -200,16 +219,10 @@ export class BinderView extends ItemView {
       dot.setCssProps({ '--ws-status-color': STATUS_COLORS[item.status] });
       dot.title = t(STATUS_DOT_KEY[item.status]);
 
-      // Title — derive from the live filename so stale binder JSON is never shown
+      // Title — refresh() has already synced drifted titles with live filenames
       const titleEl = row.createSpan('ws-binder-title');
-      const liveFile = this.app.vault.getAbstractFileByPath(item.filePath);
-      const displayTitle = liveFile instanceof TFile ? liveFile.basename : item.title;
-      titleEl.textContent = displayTitle;
+      titleEl.textContent = item.title;
       titleEl.contentEditable = 'false';
-      if (liveFile instanceof TFile && item.title !== liveFile.basename) {
-        item.title = liveFile.basename;
-        void this.saveBinder();
-      }
 
       // Word count
       const wcEl = row.createSpan('ws-binder-wc');
@@ -297,7 +310,7 @@ export class BinderView extends ItemView {
       el.textContent = '0W';
       return;
     }
-    const content = await this.app.vault.read(file);
+    const content = await this.app.vault.cachedRead(file);
     const wc = this.plugin.fmManager.countWords(content);
     const goal = item.wordCountGoal;
 

--- a/src/FolderSidebarView.ts
+++ b/src/FolderSidebarView.ts
@@ -38,6 +38,7 @@ export class FolderSidebarView extends ItemView {
    * array = completed results (may be empty)
    */
   private searchResults: SearchResult[] | null = null;
+  private searchToken = 0;
 
   constructor(leaf: WorkspaceLeaf) {
     super(leaf);
@@ -223,18 +224,21 @@ export class FolderSidebarView extends ItemView {
         !nameMatched.has(item)
     );
 
-    for (const file of textFiles) {
+    // Batched cachedRead instead of a serial vault.read per file — a vault-root
+    // scope previously meant one sequential disk read per file per search
+    const contentMatches = await Promise.all(textFiles.map(async (file) => {
       try {
-        const raw = await this.app.vault.read(file);
+        const raw = await this.app.vault.cachedRead(file);
         const body = this.stripFrontmatter(raw);
         const idx = body.toLowerCase().indexOf(q);
-        if (idx !== -1) {
-          const snippet = this.extractSnippet(body, idx, q.length);
-          results.push({ item: file, matchType: 'content', snippet });
-        }
+        if (idx === -1) return null;
+        return { item: file, matchType: 'content' as const, snippet: this.extractSnippet(body, idx, q.length) };
       } catch {
-        // skip unreadable files
+        return null; // skip unreadable files
       }
+    }));
+    for (const match of contentMatches) {
+      if (match) results.push(match);
     }
 
     return results;
@@ -597,6 +601,7 @@ export class FolderSidebarView extends ItemView {
 
     const executeSearch = async () => {
       const query = searchInput.value.trim();
+      const token = ++this.searchToken;
       if (!query) {
         this.searchQuery = '';
         this.searchResults = null;
@@ -606,7 +611,10 @@ export class FolderSidebarView extends ItemView {
       this.searchQuery = query;
       this.searchResults = null;   // null = in progress → shows "Searching…"
       this.render();
-      this.searchResults = await this.performSearch(query);
+      const results = await this.performSearch(query);
+      // A newer search started while this one was reading — drop stale results
+      if (token !== this.searchToken) return;
+      this.searchResults = results;
       this.render();               // show completed results
     };
 
@@ -645,7 +653,7 @@ export class FolderSidebarView extends ItemView {
 
     if (ext === 'md') {
       try {
-        const text = await this.app.vault.read(file);
+        const text = await this.app.vault.cachedRead(file);
         await MarkdownRenderer.render(this.app, text, content, file.path, this);
         if (this.searchQuery) this.highlightTextInElement(content, this.searchQuery);
       } catch {

--- a/src/LauncherView.ts
+++ b/src/LauncherView.ts
@@ -14,6 +14,8 @@ export const LAUNCHER_VIEW_TYPE = 'writing-studio-launcher';
 export class LauncherView extends ItemView {
   private plugin: WritingStudioPlugin;
   private refreshTimer: number | null = null;
+  private todayVals: HTMLElement[] = [];
+  private renderedSprintActive = false;
 
   constructor(leaf: WorkspaceLeaf, plugin: WritingStudioPlugin) {
     super(leaf);
@@ -34,8 +36,30 @@ export class LauncherView extends ItemView {
 
   async onOpen(): Promise<void> {
     await this.render();
-    // Refresh every 10 seconds to update word counts / sprint timer
-    this.refreshTimer = window.setInterval(() => { void this.render(); }, 10000);
+    // Patch dynamic values in place every 10 seconds — a full re-render here
+    // rebuilt the whole panel, snapping open dropdowns shut mid-selection and
+    // re-reading the writing log from disk on every tick
+    this.refreshTimer = window.setInterval(() => { void this.tickRefresh(); }, 10000);
+  }
+
+  private async tickRefresh(): Promise<void> {
+    // Sprint card layout depends on sprint state — full render only when it flips
+    const sprintActive = this.plugin.sprintTimer.isActive();
+    if (sprintActive !== this.renderedSprintActive) {
+      await this.render();
+      return;
+    }
+    await this.patchTodayCard();
+  }
+
+  private async patchTodayCard(): Promise<void> {
+    if (this.todayVals.length < 4) return;
+    const stats = this.plugin.statsTracker.getSessionStats();
+    const streak = await this.plugin.statsTracker.getStreak();
+    this.todayVals[0].textContent = stats.wordsWritten.toLocaleString();
+    this.todayVals[1].textContent = String(stats.sprintsCompleted);
+    this.todayVals[2].textContent = String(stats.totalMinutes);
+    this.todayVals[3].textContent = t('launcher.stat.streakDays', { streak });
   }
 
   onClose(): Promise<void> {
@@ -53,6 +77,8 @@ export class LauncherView extends ItemView {
   private async render(): Promise<void> {
     const root = this.containerEl.children[1] as HTMLElement;
     root.empty();
+    this.todayVals = [];
+    this.renderedSprintActive = this.plugin.sprintTimer.isActive();
     root.addClass('ws-launcher');
 
     this.renderHeader(root);
@@ -341,7 +367,7 @@ export class LauncherView extends ItemView {
 
     for (const [label, value] of items) {
       const stat = grid.createDiv('ws-launcher-today-stat');
-      stat.createDiv({ text: value, cls: 'ws-launcher-today-val' });
+      this.todayVals.push(stat.createDiv({ text: value, cls: 'ws-launcher-today-val' }));
       stat.createDiv({ text: label, cls: 'ws-launcher-today-label' });
     }
 

--- a/src/StatsTracker.ts
+++ b/src/StatsTracker.ts
@@ -27,6 +27,7 @@ export class StatsTracker {
   private sessionCurrents  = new Map<string, number>();
   private cachedTotalWordCount: number | null = null;
   private cachedWordCountProjectId: string | null = null;
+  private cachedStreak: { projectId: string; value: number } | null = null;
 
   constructor(plugin: WritingStudioPlugin) {
     this.plugin = plugin;
@@ -50,6 +51,7 @@ export class StatsTracker {
     if (this.sessionStats.date !== localDateString()) {
       this.sessionStats = this.newDailyStats();
     }
+    this.cachedStreak = null; // a new sprint can extend the streak
     this.sessionStats.wordsWritten += session.wordsWritten;
     this.sessionStats.sprintsCompleted++;
     this.sessionStats.totalMinutes += session.duration;
@@ -152,15 +154,15 @@ ${t('statsTracker.dailyNote.heading')}
 
     const binder = await this.plugin.projectManager.loadBinder(project);
     const items = this.plugin.projectManager.flattenBinder(binder.items);
-    let total = 0;
 
-    for (const item of items) {
+    // cachedRead + parallel — these are display-only reads
+    const counts = await Promise.all(items.map(async (item) => {
       const file = this.app.vault.getAbstractFileByPath(item.filePath);
-      if (file instanceof TFile) {
-        const content = await this.app.vault.read(file);
-        total += this.plugin.fmManager.countWords(content);
-      }
-    }
+      if (!(file instanceof TFile)) return 0;
+      const content = await this.app.vault.cachedRead(file);
+      return this.plugin.fmManager.countWords(content);
+    }));
+    const total = counts.reduce((sum, n) => sum + n, 0);
 
     this.cachedTotalWordCount = total;
     this.cachedWordCountProjectId = project.id;
@@ -223,6 +225,12 @@ ${t('statsTracker.dailyNote.heading')}
     const project = this.plugin.projectManager.getActiveProject();
     if (!project) return 0;
 
+    // The streak only changes when a sprint is recorded (which invalidates
+    // this cache) — don't re-read the writing log from disk on every poll
+    if (this.cachedStreak && this.cachedStreak.projectId === project.id) {
+      return this.cachedStreak.value;
+    }
+
     const log = await this.plugin.projectManager.getWritingLog(project);
     if (log.length === 0) return 0;
 
@@ -241,6 +249,7 @@ ${t('statsTracker.dailyNote.heading')}
       }
     }
 
+    this.cachedStreak = { projectId: project.id, value: streak };
     return streak;
   }
 }


### PR DESCRIPTION
Closes #112 (audit unit 9/15 — cross-cutting pattern 6). Released end-to-end including merge.

## Acceptance criteria (self-recorded)
Done when: no display-only `vault.read` remains in the binder, folder sidebar, launcher, or stats totals; render() has no write side effects; rapid searches cannot interleave stale results; the launcher interval no longer rebuilds the DOM or hits disk every 10 s; lint 0/0, tests pass, build clean, main.js committed.

## What changed
- **BinderView** — title-drift sync moved from `render()` (which fired one concurrent `saveBinder()` per drifted row) into `refresh()`: walk once, apply all, save once. `loadWordCount` uses `cachedRead`.
- **FolderSidebarView** — content-search phase batches `cachedRead` with `Promise.all` (order preserved) instead of a serial `vault.read` per file; an incrementing `searchToken` guards `executeSearch` so a slower older search can't overwrite newer results; the markdown preview also uses `cachedRead`.
- **LauncherView** — the 10 s interval calls `tickRefresh()`: patches the four Today-card values in place via stored element refs; a full re-render happens only when the sprint active/inactive state flips (layout change). Open dropdowns survive ticks; no disk reads on the hot path.
- **StatsTracker** — `getStreak()` cached per project and invalidated in `recordSprint` (the only event that changes it); `getTotalWordCount()` reads via `cachedRead` + `Promise.all`.

No behavioral changes intended — same numbers, fewer reads, no mid-interaction DOM rebuilds. 82/82 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)