### PR TITLE
refactor: ProjectManager announces project-state changes; views subscribe (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Writing Studio are documented here.
 ## [Unreleased]
 
 ### Changed
+- Project state changes (active project switched, binder saved, project created or edited) are now announced by the project manager itself, and the binder and launcher panels subscribe to them — replacing the scattered manual view-refresh calls. Panels update consistently no matter where a change originates. (#138)
 - Removed the deprecated `setDynamicTooltip()` call on the focus dim opacity and line length sliders — Obsidian 1.13 always shows the slider value inline. (On Obsidian versions before 1.13 the value tooltip while dragging is no longer shown.)
 
 ### Internal

--- a/main.js
+++ b/main.js
@@ -9985,6 +9985,8 @@ function t2(key, vars) {
 
 // modals/ProjectModal.ts
 var ProjectModal = class extends import_obsidian2.Modal {
+  // Most callers need no callback — ProjectManager announces the new project
+  // itself. Pass onDone only for work beyond refreshing project state.
   constructor(app, plugin, onDone) {
     super(app);
     this.title = "";
@@ -10014,6 +10016,7 @@ var ProjectModal = class extends import_obsidian2.Modal {
     const btnRow = contentEl.createDiv("ws-modal-btn-row");
     const createBtn = btnRow.createEl("button", { cls: "mod-cta", text: t2("projectModal.createBtn") });
     createBtn.onclick = async () => {
+      var _a2;
       if (!this.title.trim()) {
         new import_obsidian2.Notice(t2("projectModal.errorNoTitle"));
         return;
@@ -10030,7 +10033,7 @@ var ProjectModal = class extends import_obsidian2.Modal {
         await this.plugin.projectManager.setActiveProject(project.id);
         new import_obsidian2.Notice(t2("projectModal.created", { title: project.title }));
         this.close();
-        this.onDone();
+        (_a2 = this.onDone) == null ? void 0 : _a2.call(this);
       } catch (e) {
         new import_obsidian2.Notice(t2("projectModal.errorCreate", { error: e instanceof Error ? e.message : String(e) }));
         createBtn.disabled = false;
@@ -10625,6 +10628,16 @@ var BinderView = class extends import_obsidian9.ItemView {
     return "book-open";
   }
   async onOpen() {
+    this.registerEvent(this.plugin.projectManager.onActiveProjectChanged(() => {
+      void this.refresh();
+    }));
+    this.registerEvent(this.plugin.projectManager.onBinderChanged((binder) => {
+      var _a2;
+      if (binder.projectId === ((_a2 = this.activeProject) == null ? void 0 : _a2.id)) void this.refresh();
+    }));
+    this.registerEvent(this.plugin.projectManager.onProjectsChanged(() => {
+      void this.refresh();
+    }));
     await this.refresh();
   }
   async refresh() {
@@ -10674,14 +10687,11 @@ var BinderView = class extends import_obsidian9.ItemView {
     }
     projectSel.onchange = async () => {
       await this.plugin.projectManager.setActiveProject(projectSel.value || null);
-      await this.refresh();
     };
     const newProjectBtn = projectRow.createEl("button", { cls: "ws-binder-btn", title: t2("binder.newProject") });
     (0, import_obsidian9.setIcon)(newProjectBtn, "plus");
     newProjectBtn.onclick = () => {
-      new ProjectModal(this.app, this.plugin, () => {
-        void this.refresh();
-      }).open();
+      new ProjectModal(this.app, this.plugin).open();
     };
     const toolbar = header.createDiv("ws-binder-toolbar");
     const newDocBtn = toolbar.createEl("button", {
@@ -10782,7 +10792,6 @@ var BinderView = class extends import_obsidian9.ItemView {
           e.stopPropagation();
           item.collapsed = !item.collapsed;
           void this.saveBinder();
-          this.render();
         };
       } else {
         row.createSpan("ws-binder-toggle ws-binder-toggle-leaf");
@@ -11006,12 +11015,10 @@ var BinderView = class extends import_obsidian9.ItemView {
       "chapter",
       parentId
     );
-    await this.refresh();
   }
   async setItemStatus(item, status) {
     if (!this.activeProject) return;
     await this.plugin.projectManager.updateItemStatus(this.activeProject, item.id, status);
-    await this.refresh();
   }
   async duplicateItem(item) {
     if (!this.activeProject) return;
@@ -11030,7 +11037,6 @@ var BinderView = class extends import_obsidian9.ItemView {
     newItem.wordCountGoal = item.wordCountGoal;
     newItem.includeInExport = item.includeInExport;
     await this.saveBinder();
-    await this.refresh();
   }
   async moveToResearch(item) {
     if (!this.activeProject) return;
@@ -11049,7 +11055,6 @@ var BinderView = class extends import_obsidian9.ItemView {
     item.filePath = newPath;
     item.type = "note";
     await this.saveBinder();
-    await this.refresh();
   }
   deleteItem(item) {
     const project = this.activeProject;
@@ -11066,7 +11071,6 @@ var BinderView = class extends import_obsidian9.ItemView {
           await this.app.fileManager.trashFile(file);
         }
         await this.plugin.projectManager.removeItemFromBinder(project, item.id);
-        await this.refresh();
       }
     ).open();
   }
@@ -11118,7 +11122,6 @@ var BinderView = class extends import_obsidian9.ItemView {
     if (!insert(binder.items)) binder.items.unshift(moving);
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
   async moveItemAfter(sourceId, targetId) {
     if (!this.activeProject) return;
@@ -11138,7 +11141,6 @@ var BinderView = class extends import_obsidian9.ItemView {
     if (!insert(binder.items)) binder.items.push(moving);
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
   async moveItemInto(sourceId, targetId) {
     if (!this.activeProject) return;
@@ -11162,7 +11164,6 @@ var BinderView = class extends import_obsidian9.ItemView {
     if (!addTo(binder.items)) binder.items.push(moving);
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
   // Swap an item with its previous/next sibling
   async nudgeItem(item, delta) {
@@ -11176,7 +11177,6 @@ var BinderView = class extends import_obsidian9.ItemView {
     [siblings[idx], siblings[target]] = [siblings[target], siblings[idx]];
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
   findSiblings(items, id) {
     if (items.some((i) => i.id === id)) return items;
@@ -11196,7 +11196,6 @@ var BinderView = class extends import_obsidian9.ItemView {
     binder.items.push(moving);
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
   reorderItems(items, start2) {
     let order = start2;
@@ -11242,7 +11241,6 @@ var BinderView = class extends import_obsidian9.ItemView {
         });
       }
       await this.plugin.projectManager.saveBinder(binder);
-      await this.refresh();
     }).open();
   }
   async saveBinder() {
@@ -11696,6 +11694,12 @@ var LauncherView = class extends import_obsidian14.ItemView {
     return "feather";
   }
   async onOpen() {
+    this.registerEvent(this.plugin.projectManager.onActiveProjectChanged(() => {
+      void this.refresh();
+    }));
+    this.registerEvent(this.plugin.projectManager.onProjectsChanged(() => {
+      void this.refresh();
+    }));
     await this.render();
     this.refreshTimer = window.setInterval(() => {
       void this.tickRefresh();
@@ -11763,9 +11767,7 @@ var LauncherView = class extends import_obsidian14.ItemView {
     cardHeader.createSpan({ text: t2("launcher.project"), cls: "ws-launcher-card-label" });
     const newProjectBtn = cardHeader.createEl("button", { cls: "ws-launcher-text-btn", text: t2("launcher.newProject") });
     newProjectBtn.onclick = () => {
-      new ProjectModal(this.app, this.plugin, () => {
-        void this.refresh();
-      }).open();
+      new ProjectModal(this.app, this.plugin).open();
     };
     if (!project) {
       const emptyRow = card.createDiv("ws-launcher-empty");
@@ -15114,13 +15116,32 @@ ${_MagazineArticleTemplate.hint(hintText)}
 };
 
 // src/ProjectManager.ts
-var ProjectManager = class {
+var ProjectManager = class extends import_obsidian26.Events {
   constructor(plugin) {
+    super();
     this.projects = /* @__PURE__ */ new Map();
     this.activeProjectId = null;
     this.binderCache = /* @__PURE__ */ new Map();
     this.plugin = plugin;
     this.app = plugin.app;
+  }
+  // Project state is announced here, not pulled — subscribe instead of
+  // reaching into views to refresh them after a mutation. Returned refs work
+  // with Component.registerEvent for automatic cleanup.
+  onActiveProjectChanged(cb) {
+    return this.on("active-project-changed", (...data) => {
+      cb(data[0]);
+    });
+  }
+  onBinderChanged(cb) {
+    return this.on("binder-changed", (...data) => {
+      cb(data[0]);
+    });
+  }
+  onProjectsChanged(cb) {
+    return this.on("projects-changed", () => {
+      cb();
+    });
   }
   async initialize() {
     await this.loadAllProjects();
@@ -15213,6 +15234,7 @@ var ProjectManager = class {
     const path = (0, import_obsidian26.normalizePath)(`${project.folderPath}/_project.json`);
     await this.writeJson(path, project);
     this.projects.set(project.id, project);
+    this.trigger("projects-changed");
   }
   async loadBinder(project) {
     const cached = this.binderCache.get(project.id);
@@ -15248,7 +15270,7 @@ var ProjectManager = class {
     this.binderCache.set(binder.projectId, binder);
     const path = (0, import_obsidian26.normalizePath)(`${project.folderPath}/_binder.json`);
     await this.writeJson(path, binder);
-    this.plugin.statsTracker.invalidateWordCountCache();
+    this.trigger("binder-changed", binder);
   }
   async addDocumentToBinder(project, title, type, parentId, content2) {
     const binder = await this.loadBinder(project);
@@ -15397,7 +15419,7 @@ tags: [writing-studio]
     this.activeProjectId = id;
     this.plugin.settings.activeProjectId = id;
     await this.plugin.saveSettings();
-    await this.plugin.onActiveProjectChanged();
+    this.trigger("active-project-changed", this.getActiveProject());
   }
   flattenBinder(items) {
     const result = [];
@@ -17029,6 +17051,9 @@ var WritingStudioPlugin = class extends import_obsidian33.Plugin {
     this.fmManager = new FrontmatterManager(this);
     this.projectManager = new ProjectManager(this);
     this.statsTracker = new StatsTracker(this);
+    this.registerEvent(this.projectManager.onBinderChanged(() => {
+      this.statsTracker.invalidateWordCountCache();
+    }));
     this.focusMode = new FocusMode(this);
     this.typographyMode = new TypographyMode(this);
     this.writingModes = new WritingModes(this);
@@ -17138,9 +17163,7 @@ var WritingStudioPlugin = class extends import_obsidian33.Plugin {
     this.addCommand({
       id: "new-project",
       name: t2("main.cmd.newProject"),
-      callback: () => new ProjectModal(this.app, this, () => {
-        void this.refreshBinder();
-      }).open()
+      callback: () => new ProjectModal(this.app, this).open()
     });
     this.addCommand({
       id: "open-dashboard",
@@ -17327,27 +17350,13 @@ var WritingStudioPlugin = class extends import_obsidian33.Plugin {
     const existing = this.app.workspace.getLeavesOfType(BINDER_VIEW_TYPE);
     if (existing.length > 0) {
       void this.app.workspace.revealLeaf(existing[0]);
-      await this.refreshBinder();
       return;
     }
     const leaf = this.app.workspace.getLeftLeaf(false);
     if (leaf) {
       await leaf.setViewState({ type: BINDER_VIEW_TYPE, active: true });
       void this.app.workspace.revealLeaf(leaf);
-      await this.refreshBinder();
     }
-  }
-  async refreshBinder() {
-    const leaves = this.app.workspace.getLeavesOfType(BINDER_VIEW_TYPE);
-    for (const leaf of leaves) {
-      if (leaf.view instanceof BinderView) {
-        await leaf.view.refresh();
-      }
-    }
-  }
-  async onActiveProjectChanged() {
-    await this.refreshLauncher();
-    await this.refreshBinder();
   }
   async repairBinderPaths(oldPath, newPath, newBasename) {
     const projects = this.projectManager.getProjects();
@@ -17359,7 +17368,6 @@ var WritingStudioPlugin = class extends import_obsidian33.Plugin {
         item.filePath = newPath;
         item.title = newBasename;
         await this.projectManager.saveBinder(binder);
-        await this.refreshBinder();
         break;
       }
     }
@@ -17480,7 +17488,6 @@ var WritingStudioPlugin = class extends import_obsidian33.Plugin {
       };
       binder.items.push(item);
       await this.projectManager.saveBinder(binder);
-      await this.refreshBinder();
       new import_obsidian33.Notice(t2("main.notice.addedToProject", { file: file.basename, project: project.title }));
     }).open();
   }

--- a/main.ts
+++ b/main.ts
@@ -195,6 +195,9 @@ export default class WritingStudioPlugin extends Plugin {
     this.fmManager = new FrontmatterManager(this);
     this.projectManager = new ProjectManager(this);
     this.statsTracker = new StatsTracker(this);
+    this.registerEvent(this.projectManager.onBinderChanged(() => {
+      this.statsTracker.invalidateWordCountCache();
+    }));
     this.focusMode = new FocusMode(this);
     this.typographyMode = new TypographyMode(this);
     this.writingModes = new WritingModes(this);
@@ -317,7 +320,7 @@ export default class WritingStudioPlugin extends Plugin {
     this.addCommand({
       id: 'new-project',
       name: t('main.cmd.newProject'),
-      callback: () => new ProjectModal(this.app, this, () => { void this.refreshBinder(); }).open(),
+      callback: () => new ProjectModal(this.app, this).open(),
     });
 
     this.addCommand({
@@ -539,7 +542,6 @@ export default class WritingStudioPlugin extends Plugin {
     const existing = this.app.workspace.getLeavesOfType(BINDER_VIEW_TYPE);
     if (existing.length > 0) {
       void this.app.workspace.revealLeaf(existing[0]);
-      await this.refreshBinder();
       return;
     }
 
@@ -547,22 +549,7 @@ export default class WritingStudioPlugin extends Plugin {
     if (leaf) {
       await leaf.setViewState({ type: BINDER_VIEW_TYPE, active: true });
       void this.app.workspace.revealLeaf(leaf);
-      await this.refreshBinder();
     }
-  }
-
-  async refreshBinder(): Promise<void> {
-    const leaves = this.app.workspace.getLeavesOfType(BINDER_VIEW_TYPE);
-    for (const leaf of leaves) {
-      if (leaf.view instanceof BinderView) {
-        await leaf.view.refresh();
-      }
-    }
-  }
-
-  async onActiveProjectChanged(): Promise<void> {
-    await this.refreshLauncher();
-    await this.refreshBinder();
   }
 
   private async repairBinderPaths(oldPath: string, newPath: string, newBasename: string): Promise<void> {
@@ -575,7 +562,6 @@ export default class WritingStudioPlugin extends Plugin {
         item.filePath = newPath;
         item.title = newBasename;
         await this.projectManager.saveBinder(binder);
-        await this.refreshBinder();
         break;
       }
     }
@@ -708,7 +694,6 @@ export default class WritingStudioPlugin extends Plugin {
 
       binder.items.push(item);
       await this.projectManager.saveBinder(binder);
-      await this.refreshBinder();
       new Notice(t('main.notice.addedToProject', { file: file.basename, project: project.title }));
     }).open();
   }

--- a/modals/ProjectModal.ts
+++ b/modals/ProjectModal.ts
@@ -5,12 +5,14 @@ import { t } from '../src/i18n';
 
 export class ProjectModal extends Modal {
   private plugin: WritingStudioPlugin;
-  private onDone: () => void;
+  private onDone?: () => void;
   private title = '';
   private type: ProjectType = 'blank';
   private description = '';
 
-  constructor(app: App, plugin: WritingStudioPlugin, onDone: () => void) {
+  // Most callers need no callback — ProjectManager announces the new project
+  // itself. Pass onDone only for work beyond refreshing project state.
+  constructor(app: App, plugin: WritingStudioPlugin, onDone?: () => void) {
     super(app);
     this.plugin = plugin;
     this.onDone = onDone;
@@ -76,7 +78,7 @@ export class ProjectModal extends Modal {
         await this.plugin.projectManager.setActiveProject(project.id);
         new Notice(t('projectModal.created', { title: project.title }));
         this.close();
-        this.onDone();
+        this.onDone?.();
       } catch (e) {
         new Notice(t('projectModal.errorCreate', { error: e instanceof Error ? e.message : String(e) }));
         createBtn.disabled = false;

--- a/src/BinderView.ts
+++ b/src/BinderView.ts
@@ -54,6 +54,15 @@ export class BinderView extends ItemView {
   }
 
   async onOpen(): Promise<void> {
+    this.registerEvent(this.plugin.projectManager.onActiveProjectChanged(() => {
+      void this.refresh();
+    }));
+    this.registerEvent(this.plugin.projectManager.onBinderChanged((binder) => {
+      if (binder.projectId === this.activeProject?.id) void this.refresh();
+    }));
+    this.registerEvent(this.plugin.projectManager.onProjectsChanged(() => {
+      void this.refresh();
+    }));
     await this.refresh();
   }
 
@@ -112,13 +121,12 @@ export class BinderView extends ItemView {
 
     projectSel.onchange = async () => {
       await this.plugin.projectManager.setActiveProject(projectSel.value || null);
-      await this.refresh();
     };
 
     const newProjectBtn = projectRow.createEl('button', { cls: 'ws-binder-btn', title: t('binder.newProject') });
     setIcon(newProjectBtn, 'plus');
     newProjectBtn.onclick = () => {
-      new ProjectModal(this.app, this.plugin, () => { void this.refresh(); }).open();
+      new ProjectModal(this.app, this.plugin).open();
     };
 
     // Toolbar
@@ -240,7 +248,6 @@ export class BinderView extends ItemView {
           e.stopPropagation();
           item.collapsed = !item.collapsed;
           void this.saveBinder();
-          this.render();
         };
       } else {
         row.createSpan('ws-binder-toggle ws-binder-toggle-leaf');
@@ -491,13 +498,11 @@ export class BinderView extends ItemView {
       'chapter',
       parentId
     );
-    await this.refresh();
   }
 
   private async setItemStatus(item: BinderItem, status: DocumentStatus): Promise<void> {
     if (!this.activeProject) return;
     await this.plugin.projectManager.updateItemStatus(this.activeProject, item.id, status);
-    await this.refresh();
   }
 
   private async duplicateItem(item: BinderItem): Promise<void> {
@@ -525,8 +530,6 @@ export class BinderView extends ItemView {
     newItem.wordCountGoal = item.wordCountGoal;
     newItem.includeInExport = item.includeInExport;
     await this.saveBinder();
-
-    await this.refresh();
   }
 
   private async moveToResearch(item: BinderItem): Promise<void> {
@@ -549,7 +552,6 @@ export class BinderView extends ItemView {
     item.filePath = newPath;
     item.type = 'note';
     await this.saveBinder();
-    await this.refresh();
   }
 
   private deleteItem(item: BinderItem): void {
@@ -569,7 +571,6 @@ export class BinderView extends ItemView {
           await this.app.fileManager.trashFile(file);
         }
         await this.plugin.projectManager.removeItemFromBinder(project, item.id);
-        await this.refresh();
       }
     ).open();
   }
@@ -617,7 +618,6 @@ export class BinderView extends ItemView {
     if (!insert(binder.items)) binder.items.unshift(moving);
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
 
   private async moveItemAfter(sourceId: string, targetId: string): Promise<void> {
@@ -635,7 +635,6 @@ export class BinderView extends ItemView {
     if (!insert(binder.items)) binder.items.push(moving);
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
 
   private async moveItemInto(sourceId: string, targetId: string): Promise<void> {
@@ -661,7 +660,6 @@ export class BinderView extends ItemView {
     if (!addTo(binder.items)) binder.items.push(moving);
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
 
   // Swap an item with its previous/next sibling
@@ -676,7 +674,6 @@ export class BinderView extends ItemView {
     [siblings[idx], siblings[target]] = [siblings[target], siblings[idx]];
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
 
   private findSiblings(items: BinderItem[], id: string): BinderItem[] | null {
@@ -698,7 +695,6 @@ export class BinderView extends ItemView {
     binder.items.push(moving);
     this.reorderItems(binder.items, 1);
     await this.plugin.projectManager.saveBinder(binder);
-    await this.refresh();
   }
 
   private reorderItems(items: BinderItem[], start: number): number {
@@ -753,7 +749,6 @@ export class BinderView extends ItemView {
         });
       }
       await this.plugin.projectManager.saveBinder(binder);
-      await this.refresh();
     }).open();
   }
 

--- a/src/LauncherView.ts
+++ b/src/LauncherView.ts
@@ -35,6 +35,14 @@ export class LauncherView extends ItemView {
   }
 
   async onOpen(): Promise<void> {
+    // No binder-changed subscription — binder content is not shown here, and a
+    // full re-render per binder save would snap open dropdowns shut (see below)
+    this.registerEvent(this.plugin.projectManager.onActiveProjectChanged(() => {
+      void this.refresh();
+    }));
+    this.registerEvent(this.plugin.projectManager.onProjectsChanged(() => {
+      void this.refresh();
+    }));
     await this.render();
     // Patch dynamic values in place every 10 seconds — a full re-render here
     // rebuilt the whole panel, snapping open dropdowns shut mid-selection and
@@ -116,7 +124,7 @@ export class LauncherView extends ItemView {
 
     const newProjectBtn = cardHeader.createEl('button', { cls: 'ws-launcher-text-btn', text: t('launcher.newProject') });
     newProjectBtn.onclick = () => {
-      new ProjectModal(this.app, this.plugin, () => { void this.refresh(); }).open();
+      new ProjectModal(this.app, this.plugin).open();
     };
 
     if (!project) {

--- a/src/ProjectManager.ts
+++ b/src/ProjectManager.ts
@@ -1,4 +1,4 @@
-import { App, Notice, TFolder, TFile, normalizePath } from 'obsidian';
+import { App, Events, EventRef, Notice, TFolder, TFile, normalizePath } from 'obsidian';
 import type WritingStudioPlugin from '../main';
 import { t } from './i18n';
 import { localDateString } from './dates';
@@ -11,7 +11,7 @@ import { BlogCollectionTemplate } from '../templates/BlogCollectionTemplate';
 import { JournalArticleTemplate } from '../templates/JournalArticleTemplate';
 import { MagazineArticleTemplate } from '../templates/MagazineArticleTemplate';
 
-export class ProjectManager {
+export class ProjectManager extends Events {
   private plugin: WritingStudioPlugin;
   private app: App;
   private projects = new Map<string, WritingProject>();
@@ -19,8 +19,30 @@ export class ProjectManager {
   private binderCache = new Map<string, BinderData>();
 
   constructor(plugin: WritingStudioPlugin) {
+    super();
     this.plugin = plugin;
     this.app = plugin.app;
+  }
+
+  // Project state is announced here, not pulled — subscribe instead of
+  // reaching into views to refresh them after a mutation. Returned refs work
+  // with Component.registerEvent for automatic cleanup.
+  onActiveProjectChanged(cb: (project: WritingProject | null) => void): EventRef {
+    return this.on('active-project-changed', (...data: unknown[]) => {
+      cb(data[0] as WritingProject | null);
+    });
+  }
+
+  onBinderChanged(cb: (binder: BinderData) => void): EventRef {
+    return this.on('binder-changed', (...data: unknown[]) => {
+      cb(data[0] as BinderData);
+    });
+  }
+
+  onProjectsChanged(cb: () => void): EventRef {
+    return this.on('projects-changed', () => {
+      cb();
+    });
   }
 
   async initialize(): Promise<void> {
@@ -137,6 +159,7 @@ export class ProjectManager {
     const path = normalizePath(`${project.folderPath}/_project.json`);
     await this.writeJson(path, project);
     this.projects.set(project.id, project);
+    this.trigger('projects-changed');
   }
 
   async loadBinder(project: WritingProject): Promise<BinderData> {
@@ -181,7 +204,7 @@ export class ProjectManager {
     this.binderCache.set(binder.projectId, binder);
     const path = normalizePath(`${project.folderPath}/_binder.json`);
     await this.writeJson(path, binder);
-    this.plugin.statsTracker.invalidateWordCountCache();
+    this.trigger('binder-changed', binder);
   }
 
   async addDocumentToBinder(
@@ -368,7 +391,7 @@ tags: [writing-studio]
     this.activeProjectId = id;
     this.plugin.settings.activeProjectId = id;
     await this.plugin.saveSettings();
-    await this.plugin.onActiveProjectChanged();
+    this.trigger('active-project-changed', this.getActiveProject());
   }
 
   flattenBinder(items: BinderItem[]): BinderItem[] {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1,5 +1,32 @@
 export class App {}
 
+export interface EventRef {
+  name: string;
+  callback: (...data: unknown[]) => unknown;
+}
+
+export class Events {
+  private handlers = new Map<string, Set<(...data: unknown[]) => unknown>>();
+
+  on(name: string, callback: (...data: unknown[]) => unknown): EventRef {
+    if (!this.handlers.has(name)) this.handlers.set(name, new Set());
+    this.handlers.get(name)!.add(callback);
+    return { name, callback };
+  }
+
+  off(name: string, callback: (...data: unknown[]) => unknown): void {
+    this.handlers.get(name)?.delete(callback);
+  }
+
+  offref(ref: EventRef): void {
+    this.off(ref.name, ref.callback);
+  }
+
+  trigger(name: string, ...data: unknown[]): void {
+    for (const cb of this.handlers.get(name) ?? []) cb(...data);
+  }
+}
+
 export class TFile {
   path: string;
   extension: string;

--- a/tests/projectManager.test.ts
+++ b/tests/projectManager.test.ts
@@ -24,7 +24,7 @@ function makePlugin(vault: MockVault) {
   return {
     app: { vault },
     settings: { defaultProjectFolder: 'Projects', authorName: '' },
-    statsTracker: { invalidateWordCountCache: jest.fn() },
+    saveSettings: jest.fn().mockResolvedValue(undefined),
   } as never;
 }
 
@@ -120,6 +120,69 @@ describe('ProjectManager.loadBinder corrupt file handling', () => {
 
     expect(vault.read).toHaveBeenCalledTimes(1);
     expect(vault.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProjectManager change notification', () => {
+  it('announces the active project on setActiveProject', async () => {
+    const vault = makeVault();
+    const pm = new ProjectManager(makePlugin(vault));
+    const project = makeProject();
+    await pm.saveProject(project);
+    const seen: (WritingProject | null)[] = [];
+    pm.onActiveProjectChanged(p => { seen.push(p); });
+
+    await pm.setActiveProject('project-1');
+    await pm.setActiveProject(null);
+
+    expect(seen).toEqual([project, null]);
+  });
+
+  it('announces binder-changed with the saved binder', async () => {
+    const vault = makeVault();
+    const pm = new ProjectManager(makePlugin(vault));
+    await pm.saveProject(makeProject());
+    const seen: string[] = [];
+    pm.onBinderChanged(binder => { seen.push(binder.projectId); });
+
+    await pm.saveBinder({ version: '2.0', projectId: 'project-1', items: [] });
+
+    expect(seen).toEqual(['project-1']);
+  });
+
+  it('announces projects-changed when a project is saved', async () => {
+    const vault = makeVault();
+    const pm = new ProjectManager(makePlugin(vault));
+    const events = jest.fn();
+    pm.onProjectsChanged(events);
+
+    await pm.saveProject(makeProject());
+
+    expect(events).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not announce binder-changed for an unknown project', async () => {
+    const vault = makeVault();
+    const pm = new ProjectManager(makePlugin(vault));
+    const events = jest.fn();
+    pm.onBinderChanged(events);
+
+    // saveBinder returns early when the project is not loaded
+    await pm.saveBinder({ version: '2.0', projectId: 'ghost', items: [] });
+
+    expect(events).not.toHaveBeenCalled();
+  });
+
+  it('stops announcing after offref', async () => {
+    const vault = makeVault();
+    const pm = new ProjectManager(makePlugin(vault));
+    const events = jest.fn();
+    const ref = pm.onProjectsChanged(events);
+    pm.offref(ref);
+
+    await pm.saveProject(makeProject());
+
+    expect(events).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #138. Post-audit improvement 1 of 7 — accumulates under [Unreleased]; no release until all seven land.

## What changed
- **ProjectManager extends Events** and exposes three typed subscriptions: `onActiveProjectChanged`, `onBinderChanged`, `onProjectsChanged`. Emission sites: `setActiveProject`, `saveBinder`, `saveProject`.
- **Binder view and launcher subscribe in onOpen** via `registerEvent` (auto-cleanup on close) and re-render themselves.
- **Manual refresh plumbing deleted:** `WritingStudioPlugin.refreshBinder()`, the `onActiveProjectChanged()` hook (the reverse plugin dependency from ProjectManager), all post-save `refresh()` calls in BinderView (12 sites), and the `ProjectModal` refresh callbacks at all three call sites (`onDone` is now optional).
- **statsTracker decoupled:** `saveBinder` no longer reaches into `plugin.statsTracker`; the cache invalidation is a subscription wired in `onload`.

## Deliberately out of scope
- Compile preview keeps its manual-load design — auto-recompiling on every binder save would re-read every project file.
- Launcher does not subscribe to `binder-changed` — binder content is not displayed there, and a full re-render per save would reintroduce the dropdown-snapping problem its 10-second patch-in-place tick was built to avoid.

## Tests
112 passing (5 new): event emission for all three events, payload correctness, no emission for unknown projects, unsubscribe via offref. Test mock gains an `Events` implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)