### PR TITLE
Fix #113: setCssProps sweep — rule 5 compliance in four files

### DIFF
--- a/main.js
+++ b/main.js
@@ -11653,7 +11653,7 @@ var FocusMode = class {
   }
   applyDimOpacity() {
     const opacity = (this.plugin.settings.dimOpacity || 20) / 100;
-    activeDocument.documentElement.style.setProperty("--ws-focus-dim-opacity", String(opacity));
+    activeDocument.documentElement.setCssProps({ "--ws-focus-dim-opacity": String(opacity) });
   }
   hideSidebars() {
     const left = this.app.workspace.leftSplit;
@@ -11851,14 +11851,15 @@ var TypographyMode = class {
     const lineHeight = settings.lineHeight || 1.7;
     const letterSpacing = settings.letterSpacing || "normal";
     const halfWidthCh = `${maxChars / 2}ch`;
-    const root = activeDocument.documentElement;
-    root.style.setProperty("--ws-typo-font", fontStack);
-    root.style.setProperty("--ws-typo-size", `${fontSize}px`);
-    root.style.setProperty("--ws-typo-lh", String(lineHeight));
-    root.style.setProperty("--ws-typo-ls", letterSpacing);
-    root.style.setProperty("--ws-typo-pad-left", `max(1.5rem, calc(50% - ${halfWidthCh}))`);
-    root.style.setProperty("--ws-typo-pad-right", `max(1.5rem, calc(50% - ${halfWidthCh}))`);
-    root.style.setProperty("--ws-typo-max-width", `${maxChars}ch`);
+    activeDocument.documentElement.setCssProps({
+      "--ws-typo-font": fontStack,
+      "--ws-typo-size": `${fontSize}px`,
+      "--ws-typo-lh": String(lineHeight),
+      "--ws-typo-ls": letterSpacing,
+      "--ws-typo-pad-left": `max(1.5rem, calc(50% - ${halfWidthCh}))`,
+      "--ws-typo-pad-right": `max(1.5rem, calc(50% - ${halfWidthCh}))`,
+      "--ws-typo-max-width": `${maxChars}ch`
+    });
   }
   removeCustomProperties() {
     const root = activeDocument.documentElement;
@@ -15257,7 +15258,7 @@ var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab 
     new import_obsidian28.Setting(el).setName(t2("settings.focus.dimOpacity")).setDesc(t2("settings.focus.dimOpacityDesc")).addSlider((s) => s.setLimits(10, 50, 5).setValue(this.plugin.settings.dimOpacity).setDynamicTooltip().onChange(async (v) => {
       this.plugin.settings.dimOpacity = v;
       await this.plugin.saveSettings();
-      activeDocument.documentElement.style.setProperty("--ws-focus-dim-opacity", String(v / 100));
+      this.plugin.focusMode.applyDimOpacity();
     }));
     new import_obsidian28.Setting(el).setName(t2("settings.focus.fontSizeOverride")).setDesc(t2("settings.focus.fontSizeOverrideDesc")).addText((text) => text.setValue(String(this.plugin.settings.focusFontSize || 0)).onChange(async (v) => {
       this.plugin.settings.focusFontSize = parseInt(v) || 0;
@@ -15706,8 +15707,10 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     if (top + tipH > vh) top = rect.top - tipH - 6;
     if (left + tipW > vw) left = vw - tipW - 8;
     if (left < 8) left = 8;
-    tip.style.top = `${Math.round(top)}px`;
-    tip.style.left = `${Math.round(left)}px`;
+    tip.setCssProps({
+      "--ws-tip-top": `${Math.round(top)}px`,
+      "--ws-tip-left": `${Math.round(left)}px`
+    });
     tip.createDiv({ cls: "ws-tooltip-name", text: item.name });
     tip.createDiv({ cls: "ws-tooltip-divider" });
     if (item instanceof import_obsidian29.TFile) {

--- a/src/FocusMode.ts
+++ b/src/FocusMode.ts
@@ -72,9 +72,9 @@ export class FocusMode {
     }
   }
 
-  private applyDimOpacity(): void {
+  applyDimOpacity(): void {
     const opacity = (this.plugin.settings.dimOpacity || 20) / 100;
-    activeDocument.documentElement.style.setProperty('--ws-focus-dim-opacity', String(opacity));
+    activeDocument.documentElement.setCssProps({ '--ws-focus-dim-opacity': String(opacity) });
   }
 
   private hideSidebars(): void {

--- a/src/FolderSidebarView.ts
+++ b/src/FolderSidebarView.ts
@@ -279,8 +279,10 @@ export class FolderSidebarView extends ItemView {
     if (left + tipW > vw) left = vw - tipW - 8;       // clamp to right edge
     if (left < 8) left = 8;                            // clamp to left edge
 
-    tip.style.top  = `${Math.round(top)}px`;
-    tip.style.left = `${Math.round(left)}px`;
+    tip.setCssProps({
+      '--ws-tip-top': `${Math.round(top)}px`,
+      '--ws-tip-left': `${Math.round(left)}px`,
+    });
 
     // Name
     tip.createDiv({ cls: 'ws-tooltip-name', text: item.name });

--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -136,7 +136,7 @@ export class WritingStudioSettingsTab extends PluginSettingTab {
         .onChange(async v => {
           this.plugin.settings.dimOpacity = v;
           await this.plugin.saveSettings();
-          activeDocument.documentElement.style.setProperty('--ws-focus-dim-opacity', String(v / 100));
+          this.plugin.focusMode.applyDimOpacity();
         }));
 
     new Setting(el)

--- a/src/TypographyMode.ts
+++ b/src/TypographyMode.ts
@@ -71,14 +71,15 @@ export class TypographyMode {
     const letterSpacing = settings.letterSpacing || 'normal';
     const halfWidthCh = `${maxChars / 2}ch`;
 
-    const root = activeDocument.documentElement;
-    root.style.setProperty('--ws-typo-font', fontStack);
-    root.style.setProperty('--ws-typo-size', `${fontSize}px`);
-    root.style.setProperty('--ws-typo-lh', String(lineHeight));
-    root.style.setProperty('--ws-typo-ls', letterSpacing);
-    root.style.setProperty('--ws-typo-pad-left', `max(1.5rem, calc(50% - ${halfWidthCh}))`);
-    root.style.setProperty('--ws-typo-pad-right', `max(1.5rem, calc(50% - ${halfWidthCh}))`);
-    root.style.setProperty('--ws-typo-max-width', `${maxChars}ch`);
+    activeDocument.documentElement.setCssProps({
+      '--ws-typo-font': fontStack,
+      '--ws-typo-size': `${fontSize}px`,
+      '--ws-typo-lh': String(lineHeight),
+      '--ws-typo-ls': letterSpacing,
+      '--ws-typo-pad-left': `max(1.5rem, calc(50% - ${halfWidthCh}))`,
+      '--ws-typo-pad-right': `max(1.5rem, calc(50% - ${halfWidthCh}))`,
+      '--ws-typo-max-width': `${maxChars}ch`,
+    });
   }
 
   private removeCustomProperties(): void {

--- a/styles.css
+++ b/styles.css
@@ -1567,6 +1567,8 @@ body .ws-launcher select {
 /* ── Hover info tooltip ──────────────────────────────────────────── */
 .ws-info-tooltip {
   position: fixed;
+  top: var(--ws-tip-top, 0);
+  left: var(--ws-tip-left, 0);
   z-index: 9999;
   max-width: 280px;
   background: var(--background-primary);

--- a/tests/modes.test.ts
+++ b/tests/modes.test.ts
@@ -5,7 +5,10 @@ import { Notice } from 'obsidian';
 // TypographyMode touches the Obsidian `activeDocument` global; fake it for node
 const fakeActiveDocument = {
   body: { classList: { add: jest.fn(), remove: jest.fn() } },
-  documentElement: { style: { setProperty: jest.fn(), removeProperty: jest.fn() } },
+  documentElement: {
+    style: { setProperty: jest.fn(), removeProperty: jest.fn() },
+    setCssProps: jest.fn(),
+  },
 };
 (globalThis as { activeDocument?: unknown }).activeDocument = fakeActiveDocument;
 


### PR DESCRIPTION
Closes #113 (audit unit 10/15 — cross-cutting pattern 7). Released end-to-end including merge.

## What changed
- **FolderSidebarView tooltip**: `tip.style.top/left` → `setCssProps({ '--ws-tip-top', '--ws-tip-left' })` with `top/left: var(...)` rules added to `.ws-info-tooltip` in styles.css.
- **TypographyMode**: seven raw `style.setProperty` calls → one `setCssProps` object call. (`removeProperty` teardown calls left as-is — rule 5 targets style *assignment*.)
- **SettingsTab dim-opacity slider**: direct `setProperty` (which duplicated `FocusMode.applyDimOpacity`) → calls the focus mode's method; `applyDimOpacity` made public and converted to `setCssProps`.
- Test fake for `activeDocument` grew a `setCssProps` stub.

No behavior change. 82/82 tests passing; lint 0/0; build clean; main.js committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)