### PR TITLE
chore: Obsidian 1.13 follow-ups — collision guard test, typings pin, deprecated API removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Writing Studio are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+- Removed the deprecated `setDynamicTooltip()` call on the focus dim opacity and line length sliders — Obsidian 1.13 always shows the slider value inline. (On Obsidian versions before 1.13 the value tooltip while dragging is no longer shown.)
+
+### Internal
+- Added a regression test that fails if the settings tab ever defines a member shadowing Obsidian's undocumented `SettingTab` internals — the failure mode behind the 2.6.1 blank-settings bug (#135).
+- Pinned the `obsidian` typings dev-dependency to `^1.13.1` (was `latest`).
+
 ## [2.6.1]
 
 ### Fixed

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   moduleNameMapper: {
     '^obsidian$': '<rootDir>/tests/__mocks__/obsidian.ts',
     '^.*/i18n$': '<rootDir>/tests/__mocks__/i18n.ts',
+    '\\.md$': '<rootDir>/tests/__mocks__/markdown-file.ts',
   },
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],

--- a/main.js
+++ b/main.js
@@ -15820,7 +15820,7 @@ var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab 
       this.plugin.settings.focusUnit = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.focus.dimOpacity")).setDesc(t2("settings.focus.dimOpacityDesc")).addSlider((s) => s.setLimits(10, 50, 5).setValue(this.plugin.settings.dimOpacity).setDynamicTooltip().onChange(async (v) => {
+    new import_obsidian29.Setting(el).setName(t2("settings.focus.dimOpacity")).setDesc(t2("settings.focus.dimOpacityDesc")).addSlider((s) => s.setLimits(10, 50, 5).setValue(this.plugin.settings.dimOpacity).onChange(async (v) => {
       this.plugin.settings.dimOpacity = v;
       await this.plugin.saveSettings();
       this.plugin.focusMode.applyDimOpacity();
@@ -15869,7 +15869,7 @@ var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab 
       this.plugin.settings.customFontName = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.typography.maxLineLength")).setDesc(t2("settings.typography.maxLineLengthDesc")).addSlider((s) => s.setLimits(55, 80, 1).setValue(this.plugin.settings.maxLineLength).setDynamicTooltip().onChange(async (v) => {
+    new import_obsidian29.Setting(el).setName(t2("settings.typography.maxLineLength")).setDesc(t2("settings.typography.maxLineLengthDesc")).addSlider((s) => s.setLimits(55, 80, 1).setValue(this.plugin.settings.maxLineLength).onChange(async (v) => {
       this.plugin.settings.maxLineLength = v;
       await this.plugin.saveSettings();
     }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "esbuild": "0.28.0",
         "eslint-plugin-obsidianmd": "^0.3.0",
         "jest": "^30.4.2",
-        "obsidian": "latest",
+        "obsidian": "^1.13.1",
         "ts-jest": "^29.4.11",
         "tslib": "2.8.1",
         "typescript": "6.0.3"
@@ -7666,9 +7666,9 @@
       }
     },
     "node_modules/obsidian": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.0.tgz",
-      "integrity": "sha512-PHw5+SAPlJ0S3leFvJ0wgFg63Z3DavxL6+d1ll+8toXR2ZlYKc1rMWqdUv9LgUbTwPQUyY6yfhOMMivampRRiQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+      "integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "esbuild": "0.28.0",
     "eslint-plugin-obsidianmd": "^0.3.0",
     "jest": "^30.4.2",
-    "obsidian": "latest",
+    "obsidian": "^1.13.1",
     "ts-jest": "^29.4.11",
     "tslib": "2.8.1",
     "typescript": "6.0.3"

--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -152,7 +152,6 @@ export class WritingStudioSettingsTab extends PluginSettingTab {
       .addSlider(s => s
         .setLimits(10, 50, 5)
         .setValue(this.plugin.settings.dimOpacity)
-        .setDynamicTooltip()
         .onChange(async v => {
           this.plugin.settings.dimOpacity = v;
           await this.plugin.saveSettings();
@@ -231,7 +230,6 @@ export class WritingStudioSettingsTab extends PluginSettingTab {
       .addSlider(s => s
         .setLimits(55, 80, 1)
         .setValue(this.plugin.settings.maxLineLength)
-        .setDynamicTooltip()
         .onChange(async v => { this.plugin.settings.maxLineLength = v; await this.plugin.saveSettings(); }));
 
     new Setting(el)

--- a/tests/__mocks__/markdown-file.ts
+++ b/tests/__mocks__/markdown-file.ts
@@ -1,0 +1,2 @@
+// Stand-in for raw .md imports (esbuild loads them as text strings)
+export default '## Features\n\nMock readme content for tests.\n';

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -38,3 +38,27 @@ export class Notice {
 export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+/g, '/');
 }
+
+export class Component {
+  load(): void {}
+  unload(): void {}
+}
+
+export class PluginSettingTab {
+  app: unknown;
+  plugin: unknown;
+  constructor(app: unknown, plugin: unknown) {
+    this.app = app;
+    this.plugin = plugin;
+  }
+  display(): void {}
+  hide(): void {}
+}
+
+export class Setting {
+  constructor(_el?: unknown) {}
+}
+
+export class MarkdownRenderer {
+  static async render(): Promise<void> {}
+}

--- a/tests/settingsTab.test.ts
+++ b/tests/settingsTab.test.ts
@@ -1,0 +1,40 @@
+import { WritingStudioSettingsTab } from '../src/SettingsTab';
+
+// Runtime members of Obsidian's SettingTab base class that are NOT declared
+// in the public obsidian.d.ts (harvested from Obsidian 1.13.1 app.js). Because
+// they are invisible to TypeScript, a same-named member here compiles cleanly
+// but silently shadows the app's own machinery at runtime. That is exactly how
+// #135 happened: Obsidian 1.13 made tab.renderTab() the entry point for
+// opening a settings tab, and our private helper of the same name swallowed
+// the call — the settings pane opened blank with no error.
+//
+// display() and hide() are deliberately not listed: they are the documented
+// extension points, and overriding them is correct.
+//
+// When a new Obsidian version lands, re-harvest with:
+//   npx @electron/asar extract-file %APPDATA%\obsidian\obsidian-X.Y.Z.asar app.js
+// then search app.js for `prototype.<name>=function` on the SettingTab base.
+const RESERVED_SETTING_TAB_MEMBERS = [
+  'renderTab',
+  'settingItems',
+  'renderedItems',
+  'refreshDomState',
+  'getElementForDefinition',
+  'getDefinitionForElement',
+];
+
+type CtorArgs = ConstructorParameters<typeof WritingStudioSettingsTab>;
+
+describe('WritingStudioSettingsTab must not shadow SettingTab internals', () => {
+  test('no prototype member collides with a reserved base-class member', () => {
+    const ownMembers = Object.getOwnPropertyNames(WritingStudioSettingsTab.prototype);
+    const collisions = ownMembers.filter(n => RESERVED_SETTING_TAB_MEMBERS.includes(n));
+    expect(collisions).toEqual([]);
+  });
+
+  test('no instance field collides with a reserved base-class member', () => {
+    const tab = new WritingStudioSettingsTab({} as CtorArgs[0], {} as CtorArgs[1]);
+    const collisions = Object.keys(tab).filter(n => RESERVED_SETTING_TAB_MEMBERS.includes(n));
+    expect(collisions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-ups from the #135 blank-settings investigation. No release — changes ride under `[Unreleased]` in the changelog until the next version ships.

## Changes

- **Regression guard:** new test (`tests/settingsTab.test.ts`) fails if `WritingStudioSettingsTab` ever defines a member shadowing Obsidian''s undocumented `SettingTab` runtime internals (`renderTab`, `settingItems`, `renderedItems`, `refreshDomState`, `getElementForDefinition`, `getDefinitionForElement`) — the exact failure mode behind #135. Includes re-harvest instructions for future Obsidian versions.
- **Typings:** `obsidian` dev-dependency bumped 1.13.0 → 1.13.1 and pinned as `^1.13.1` (was floating `latest`).
- **Deprecation fix:** removed `setDynamicTooltip()` on the two settings sliders — deprecated in 1.13, which always shows the value inline.
- **Test infra:** jest mapping for raw `.md` imports; obsidian mock extended with `PluginSettingTab`, `Component`, `Setting`, `MarkdownRenderer`.

## Verification

- Lint: 0 errors, 0 warnings (the typings bump surfaced the two deprecations; fixed properly, no suppressions)
- Tests: 107/107 passing (12 suites, +2 new)
- Build: clean; `main.js` committed with source

🤖 Generated with [Claude Code](https://claude.com/claude-code)