### PR TITLE
refactor: vault I/O behind a narrow VaultFiles seam (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Writing Studio are documented here.
 
 ### Internal
 - The plugin entry point (main.ts) was decomposed: the 19 palette commands now live in a declarative registry (`src/commands.ts`), the four status bar items and their fixed ordering in `src/StatusBar.ts`, and the inline goal banner in `src/GoalBanner.ts`. New tests enforce command-table integrity (unique ids, valid i18n keys, sentence-case names) and the status bar ordering invariant. (#139)
+- File access now goes through a narrow vault adapter (`src/VaultFiles.ts`) consumed by the project manager and both export engines, with an in-memory implementation for tests. The compile/export pipeline — frontmatter stripping, binder-title headings, research and export-exclusion filtering — is covered by automated tests for the first time. (#140)
 - Removed the deprecated `setDynamicTooltip()` call on the focus dim opacity and line length sliders — Obsidian 1.13 always shows the slider value inline. (On Obsidian versions before 1.13 the value tooltip while dragging is no longer shown.)
 
 ### Internal

--- a/main.js
+++ b/main.js
@@ -12784,12 +12784,9 @@ var SprintTimer = class {
 };
 
 // src/ExportEngine.ts
-var import_obsidian19 = require("obsidian");
+var import_obsidian18 = require("obsidian");
 var import_child_process = require("child_process");
 var import_util = require("util");
-
-// src/EpubEngine.ts
-var import_obsidian18 = require("obsidian");
 
 // node_modules/fflate/esm/browser.js
 var ch2 = {};
@@ -13642,15 +13639,14 @@ var mt = typeof queueMicrotask == "function" ? queueMicrotask : typeof setTimeou
 
 // src/EpubEngine.ts
 var EpubEngine = class {
-  constructor(plugin) {
+  constructor(files) {
     // Configured book language — every chapter's xml:lang previously
     // hardcoded "en", contradicting the language declared in content.opf
     this.lang = "en";
-    this.plugin = plugin;
-    this.app = plugin.app;
+    this.files = files;
   }
   async build(opts, outputVaultPath) {
-    var _a2;
+    var _a2, _b2;
     this.lang = opts.language || "en";
     const uid = `urn:uuid:${this.uuid()}`;
     const modified = (/* @__PURE__ */ new Date()).toISOString().replace(/\.\d{3}Z$/, "Z");
@@ -13660,9 +13656,8 @@ var EpubEngine = class {
     let coverImageFile = null;
     let coverImageMime = "image/jpeg";
     if (opts.coverImagePath) {
-      const vaultFile = this.app.vault.getAbstractFileByPath(opts.coverImagePath);
-      if (vaultFile instanceof import_obsidian18.TFile) {
-        const raw = await this.app.vault.readBinary(vaultFile);
+      const raw = await this.files.readBinary(opts.coverImagePath);
+      if (raw !== null) {
         const mimeByExt = {
           png: "image/png",
           webp: "image/webp",
@@ -13670,8 +13665,8 @@ var EpubEngine = class {
           jpg: "image/jpeg",
           jpeg: "image/jpeg"
         };
-        const ext = vaultFile.extension.toLowerCase();
-        coverImageMime = (_a2 = mimeByExt[ext]) != null ? _a2 : "image/jpeg";
+        const ext = ((_a2 = opts.coverImagePath.split(".").pop()) != null ? _a2 : "").toLowerCase();
+        coverImageMime = (_b2 = mimeByExt[ext]) != null ? _b2 : "image/jpeg";
         coverImageFile = `cover.${ext === "jpeg" ? "jpg" : ext || "jpg"}`;
         entries[`OEBPS/${coverImageFile}`] = [new Uint8Array(raw), { level: 6 }];
       }
@@ -13692,12 +13687,7 @@ var EpubEngine = class {
     });
     const data = new ArrayBuffer(compressed.byteLength);
     new Uint8Array(data).set(compressed);
-    const existing = this.app.vault.getAbstractFileByPath(outputVaultPath);
-    if (existing instanceof import_obsidian18.TFile) {
-      await this.app.vault.modifyBinary(existing, data);
-    } else {
-      await this.app.vault.createBinary(outputVaultPath, data);
-    }
+    await this.files.writeBinary(outputVaultPath, data);
   }
   // ── Helpers ────────────────────────────────────────────────────────────────
   uuid() {
@@ -14167,9 +14157,10 @@ var MANUSCRIPT_CSS = `
 `;
 var SECTION_BREAK = "\n\n\0WS-SECTION-BREAK\0\n\n";
 var ExportEngine = class {
-  constructor(plugin) {
+  constructor(plugin, files) {
     this.plugin = plugin;
     this.app = plugin.app;
+    this.files = files;
   }
   // Resolve section sentinels to a markdown hr for text-based outputs
   toMarkdown(compiled) {
@@ -14177,11 +14168,11 @@ var ExportEngine = class {
   }
   async export(opts) {
     const project = this.plugin.projectManager.getActiveProject();
-    const outputDir = project ? (0, import_obsidian19.normalizePath)(`${project.folderPath}/Exports`) : (0, import_obsidian19.normalizePath)("Exports");
-    await this.ensureFolder(outputDir);
+    const outputDir = project ? (0, import_obsidian18.normalizePath)(`${project.folderPath}/Exports`) : (0, import_obsidian18.normalizePath)("Exports");
+    await this.files.ensureFolder(outputDir);
     const timestamp = (/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-").slice(0, 19);
     const projectTitle = (project == null ? void 0 : project.title.replace(/[\\/:*?"<>|]/g, "-")) || "export";
-    const baseFile = (0, import_obsidian19.normalizePath)(`${outputDir}/${projectTitle}-${timestamp}`);
+    const baseFile = (0, import_obsidian18.normalizePath)(`${outputDir}/${projectTitle}-${timestamp}`);
     if (opts.format === "epub") {
       return this.exportEpub(opts, baseFile);
     }
@@ -14215,11 +14206,14 @@ var ExportEngine = class {
     if (opts.scope === "current") {
       const leaf = this.app.workspace.getMostRecentLeaf();
       const view = leaf == null ? void 0 : leaf.view;
-      const file = view instanceof import_obsidian19.MarkdownView ? view.file : null;
-      if (!(file instanceof import_obsidian19.TFile)) {
+      const file = view instanceof import_obsidian18.MarkdownView ? view.file : null;
+      if (!(file instanceof import_obsidian18.TFile)) {
         throw new Error(t2("exportEngine.noActiveDocument"));
       }
-      let content2 = await this.app.vault.read(file);
+      let content2 = await this.files.readText(file.path);
+      if (content2 === null) {
+        throw new Error(t2("exportEngine.noActiveDocument"));
+      }
       if (!opts.includeFrontmatter) {
         content2 = content2.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
       }
@@ -14234,9 +14228,8 @@ var ExportEngine = class {
         if (!item.includeInExport) continue;
         if (!item.filePath) continue;
         if (!opts.includeResearch && item.filePath.includes("/Research/")) continue;
-        const file = this.app.vault.getAbstractFileByPath(item.filePath);
-        if (!(file instanceof import_obsidian19.TFile)) continue;
-        let content2 = await this.app.vault.read(file);
+        let content2 = await this.files.readText(item.filePath);
+        if (content2 === null) continue;
         if (!opts.includeFrontmatter) {
           content2 = content2.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
         }
@@ -14251,7 +14244,7 @@ var ExportEngine = class {
     if (chapters.length === 0) {
       throw new Error(t2("exportEngine.noActiveDocument"));
     }
-    await new EpubEngine(this.plugin).build({
+    await new EpubEngine(this.files).build({
       title,
       author,
       language,
@@ -14259,7 +14252,7 @@ var ExportEngine = class {
       coverImagePath: opts.coverImagePath,
       chapters
     }, outputPath);
-    new import_obsidian19.Notice(t2("exportEngine.epubExported", { path: outputPath }));
+    new import_obsidian18.Notice(t2("exportEngine.epubExported", { path: outputPath }));
     return outputPath;
   }
   preprocessObsidianMarkdown(md) {
@@ -14269,6 +14262,7 @@ var ExportEngine = class {
     return html.replace(/<hr>/g, "<hr/>").replace(/<br>/g, "<br/>").replace(/<img([^>]*)(?<!\/)>/g, "<img$1/>");
   }
   async compileContent(opts) {
+    var _a2, _b2;
     const parts = [];
     const project = this.plugin.projectManager.getActiveProject();
     if (opts.addTitlePage && project) {
@@ -14282,11 +14276,15 @@ ${today}`);
     if (opts.scope === "current") {
       const leaf = this.app.workspace.getMostRecentLeaf();
       const view = leaf == null ? void 0 : leaf.view;
-      const file = view instanceof import_obsidian19.MarkdownView ? view.file : null;
-      if (!(file instanceof import_obsidian19.TFile)) {
+      const file = view instanceof import_obsidian18.MarkdownView ? view.file : null;
+      if (!(file instanceof import_obsidian18.TFile)) {
         throw new Error(t2("exportEngine.noActiveDocument"));
       }
-      parts.push(await this.processFile(file, opts));
+      const content2 = await this.processPath(file.path, opts);
+      if (content2 === null) {
+        throw new Error(t2("exportEngine.noActiveDocument"));
+      }
+      parts.push(content2);
     } else if (opts.scope === "project" && project) {
       const binder = await this.plugin.projectManager.loadBinder(project);
       const flatItems = this.plugin.projectManager.flattenBinder(binder.items);
@@ -14294,9 +14292,8 @@ ${today}`);
         if (!item.includeInExport) continue;
         if (!item.filePath) continue;
         if (!opts.includeResearch && item.filePath.includes("/Research/")) continue;
-        const file = this.app.vault.getAbstractFileByPath(item.filePath);
-        if (!(file instanceof import_obsidian19.TFile)) continue;
-        const content2 = await this.processFile(file, opts);
+        const content2 = await this.processPath(item.filePath, opts);
+        if (content2 === null) continue;
         if (opts.includeTitlesAsHeadings) {
           const body = content2.replace(/^# [^\n]*\n+/, "").trim();
           parts.push(`# ${item.title}
@@ -14308,12 +14305,12 @@ ${body}`);
       }
     } else if (opts.scope === "selected" && opts.selectedFiles) {
       for (const filePath of opts.selectedFiles) {
-        const file = this.app.vault.getAbstractFileByPath(filePath);
-        if (!(file instanceof import_obsidian19.TFile)) continue;
-        const content2 = await this.processFile(file, opts);
+        const content2 = await this.processPath(filePath, opts);
+        if (content2 === null) continue;
         if (opts.includeTitlesAsHeadings) {
+          const basename = (_b2 = (_a2 = filePath.split("/").pop()) == null ? void 0 : _a2.replace(/\.md$/, "")) != null ? _b2 : filePath;
           const body = content2.replace(/^# [^\n]*\n+/, "").trim();
-          parts.push(`# ${file.basename}
+          parts.push(`# ${basename}
 
 ${body}`);
         } else {
@@ -14323,8 +14320,10 @@ ${body}`);
     }
     return parts.join(SECTION_BREAK);
   }
-  async processFile(file, opts) {
-    let content2 = await this.app.vault.read(file);
+  // Resolves to null when the file does not exist.
+  async processPath(path, opts) {
+    let content2 = await this.files.readText(path);
+    if (content2 === null) return null;
     if (!opts.includeFrontmatter) {
       content2 = content2.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
     }
@@ -14369,7 +14368,7 @@ ${body}`);
   </div>
 </div>`;
     const fullHtml = `<!DOCTYPE html>
-<html lang="${(0, import_obsidian19.getLanguage)()}">
+<html lang="${(0, import_obsidian18.getLanguage)()}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14383,20 +14382,20 @@ ${bodyHtml}
 </div>
 </body>
 </html>`;
-    await this.writeFile(outputPath, fullHtml);
-    new import_obsidian19.Notice(t2("exportEngine.manuscriptExported", { path: outputPath }));
+    await this.files.writeText(outputPath, fullHtml);
+    new import_obsidian18.Notice(t2("exportEngine.manuscriptExported", { path: outputPath }));
     return outputPath;
   }
   async exportMarkdown(content2, outputPath) {
-    await this.writeFile(outputPath, content2);
-    new import_obsidian19.Notice(t2("exportEngine.exportedTo", { path: outputPath }));
+    await this.files.writeText(outputPath, content2);
+    new import_obsidian18.Notice(t2("exportEngine.exportedTo", { path: outputPath }));
     return outputPath;
   }
   async exportHtml(content2, outputPath, title, opts) {
     const font = opts.font || "Georgia";
     const fontSize = opts.fontSize || 16;
     const html = `<!DOCTYPE html>
-<html lang="${(0, import_obsidian19.getLanguage)()}">
+<html lang="${(0, import_obsidian18.getLanguage)()}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14418,57 +14417,38 @@ ${bodyHtml}
 ${markdownToHtml(content2)}
 </body>
 </html>`;
-    await this.writeFile(outputPath, html);
-    new import_obsidian19.Notice(t2("exportEngine.exportedHtmlTo", { path: outputPath }));
+    await this.files.writeText(outputPath, html);
+    new import_obsidian18.Notice(t2("exportEngine.exportedHtmlTo", { path: outputPath }));
     return outputPath;
   }
   async exportPandoc(content2, outputPath, opts) {
     const pandocPath = this.plugin.settings.pandocPath || "pandoc";
     const tempMdPath = outputPath.replace(/\.[^.]+$/, ".tmp.md");
     try {
-      await this.writeFile(tempMdPath, content2);
-      const absOutput = this.getAbsPath(outputPath);
-      const absInput = this.getAbsPath(tempMdPath);
+      await this.files.writeText(tempMdPath, content2);
+      const absOutput = this.files.absolutePath(outputPath);
+      const absInput = this.files.absolutePath(tempMdPath);
       const args = [absInput, "--from", "markdown", "-o", absOutput];
       if (opts.font) {
         const safeFont = opts.font.replace(/["'`\\$]/g, "");
         args.push("-V", `mainfont=${safeFont}`);
       }
       await execFileAsync(pandocPath, args);
-      new import_obsidian19.Notice(t2("exportEngine.exportedTo", { path: outputPath }));
+      new import_obsidian18.Notice(t2("exportEngine.exportedTo", { path: outputPath }));
       return outputPath;
     } catch (e) {
       throw new Error(`Pandoc export failed: ${e instanceof Error ? e.message : String(e)}
 Ensure pandoc is installed.`);
     } finally {
-      if (this.app.vault.getAbstractFileByPath(tempMdPath) instanceof import_obsidian19.TFile) {
-        await this.app.vault.adapter.remove(tempMdPath);
-      }
+      await this.files.remove(tempMdPath);
     }
   }
   async exportPdf(content2, outputPath, opts) {
     try {
       return await this.exportPandoc(content2, outputPath, opts);
     } catch (e) {
-      new import_obsidian19.Notice(t2("exportEngine.pdfRequiresPandoc"));
+      new import_obsidian18.Notice(t2("exportEngine.pdfRequiresPandoc"));
       throw e;
-    }
-  }
-  async writeFile(vaultPath, content2) {
-    const existing = this.app.vault.getAbstractFileByPath(vaultPath);
-    if (existing instanceof import_obsidian19.TFile) {
-      await this.app.vault.modify(existing, content2);
-    } else {
-      await this.app.vault.create(vaultPath, content2);
-    }
-  }
-  getAbsPath(vaultPath) {
-    const adapter = this.app.vault.adapter;
-    return adapter instanceof import_obsidian19.FileSystemAdapter ? adapter.getFullPath(vaultPath) : vaultPath;
-  }
-  async ensureFolder(path) {
-    if (!this.app.vault.getAbstractFileByPath(path)) {
-      await this.app.vault.createFolder(path);
     }
   }
   escapeHtml(str) {
@@ -14477,7 +14457,7 @@ Ensure pandoc is installed.`);
 };
 
 // src/WordPressClient.ts
-var import_obsidian20 = require("obsidian");
+var import_obsidian19 = require("obsidian");
 var WordPressClient = class {
   authHeaders(site) {
     const credentials = `${site.username}:${site.appPassword}`;
@@ -14494,7 +14474,7 @@ var WordPressClient = class {
   async testConnection(site) {
     var _a2;
     try {
-      const resp = await (0, import_obsidian20.requestUrl)({
+      const resp = await (0, import_obsidian19.requestUrl)({
         url: this.apiUrl(site, "users/me"),
         method: "GET",
         headers: this.authHeaders(site),
@@ -14509,7 +14489,7 @@ var WordPressClient = class {
       const data = resp.json;
       let siteName = site.url;
       try {
-        const siteResp = await (0, import_obsidian20.requestUrl)({
+        const siteResp = await (0, import_obsidian19.requestUrl)({
           url: `${site.url.replace(/\/$/, "")}/wp-json/`,
           method: "GET",
           headers: this.authHeaders(site),
@@ -14534,7 +14514,7 @@ var WordPressClient = class {
     try {
       const all = [];
       for (let page = 1; page <= 20; page++) {
-        const resp = await (0, import_obsidian20.requestUrl)({
+        const resp = await (0, import_obsidian19.requestUrl)({
           url: this.apiUrl(site, `categories?per_page=100&page=${page}`),
           method: "GET",
           headers: this.authHeaders(site),
@@ -14555,7 +14535,7 @@ var WordPressClient = class {
       }
       return all;
     } catch (e) {
-      new import_obsidian20.Notice(t2("wpClient.fetchCategoriesFailed", { error: e instanceof Error ? e.message : String(e) }));
+      new import_obsidian19.Notice(t2("wpClient.fetchCategoriesFailed", { error: e instanceof Error ? e.message : String(e) }));
       return [];
     }
   }
@@ -14575,7 +14555,7 @@ var WordPressClient = class {
     if (opts.featuredMediaId) body.featured_media = opts.featuredMediaId;
     if (opts.scheduledDate) body.date = opts.scheduledDate;
     const url = opts.existingPostId ? this.apiUrl(site, `posts/${opts.existingPostId}`) : this.apiUrl(site, "posts");
-    const resp = await (0, import_obsidian20.requestUrl)({
+    const resp = await (0, import_obsidian19.requestUrl)({
       url,
       method: opts.existingPostId ? "PUT" : "POST",
       headers: this.authHeaders(site),
@@ -14599,7 +14579,7 @@ var WordPressClient = class {
     const skipped = [];
     for (const name of tagNames) {
       try {
-        const searchResp = await (0, import_obsidian20.requestUrl)({
+        const searchResp = await (0, import_obsidian19.requestUrl)({
           url: this.apiUrl(site, `tags?search=${encodeURIComponent(name)}`),
           method: "GET",
           headers: this.authHeaders(site),
@@ -14613,7 +14593,7 @@ var WordPressClient = class {
             continue;
           }
         }
-        const createResp = await (0, import_obsidian20.requestUrl)({
+        const createResp = await (0, import_obsidian19.requestUrl)({
           url: this.apiUrl(site, "tags"),
           method: "POST",
           headers: this.authHeaders(site),
@@ -14630,7 +14610,7 @@ var WordPressClient = class {
       }
     }
     if (skipped.length > 0) {
-      new import_obsidian20.Notice(t2("wpClient.tagsSkipped", { tags: skipped.join(", ") }));
+      new import_obsidian19.Notice(t2("wpClient.tagsSkipped", { tags: skipped.join(", ") }));
     }
     return ids;
   }
@@ -14651,17 +14631,17 @@ var WordPressClient = class {
 };
 
 // src/ProjectManager.ts
-var import_obsidian26 = require("obsidian");
+var import_obsidian25 = require("obsidian");
 
 // templates/BookTemplate.ts
-var import_obsidian21 = require("obsidian");
+var import_obsidian20 = require("obsidian");
 var BookTemplate = class _BookTemplate {
   static async apply(app, project) {
     const now = localDateString();
-    const chaptersPath = (0, import_obsidian21.normalizePath)(`${project.folderPath}/Chapters`);
-    const frontMatterFile = (0, import_obsidian21.normalizePath)(`${chaptersPath}/Front Matter.md`);
-    const chapter1File = (0, import_obsidian21.normalizePath)(`${chaptersPath}/Part 1 - Chapter 1.md`);
-    const backMatterFile = (0, import_obsidian21.normalizePath)(`${chaptersPath}/Back Matter.md`);
+    const chaptersPath = (0, import_obsidian20.normalizePath)(`${project.folderPath}/Chapters`);
+    const frontMatterFile = (0, import_obsidian20.normalizePath)(`${chaptersPath}/Front Matter.md`);
+    const chapter1File = (0, import_obsidian20.normalizePath)(`${chaptersPath}/Part 1 - Chapter 1.md`);
+    const backMatterFile = (0, import_obsidian20.normalizePath)(`${chaptersPath}/Back Matter.md`);
     await _BookTemplate.createFile(app, frontMatterFile, _BookTemplate.frontMatterDoc(now));
     await _BookTemplate.createFile(app, chapter1File, _BookTemplate.chapter1Doc(project.title, now));
     await _BookTemplate.createFile(app, backMatterFile, _BookTemplate.backMatterDoc(now));
@@ -14772,13 +14752,13 @@ tags: [writing-studio]
 };
 
 // templates/ArticleSeriesTemplate.ts
-var import_obsidian22 = require("obsidian");
+var import_obsidian21 = require("obsidian");
 var ArticleSeriesTemplate = class _ArticleSeriesTemplate {
   static async apply(app, project) {
     const now = localDateString();
-    const chaptersPath = (0, import_obsidian22.normalizePath)(`${project.folderPath}/Chapters`);
-    const seriesMetaFile = (0, import_obsidian22.normalizePath)(`${chaptersPath}/Series Overview.md`);
-    const article1File = (0, import_obsidian22.normalizePath)(`${chaptersPath}/Article 1.md`);
+    const chaptersPath = (0, import_obsidian21.normalizePath)(`${project.folderPath}/Chapters`);
+    const seriesMetaFile = (0, import_obsidian21.normalizePath)(`${chaptersPath}/Series Overview.md`);
+    const article1File = (0, import_obsidian21.normalizePath)(`${chaptersPath}/Article 1.md`);
     await _ArticleSeriesTemplate.createFile(app, seriesMetaFile, _ArticleSeriesTemplate.seriesOverviewDoc(project.title, now));
     await _ArticleSeriesTemplate.createFile(app, article1File, _ArticleSeriesTemplate.article1Doc(project.title, now));
     const items = [
@@ -14864,14 +14844,14 @@ tags: [writing-studio]
 };
 
 // templates/BlogCollectionTemplate.ts
-var import_obsidian23 = require("obsidian");
+var import_obsidian22 = require("obsidian");
 var BlogCollectionTemplate = class _BlogCollectionTemplate {
   static async apply(app, project) {
     const now = localDateString();
-    const chaptersPath = (0, import_obsidian23.normalizePath)(`${project.folderPath}/Chapters`);
+    const chaptersPath = (0, import_obsidian22.normalizePath)(`${project.folderPath}/Chapters`);
     const year = (/* @__PURE__ */ new Date()).getFullYear();
-    await _BlogCollectionTemplate.createFolder(app, (0, import_obsidian23.normalizePath)(`${chaptersPath}/${year}`));
-    const firstPostFile = (0, import_obsidian23.normalizePath)(`${chaptersPath}/${year}/${now}-first-post.md`);
+    await _BlogCollectionTemplate.createFolder(app, (0, import_obsidian22.normalizePath)(`${chaptersPath}/${year}`));
+    const firstPostFile = (0, import_obsidian22.normalizePath)(`${chaptersPath}/${year}/${now}-first-post.md`);
     await _BlogCollectionTemplate.createFile(app, firstPostFile, _BlogCollectionTemplate.firstPostDoc(now));
     const items = [
       {
@@ -14933,11 +14913,11 @@ tags: [writing-studio]
 };
 
 // templates/JournalArticleTemplate.ts
-var import_obsidian24 = require("obsidian");
+var import_obsidian23 = require("obsidian");
 var JournalArticleTemplate = class _JournalArticleTemplate {
   static async apply(app, project) {
     const now = localDateString();
-    const p = (name) => (0, import_obsidian24.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
+    const p = (name) => (0, import_obsidian23.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
     const docs = [
       [p("Title Page"), _JournalArticleTemplate.titlePageDoc(project.title, project.author, now)],
       [p("Abstract"), _JournalArticleTemplate.standardDoc("Abstract", "abstract", 2, 250, now, "Write a concise summary of the article in 150\u2013250 words. Include research question, methodology, key findings, and conclusion.")],
@@ -15023,11 +15003,11 @@ ${_JournalArticleTemplate.hint(hintText)}
 };
 
 // templates/MagazineArticleTemplate.ts
-var import_obsidian25 = require("obsidian");
+var import_obsidian24 = require("obsidian");
 var MagazineArticleTemplate = class _MagazineArticleTemplate {
   static async apply(app, project) {
     const now = localDateString();
-    const p = (name) => (0, import_obsidian25.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
+    const p = (name) => (0, import_obsidian24.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
     const docs = [
       [p("Pitch - Query Notes"), _MagazineArticleTemplate.notesDoc(
         "Pitch / Query Notes",
@@ -15116,14 +15096,15 @@ ${_MagazineArticleTemplate.hint(hintText)}
 };
 
 // src/ProjectManager.ts
-var ProjectManager = class extends import_obsidian26.Events {
-  constructor(plugin) {
+var ProjectManager = class extends import_obsidian25.Events {
+  constructor(plugin, files) {
     super();
     this.projects = /* @__PURE__ */ new Map();
     this.activeProjectId = null;
     this.binderCache = /* @__PURE__ */ new Map();
     this.plugin = plugin;
     this.app = plugin.app;
+    this.files = files;
   }
   // Project state is announced here, not pulled — subscribe instead of
   // reaching into views to refresh them after a mutation. Returned refs work
@@ -15153,22 +15134,18 @@ var ProjectManager = class extends import_obsidian26.Events {
     this.projects.clear();
     const rootFolder = this.plugin.settings.defaultProjectFolder;
     if (!rootFolder) return;
-    const folder = this.app.vault.getAbstractFileByPath((0, import_obsidian26.normalizePath)(rootFolder));
-    if (!(folder instanceof import_obsidian26.TFolder)) return;
-    const subfolders = folder.children.filter((c) => c instanceof import_obsidian26.TFolder);
-    await Promise.all(subfolders.map((f) => this.loadProject(f.path)));
+    const subfolders = this.files.listSubfolders((0, import_obsidian25.normalizePath)(rootFolder));
+    await Promise.all(subfolders.map((f) => this.loadProject(f)));
   }
   async loadProject(folderPath) {
-    const projectFilePath = (0, import_obsidian26.normalizePath)(`${folderPath}/_project.json`);
-    const file = this.app.vault.getAbstractFileByPath(projectFilePath);
-    if (!(file instanceof import_obsidian26.TFile)) return null;
+    const content2 = await this.files.readText((0, import_obsidian25.normalizePath)(`${folderPath}/_project.json`));
+    if (content2 === null) return null;
     try {
-      const content2 = await this.app.vault.read(file);
       const project = JSON.parse(content2);
       this.projects.set(project.id, project);
       return project;
     } catch (e) {
-      new import_obsidian26.Notice(t2("projectManager.corruptProject", { folder: folderPath }));
+      new import_obsidian25.Notice(t2("projectManager.corruptProject", { folder: folderPath }));
       return null;
     }
   }
@@ -15176,14 +15153,14 @@ var ProjectManager = class extends import_obsidian26.Events {
     const rootFolder = this.plugin.settings.defaultProjectFolder || "Writing Projects";
     const id = this.uniqueId("project");
     const folderName = title.replace(/[\\/:*?"<>|]/g, "-");
-    const folderPath = (0, import_obsidian26.normalizePath)(`${rootFolder}/${folderName}`);
-    if (this.app.vault.getAbstractFileByPath(folderPath)) {
+    const folderPath = (0, import_obsidian25.normalizePath)(`${rootFolder}/${folderName}`);
+    if (this.files.exists(folderPath)) {
       throw new Error(t2("projectManager.errorFolderExists", { folder: folderName }));
     }
-    await this.ensureFolder(folderPath);
-    await this.ensureFolder((0, import_obsidian26.normalizePath)(`${folderPath}/Chapters`));
-    await this.ensureFolder((0, import_obsidian26.normalizePath)(`${folderPath}/Research`));
-    await this.ensureFolder((0, import_obsidian26.normalizePath)(`${folderPath}/Exports`));
+    await this.files.ensureFolder(folderPath);
+    await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/Chapters`));
+    await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/Research`));
+    await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/Exports`));
     const now = localDateString();
     const project = {
       id,
@@ -15231,7 +15208,7 @@ var ProjectManager = class extends import_obsidian26.Events {
   }
   async saveProject(project) {
     project.modified = localDateString();
-    const path = (0, import_obsidian26.normalizePath)(`${project.folderPath}/_project.json`);
+    const path = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_project.json`);
     await this.writeJson(path, project);
     this.projects.set(project.id, project);
     this.trigger("projects-changed");
@@ -15239,15 +15216,14 @@ var ProjectManager = class extends import_obsidian26.Events {
   async loadBinder(project) {
     const cached = this.binderCache.get(project.id);
     if (cached) return cached;
-    const path = (0, import_obsidian26.normalizePath)(`${project.folderPath}/_binder.json`);
-    const file = this.app.vault.getAbstractFileByPath(path);
-    if (!(file instanceof import_obsidian26.TFile)) {
-      return { version: "2.0", projectId: project.id, items: [] };
-    }
+    const path = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_binder.json`);
     let content2;
     try {
-      content2 = await this.app.vault.read(file);
+      content2 = await this.files.readText(path);
     } catch (e) {
+      return { version: "2.0", projectId: project.id, items: [] };
+    }
+    if (content2 === null) {
       return { version: "2.0", projectId: project.id, items: [] };
     }
     try {
@@ -15255,8 +15231,8 @@ var ProjectManager = class extends import_obsidian26.Events {
       this.binderCache.set(project.id, data);
       return data;
     } catch (e) {
-      await this.writeRaw((0, import_obsidian26.normalizePath)(`${project.folderPath}/_binder.json.bak`), content2);
-      new import_obsidian26.Notice(t2("projectManager.corruptBinder", { project: project.title }));
+      await this.files.writeText((0, import_obsidian25.normalizePath)(`${project.folderPath}/_binder.json.bak`), content2);
+      new import_obsidian25.Notice(t2("projectManager.corruptBinder", { project: project.title }));
       return { version: "2.0", projectId: project.id, items: [] };
     }
   }
@@ -15268,7 +15244,7 @@ var ProjectManager = class extends import_obsidian26.Events {
     const project = this.projects.get(binder.projectId);
     if (!project) return;
     this.binderCache.set(binder.projectId, binder);
-    const path = (0, import_obsidian26.normalizePath)(`${project.folderPath}/_binder.json`);
+    const path = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_binder.json`);
     await this.writeJson(path, binder);
     this.trigger("binder-changed", binder);
   }
@@ -15276,9 +15252,9 @@ var ProjectManager = class extends import_obsidian26.Events {
     const binder = await this.loadBinder(project);
     const now = localDateString();
     const baseName = title.replace(/[\\/:*?"<>|]/g, "-");
-    let filePath = (0, import_obsidian26.normalizePath)(`${project.folderPath}/Chapters/${baseName}.md`);
-    for (let n = 2; this.app.vault.getAbstractFileByPath(filePath); n++) {
-      filePath = (0, import_obsidian26.normalizePath)(`${project.folderPath}/Chapters/${baseName} ${n}.md`);
+    let filePath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/Chapters/${baseName}.md`);
+    for (let n = 2; this.files.exists(filePath); n++) {
+      filePath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/Chapters/${baseName} ${n}.md`);
     }
     const item = {
       id: this.uniqueId("item"),
@@ -15290,7 +15266,7 @@ var ProjectManager = class extends import_obsidian26.Events {
       includeInExport: true
     };
     const frontmatter = this.buildDocFrontmatter(title, type, item.order, now);
-    await this.app.vault.create(filePath, content2 != null ? content2 : frontmatter + "\n\n");
+    await this.files.writeText(filePath, content2 != null ? content2 : frontmatter + "\n\n");
     if (parentId) {
       const parent = this.findItem(binder.items, parentId);
       if (parent) {
@@ -15355,15 +15331,14 @@ tags: [writing-studio]
     }
   }
   async logSprintSession(project, session) {
-    const logPath = (0, import_obsidian26.normalizePath)(`${project.folderPath}/_writing-log.json`);
+    const logPath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_writing-log.json`);
     let log = [];
-    const file = this.app.vault.getAbstractFileByPath(logPath);
-    if (file instanceof import_obsidian26.TFile) {
+    const content2 = await this.files.readText(logPath);
+    if (content2 !== null) {
       try {
-        const content2 = await this.app.vault.read(file);
         log = JSON.parse(content2);
       } catch (e) {
-        new import_obsidian26.Notice(t2("projectManager.corruptLog", { project: project.title }));
+        new import_obsidian25.Notice(t2("projectManager.corruptLog", { project: project.title }));
       }
     }
     log.push(session);
@@ -15374,36 +15349,20 @@ tags: [writing-studio]
     await this.writeJson(logPath, log);
   }
   async getWritingLog(project) {
-    const logPath = (0, import_obsidian26.normalizePath)(`${project.folderPath}/_writing-log.json`);
-    const file = this.app.vault.getAbstractFileByPath(logPath);
-    if (!(file instanceof import_obsidian26.TFile)) return [];
+    const logPath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_writing-log.json`);
     try {
-      const content2 = await this.app.vault.read(file);
-      return JSON.parse(content2);
+      const content2 = await this.files.readText(logPath);
+      return content2 === null ? [] : JSON.parse(content2);
     } catch (e) {
       return [];
     }
   }
   async initWritingLog(project) {
-    const logPath = (0, import_obsidian26.normalizePath)(`${project.folderPath}/_writing-log.json`);
+    const logPath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_writing-log.json`);
     await this.writeJson(logPath, []);
   }
   async writeJson(path, data) {
-    await this.writeRaw(path, JSON.stringify(data, null, 2));
-  }
-  async writeRaw(path, content2) {
-    const existing = this.app.vault.getAbstractFileByPath(path);
-    if (existing instanceof import_obsidian26.TFile) {
-      await this.app.vault.modify(existing, content2);
-    } else {
-      await this.app.vault.create(path, content2);
-    }
-  }
-  async ensureFolder(path) {
-    const existing = this.app.vault.getAbstractFileByPath(path);
-    if (!existing) {
-      await this.app.vault.createFolder(path);
-    }
+    await this.files.writeText(path, JSON.stringify(data, null, 2));
   }
   getProjects() {
     return Array.from(this.projects.values());
@@ -15457,7 +15416,7 @@ tags: [writing-studio]
 };
 
 // src/StatsTracker.ts
-var import_obsidian27 = require("obsidian");
+var import_obsidian26 = require("obsidian");
 var StatsTracker = class {
   constructor(plugin) {
     this.sessionBaselines = /* @__PURE__ */ new Map();
@@ -15514,7 +15473,7 @@ ${t2("statsTracker.dailyNote.heading")}
 - ${t2("statsTracker.dailyNote.sessionTotal")} ${t2("statsTracker.dailyNote.sessionTotalValue", { duration: session.duration })}
 `;
     const dailyFile = this.app.vault.getAbstractFileByPath(dailyNotePath);
-    if (dailyFile instanceof import_obsidian27.TFile) {
+    if (dailyFile instanceof import_obsidian26.TFile) {
       await this.app.vault.append(dailyFile, "\n" + entry);
       return;
     }
@@ -15528,7 +15487,7 @@ ${t2("statsTracker.dailyNote.heading")}
     const options = (_d = (_c = (_b2 = (_a2 = this.app.internalPlugins) == null ? void 0 : _a2.plugins) == null ? void 0 : _b2["daily-notes"]) == null ? void 0 : _c.instance) == null ? void 0 : _d.options;
     const fileName = moment().format((options == null ? void 0 : options.format) || "YYYY-MM-DD");
     const folder = (options == null ? void 0 : options.folder) || "";
-    return (0, import_obsidian27.normalizePath)(folder ? `${folder}/${fileName}.md` : `${fileName}.md`);
+    return (0, import_obsidian26.normalizePath)(folder ? `${folder}/${fileName}.md` : `${fileName}.md`);
   }
   updateFileWordCount(path, wordCount) {
     if (!this.sessionBaselines.has(path)) {
@@ -15567,7 +15526,7 @@ ${t2("statsTracker.dailyNote.heading")}
     const items = this.plugin.projectManager.flattenBinder(binder.items);
     const counts = await Promise.all(items.map(async (item) => {
       const file = this.app.vault.getAbstractFileByPath(item.filePath);
-      if (!(file instanceof import_obsidian27.TFile)) return 0;
+      if (!(file instanceof import_obsidian26.TFile)) return 0;
       const content2 = await this.app.vault.cachedRead(file);
       return this.plugin.fmManager.countWords(content2);
     }));
@@ -15649,7 +15608,7 @@ ${t2("statsTracker.dailyNote.heading")}
 };
 
 // src/FrontmatterManager.ts
-var import_obsidian28 = require("obsidian");
+var import_obsidian27 = require("obsidian");
 
 // src/words.ts
 function countWords(content2) {
@@ -15685,7 +15644,7 @@ var FrontmatterManager = class {
     if (file.extension !== "md") return false;
     const projectFolder = this.plugin.settings.defaultProjectFolder;
     if (!projectFolder) return false;
-    return file.path.startsWith((0, import_obsidian28.normalizePath)(projectFolder) + "/");
+    return file.path.startsWith((0, import_obsidian27.normalizePath)(projectFolder) + "/");
   }
   async updateFrontmatter(file) {
     this.writingFiles.add(file.path);
@@ -15716,7 +15675,7 @@ var FrontmatterManager = class {
 };
 
 // src/SettingsTab.ts
-var import_obsidian29 = require("obsidian");
+var import_obsidian28 = require("obsidian");
 
 // README.md
 var README_default = '<p align="center">\r\n  <img src="assets/logo.png" width="120" alt="Writing Studio logo">\r\n</p>\r\n\r\n# Writing Studio\r\n\r\n**Version 2.6.1** \xB7 Desktop only\r\n\r\n![GitHub all releases](https://img.shields.io/github/downloads/writerP-777/obsidian-writing-studio/total)\r\n[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12832/badge)](https://www.bestpractices.dev/projects/12832)\r\n\r\nWriting Studio turns Obsidian into a dedicated environment for serious nonfiction work \u2014 from your first research notes to a finished, exported manuscript. It bundles a project binder, writing modes, focus and typography tools, sprint timer, progress tracking, manuscript export, and WordPress publishing into a single plugin. A built-in sidebar file explorer lets you browse, preview, and pull content from anywhere in your vault without leaving your draft.\r\n\r\n<p align="center">\r\n  <img src="assets/sidebar-explorer-screenshot.png" alt="Writing Studio with the Launcher panel open on the left, an active draft in the center, and the Folder Sidebar Explorer open to a research folder on the right" width="900">\r\n  <br>\r\n  <em>Writing Studio in use \u2014 Launcher (left), active draft with word count goal banner (center), Folder Sidebar Explorer open to a research folder (right).</em>\r\n</p>\r\n\r\n<p align="center">\r\n  <a href="https://buymeacoffee.com/writerp777">\r\n    <img src="https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&slug=writerp777&button_colour=c9a84c&font_colour=000000&font_family=Georgia&outline_colour=000000&coffee_colour=ffffff" alt="Buy me a coffee" height="40">\r\n  </a>\r\n</p>\r\n\r\n## Contents\r\n\r\n- [Features](#features)\r\n- [Language support](#language-support)\r\n- [Writing Studio Launcher](#writing-studio-launcher)\r\n- [Folder Sidebar Explorer](#folder-sidebar-explorer)\r\n- [Your Project](#your-project)\r\n- [Your Writing Environment](#your-writing-environment)\r\n- [Tracking Your Progress](#tracking-your-progress)\r\n- [Getting Your Work Out](#getting-your-work-out)\r\n- [Supporting Tools](#supporting-tools)\r\n- [Context Menus](#context-menus)\r\n- [Commands Reference](#commands-reference)\r\n- [Settings Overview](#settings-overview)\r\n- [Ribbon Icon](#ribbon-icon)\r\n- [Installation](#installation)\r\n- [Requirements](#requirements)\r\n- [Reporting a Bug](#reporting-a-bug)\r\n- [Security](#security)\r\n\r\n---\r\n\r\n## Features\r\n\r\n**Writing Binder** \u2014 Organize your manuscript as an ordered collection of documents with per-item status, word count, and export flags. Drag chapters into order, toggle items in or out of export, and add files from anywhere in your vault.\r\n\r\n**Project Manager** \u2014 Create projects from six templates (blank, book, article series, blog collection, journal article, magazine article), set a total word count goal, and switch between projects from the Launcher.\r\n\r\n**Compile Preview** \u2014 Concatenate all binder documents in order and render them as a finished manuscript in a split pane, without exporting.\r\n\r\n**Writing Modes** \u2014 Switch between Draft (distraction-free), Edit (full tooling), and Review (read-only) modes from the status bar, command palette, context menu, or Launcher.\r\n\r\n**Focus Mode** \u2014 Dim everything except the paragraph or sentence you are writing. Configurable dim level, font size override, sidebar collapse, and typewriter scroll.\r\n\r\n**Typography Mode** \u2014 Apply a curated font, constrained line length, and controlled line height to the editor. Fourteen font options including iA Writer fonts, Google Fonts, and custom system fonts.\r\n\r\n**Sprint Timer** \u2014 Run timed writing sessions with a draggable floating overlay. Set duration, word goal, and scope (file or project). Quick-start presets (10 m, 15 m, 25 m) available from the Launcher.\r\n\r\n**Progress Tracking** \u2014 Live word counts in the status bar and Launcher, session delta tracking, per-document and per-project word count goals with inline progress banners, and a 30-day writing log with streak tracking.\r\n\r\n**Export Engine** \u2014 Export to Manuscript (HTML), PDF, Word (.docx), RTF, HTML, Markdown, and EPUB. Manuscript format produces industry-standard layout with no external tools; other formats require Pandoc.\r\n\r\n**WordPress Publishing** \u2014 Publish directly to WordPress from Obsidian. Set post title, status, categories, tags, excerpt, and scheduled date. Supports multiple sites with per-site credentials and connection testing.\r\n\r\n**Folder Sidebar Explorer** \u2014 Browse any vault folder in a sidebar panel. Search by name or file content, preview Markdown files and images inline, and insert selected text directly into the active editor.\r\n\r\n## Language support\r\n\r\nWriting Studio is available in the following languages in addition to English:\r\n\r\n- Arabic\r\n- Chinese (Simplified)\r\n- French\r\n- German\r\n- Japanese\r\n- Korean\r\n- Portuguese (Brazil)\r\n- Russian\r\n- Spanish\r\n\r\n**To change the language:** Open **Settings \u2192 General** in Obsidian, scroll to **Language**, and select your preferred language from the list. Restart Obsidian for the change to take effect. Writing Studio will display in the selected language if it is supported.\r\n\r\n**Found a translation error or missing text?** Please open an issue on GitHub \u2014 [Submit a bug report or enhancement request](https://github.com/writerP-777/obsidian-writing-studio/issues/new) \u2014 and include the language, the location in the plugin where the text appears, and what it currently says. We will address it in the next release.\r\n\r\n### Writing Studio Launcher\r\n\r\nThe Launcher is your home base in Writing Studio \u2014 a sidebar panel that shows your active project, progress toward your goals, and one-click access to every major feature.\r\n\r\nBy default it opens automatically when Obsidian loads. To disable this, turn off **Open on startup** in **Settings \u2192 General**.\r\n\r\n**To open manually:** Click the feather ribbon icon, or assign a hotkey to **Open launcher** in Settings \u2192 Hotkeys.\r\n\r\n**The Launcher includes:**\r\n- Active project name, total word count, and progress toward your project word count goal\r\n- Writing mode selector (Draft / Edit / Review)\r\n- Focus Mode and Typography Mode toggles\r\n- Sprint timer with "Set up sprint" button and Quick Sprint Options presets (10 m, 15 m, 25 m)\r\n- Today card showing words written, sprints completed, session word count, and streak\r\n- Quick-action buttons: Targets Dashboard, Writing Dashboard, Preview manuscript, Export, Writing Log, Publish to WordPress\r\n\r\n---\r\n\r\n### Folder Sidebar Explorer\r\n\r\nThe Folder Sidebar Explorer opens any vault folder in a right-sidebar panel, letting you browse reference material, research notes, or any folder outside your active project without leaving your draft. Unlike the Binder \u2014 which is scoped to your writing project \u2014 the sidebar explorer works with any folder in your vault.\r\n\r\n**To open:**\r\n- Use the command **Open folder in sidebar explorer** from the command palette \u2014 a folder picker appears so you can choose which folder to explore.\r\n- Right-click any folder in the file explorer and choose **Open in sidebar explorer** under **Writing studio options**.\r\n- Right-click any folder in [Notebook Navigator](https://github.com/johansan/notebook-navigator) and choose **Open in sidebar explorer** (requires Notebook Navigator to be installed).\r\n- Assign a hotkey in Settings \u2192 Hotkeys.\r\n\r\nThe panel opens in the **right sidebar**. The folder you open becomes the **root folder** for that session \u2014 the breadcrumb trail, the \u2302 root button, and search all operate relative to it.\r\n\r\n**Browsing and navigation:**\r\n\r\n| Feature | How to use |\r\n|---------|-----------|\r\n| Browse into a subfolder | Click the folder |\r\n| Preview a Markdown file | Click the file \u2014 the folder listing is replaced by a rendered preview inside the panel |\r\n| Preview an image | Click the file \u2014 displayed inline |\r\n| Preview audio | Click the file \u2014 player appears inline |\r\n| Other file types | Click the file \u2014 an **Open in editor** button appears |\r\n| Go back | Click **\u2190 back**, or press `Backspace` when the list has keyboard focus |\r\n| Return to root folder | Click **\u2302 root** to jump back to the folder you originally opened |\r\n| Keyboard navigation | Tab to focus the list, then `\u2191` / `\u2193` to move, `Enter` to open, `Backspace` to go back |\r\n| Breadcrumb navigation | Click any segment in the breadcrumb trail to jump directly to that folder |\r\n\r\n**Search:**\r\n\r\nA search bar appears at the top of the folder list. Type your query and press **Enter** to run the search.\r\n\r\n- Searches **both folder/file names and file contents** (`.md` and `.txt` files).\r\n- Frontmatter is excluded from content search to avoid false positives from YAML fields.\r\n- Name matches show the matched term highlighted in the result title.\r\n- Content matches show a text snippet around the match with the term highlighted, plus a **CONTENT** badge to distinguish them from name matches.\r\n- Results always search from the root folder, regardless of which subfolder you are currently browsing.\r\n- Click **\xD7** to clear the search and return to the normal folder view.\r\n\r\n**Sort:**\r\n\r\nA sort dropdown sits next to the search bar. Options:\r\n\r\n| Option | Description |\r\n|--------|-------------|\r\n| Folders \u2191 A-Z | Folders first, then files, both alphabetical (default) |\r\n| Folders \u2191 Z-A | Folders first, then files, both reverse-alphabetical |\r\n| Name A-Z | All items alphabetical, folders and files mixed |\r\n| Name Z-A | All items reverse-alphabetical, mixed |\r\n| Newest first | Sort by last-modified date, newest at top |\r\n| Oldest first | Sort by last-modified date, oldest at top |\r\n\r\n**Copy content to the editor:**\r\n\r\nWhen a Markdown file is open in preview mode (after clicking it in the file list), its text is selectable. To insert a passage into the active editor:\r\n\r\n1. Click a file in the list \u2014 the panel switches to preview mode showing the rendered file.\r\n2. Select the text you want in the preview pane.\r\n3. Click the **\u21A9 insert selection** button in the nav bar.\r\n4. The selected text is inserted at the cursor position in the active editor.\r\n\r\nThe preview is read-only \u2014 you cannot edit the file from the sidebar.\r\n\r\n**Hover tooltips:**\r\n\r\nHover over any file or folder in the list to see an information card:\r\n\r\n| Item type | Information shown |\r\n|-----------|------------------|\r\n| Markdown / text file | Last modified date and time \xB7 File size \xB7 Word count (frontmatter excluded) |\r\n| Image / audio / other file | Last modified date and time \xB7 File size |\r\n| Folder | Total file count \xB7 Subfolder count |\r\n\r\nThe word count updates asynchronously from Obsidian\'s file cache and appears within a moment of hover.\r\n\r\n---\r\n\r\n### Your Project\r\n\r\n#### Project Manager\r\n\r\nProjects group a set of documents (binder items) and act as the scope for export, statistics, and the word count goal banner.\r\n\r\n**To create a project:** Use the command **New writing project** from the command palette, or click **+ New** in the Launcher panel.\r\n\r\n**To switch projects:** Use the Launcher panel or the project selector at the top of the Binder panel.\r\n\r\nEach project stores:\r\n- Title, type, author, and description\r\n- Ordered binder with chapters, sections, articles, and notes\r\n- Per-item word count goals, statuses, and export flags\r\n- Optional total word count goal (shown in the Launcher and status bar)\r\n\r\n**Project templates available at creation:**\r\n\r\n| Template | Structure created |\r\n|----------|------------------|\r\n| Blank | Empty \u2014 build your own structure |\r\n| Book | Front Matter, Part 1 / Chapter 1, Back Matter |\r\n| Article series | Series folder, Article 1 placeholder, series metadata |\r\n| Blog collection | Date-organized folder, first post placeholder |\r\n| Journal article | Title Page, Abstract, Keywords, Introduction, Literature Review, Methodology, Findings / Analysis, Discussion, Conclusion, References, Appendices |\r\n| Magazine article | Pitch / Query Notes, Headline & Deck, Lede, Nut Graf, Body, Quotes & Sources, Kicker, Fact-Check Notes, Author Bio |\r\n\r\n---\r\n\r\n#### Writing Binder\r\n\r\nKeeping a book-length manuscript organized means knowing at a glance which chapters are drafted, which are in progress, and how each contributes to your total word count. The Binder is a sidebar panel that shows all of that for your active project.\r\n\r\nEach document shows its title, type (Chapter, Section, Article, Note), status (Draft, In Progress, Complete), and live word count. Documents can be reordered by drag-and-drop and toggled in or out of export.\r\n\r\n**To open:** Use the command **Open binder** from the command palette, or assign a hotkey in Settings \u2192 Hotkeys.\r\n\r\n**Adding a file to a project:**\r\n1. Right-click any Markdown file in the file explorer and choose **Add to writing project** under **Writing studio options**.\r\n2. A modal appears with a dropdown listing all your writing projects.\r\n3. Select the target project and click **Add to project**.\r\n\r\n**Adding files copied directly to the project folder:**\r\n\r\nIf you copied or moved files into the project folder outside of Obsidian and they do not appear in the binder, use the **Add files copied to this folder** button in the binder toolbar (immediately to the right of the **+ document** button). The plugin scans the project folder, lists any files not yet in the binder, and lets you select which ones to add before making any changes.\r\n\r\n---\r\n\r\n#### Compile Preview\r\n\r\nThe Compile Preview opens a split pane showing all binder documents for the active project concatenated in order, rendered as a finished manuscript.\r\n\r\n**To open:** Use the command **Preview compiled manuscript** from the command palette, or click the **Preview manuscript** button in the Launcher panel.\r\n\r\n---\r\n\r\n### Your Writing Environment\r\n\r\n#### Writing Modes\r\n\r\nThree modes shape how the editor behaves. The current mode is always shown in the status bar. Click the mode pill in the status bar to switch modes.\r\n\r\n| Mode | Purpose |\r\n|------|---------|\r\n| **Draft** | Distraction-free drafting; spell-check and formatting hints suppressed |\r\n| **Edit** | Revision pass; full editor tooling active |\r\n| **Review** | Read-only style; ideal for a final proofread |\r\n| **None** | Normal Obsidian behavior |\r\n\r\n**To switch modes:**\r\n- Click the mode indicator in the status bar.\r\n- Right-click inside the editor, then choose **Switch writing mode \u2192** under **Writing studio options**.\r\n- Assign hotkeys to **Switch to draft mode / Edit mode / Review mode** in Settings \u2192 Hotkeys.\r\n- Use the Writing Studio Launcher panel.\r\n\r\nThe active mode persists across Obsidian restarts.\r\n\r\n---\r\n\r\n#### Focus Mode\r\n\r\nFocus Mode dims everything in the editor except the paragraph or sentence you are currently writing, reducing visual noise and keeping attention on the active thought.\r\n\r\n**To toggle:** Assign a hotkey to **Toggle focus mode** in Settings \u2192 Hotkeys, or use the toggle in the Launcher panel. Press `Escape` to exit.\r\n\r\n**Settings (Settings \u2192 Focus mode):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Focus unit | Highlight at the **paragraph** or **sentence (line)** level |\r\n| Dim opacity | How opaque the dimmed text appears (10\u201350%) |\r\n| Font size override | Override the editor font size while focused; 0 = use theme default. Takes precedence over Typography Mode\'s font size while Focus Mode is active |\r\n| Auto-hide sidebars | Collapse left and right sidebars when Focus Mode activates |\r\n| Typewriter scroll | Keep the active line vertically centered as you type |\r\n\r\n---\r\n\r\n#### Typography Mode\r\n\r\nTypography Mode applies a consistent, reader-friendly text treatment to the editor: a curated font, constrained line length, controlled line height, and optional letter spacing.\r\n\r\n**To toggle:** Assign a hotkey to **Toggle typography mode** in Settings \u2192 Hotkeys, or use the toggle in the Launcher panel.\r\n\r\n**To change the font while Typography Mode is active:** Right-click inside the editor and choose **Typography font \u2192** under **Writing studio options**. A font picker menu appears with all available fonts; the active font is shown with a checkmark. Selecting a font applies it immediately and saves the setting.\r\n\r\n> **Note on fonts:** Typography fonts are loaded from Google Fonts and require an internet connection the first time each font is used. After the initial load they are cached and work offline.\r\n\r\n**Settings (Settings \u2192 Typography):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Font family | Choose from the curated font list or enter a custom font name |\r\n| Custom font name | Used when **Custom font name\u2026** is selected above |\r\n| Max line length | Characters per line (55\u201380); constrains the editor column width |\r\n| Font size | Editor font size in pixels |\r\n| Line height | Multiplier; default 1.7 |\r\n| Letter spacing | CSS `letter-spacing` value (e.g. `normal`, `0.02em`) |\r\n| Persist across sessions | Keep Typography Mode active when Obsidian reopens |\r\n\r\n**Available fonts:**\r\n\r\n| Option | Font |\r\n|--------|------|\r\n| Monospaced | iA Writer Mono (falls back to Roboto Mono / Courier New) |\r\n| Serif | iA Writer Duo Serif (falls back to Georgia) |\r\n| Sans-serif | iA Writer Quattro (falls back to system sans-serif) |\r\n| Cormorant Garamond | Elegant display serif |\r\n| Crimson Text | Classic book serif |\r\n| EB Garamond | Traditional Garamond revival |\r\n| Libre Baskerville | Readable web serif |\r\n| Libre Caslon Text | Clean slab serif |\r\n| Literata | Designed for long-form reading |\r\n| Lora | Contemporary calligraphic serif |\r\n| Inter | Modern humanist sans-serif |\r\n| Lato | Friendly rounded sans-serif |\r\n| Source Sans 3 | Clean UI sans-serif |\r\n| Custom font name\u2026 | Use any font installed on your system |\r\n\r\n---\r\n\r\n### Tracking Your Progress\r\n\r\n#### Writing Sprint Timer\r\n\r\nThe Sprint Timer runs a timed writing session. When a sprint is active, a floating overlay displays the countdown and gives you full control \u2014 without requiring you to stay on the dashboard.\r\n\r\n**To set up a sprint:**\r\n\r\n- Click **Set up sprint** in the Launcher panel to open the sprint configuration modal.\r\n- Or click one of the **Quick Sprint Options** preset buttons (10 m, 15 m, 25 m) in the Launcher panel to load a duration directly.\r\n\r\nEither path opens the floating overlay in a ready state \u2014 the timer does not start until you press \u25B6 on the overlay itself. This gives you time to navigate to your draft or open the Binder before the clock begins.\r\n\r\n**Sprint configuration modal:**\r\n\r\nThe modal lets you set:\r\n\r\n- Duration (preset or custom, in minutes)\r\n- Word count goal for the session\r\n- Scope (current file or entire project)\r\n\r\nClick **Launch sprint timer** to open the overlay in ready state.\r\n\r\n**Using the floating overlay:**\r\n\r\n| Control | Action |\r\n|---------|--------|\r\n| \u25B6 | Start or resume the sprint |\r\n| \u23F8 | Pause the sprint |\r\n| \u25A0 | Stop and end the sprint |\r\n\r\nThe overlay is draggable \u2014 click and drag the header to reposition it anywhere on screen. It stays on top regardless of writing mode or Focus Mode. The current countdown is also shown in the Obsidian status bar (`\u23F1 MM:SS`) and, when Focus Mode is active, in the focus toolbar.\r\n\r\nWhen the sprint ends, a summary modal shows words written, duration, and words-per-minute. The session is logged to sprint history and optionally appended to your Daily Note.\r\n\r\n**Settings (Settings \u2192 Sprint & goals):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Default sprint duration | Starting value in the sprint modal (minutes) |\r\n| Default daily word goal | Target used in the Writing Dashboard and Launcher |\r\n| Sound notifications | Play a tone when the sprint ends |\r\n| Sprint history retention | Days to keep sprint records before purging |\r\n| Inline goal banner | Show a progress bar below the editor toolbar when a document has a word count goal set |\r\n\r\n---\r\n\r\n#### Word Count Goal\r\n\r\nA per-document word count goal can be set and tracked inline.\r\n\r\n**To set a goal:**\r\n- Use the command **Set word count goal** from the command palette.\r\n- Right-click inside the editor and choose **Set word count goal** under **Writing studio options**.\r\n\r\nWhen a goal is set and **Inline goal banner** is enabled, a progress bar appears below the editor toolbar showing current words, goal, and percentage. It updates in real time as you type.\r\n\r\n---\r\n\r\n#### Session Word Count\r\n\r\nThe status bar shows a `(+N)` delta next to the current file\'s word count, indicating how many words you have added since opening that file this session. The Launcher\'s **Today** card also shows a cumulative session total across all files opened during the current Obsidian session. Both counts reset when Obsidian restarts.\r\n\r\n---\r\n\r\n#### Project Word Count Goal\r\n\r\nWhen an active project has a total word count goal set, a dedicated status bar item shows `{current} / {goal} project words`. This updates automatically as you write. Set a project goal in the Project modal when creating or editing a project.\r\n\r\n---\r\n\r\n#### Writing Dashboard\r\n\r\nThe Writing Dashboard shows session statistics (words written, sprints completed, time), sprint history, daily progress toward your goal, and per-project word counts with reading time.\r\n\r\n**To open:** Use the command **Open writing dashboard** from the command palette, or click the **Writing dashboard** button in the Launcher panel.\r\n\r\n---\r\n\r\n#### Targets Dashboard\r\n\r\nThe Targets Dashboard lets you assign word count goals to individual documents in the active project\'s binder and track progress across the whole project at a glance. Goals can be edited inline in the table. Rows are sortable and filterable by status.\r\n\r\n**To open:** Use the command **Open targets dashboard**, click the **Targets dashboard** button in the Launcher panel, or assign a hotkey in Settings \u2192 Hotkeys.\r\n\r\n---\r\n\r\n#### Daily Writing Log\r\n\r\nThe Writing Log is a sidebar panel that shows your writing history at a glance.\r\n\r\n**To open:** Use the command **Open writing log** from the command palette, or click the **Writing log** button in the Launcher panel.\r\n\r\n**The Writing Log shows:**\r\n- Current streak (days in a row with at least one sprint)\r\n- This session: total session words, sprint words, sprints completed, and minutes written\r\n- Last 30 days: a bar chart with one row per day showing word count, sprints completed, and a visual bar proportional to the day\'s output\r\n\r\nWhen **Append to daily note** is enabled (Settings \u2192 Writing log), a summary of each completed sprint is also appended to today\'s Daily Note.\r\n\r\n---\r\n\r\n### Getting Your Work Out\r\n\r\n#### Export Engine\r\n\r\nWhen your draft is ready, the Export Engine converts it to a finished file in your chosen format \u2014 no reformatting required.\r\n\r\n**Supported formats:** Manuscript (HTML) \xB7 PDF \xB7 Word (.docx) \xB7 RTF \xB7 HTML \xB7 Markdown \xB7 EPUB\r\n\r\n**To export:**\r\n- Right-click inside the editor and choose **Export this document** under **Writing studio options**.\r\n- Use the command **Export document** from the command palette.\r\n- Click the **Export** button in the Launcher panel.\r\n- Assign a hotkey to **Export document** in Settings \u2192 Hotkeys.\r\n\r\n**Manuscript format**\r\n\r\nThe Manuscript format produces a self-contained HTML file formatted to industry-standard manuscript conventions:\r\n- Courier New 12 pt, double-spaced, 1-inch margins\r\n- Title page with project title, author name, approximate word count, and optional contact information\r\n- Chapter headings in uppercase, page-break before each\r\n- Scene breaks rendered as `#` (the standard manuscript convention)\r\n\r\nNo external tools are required for manuscript export.\r\n\r\n**Settings (Settings \u2192 Export):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Default export format | Pre-selected format in the export modal |\r\n| Default paper size | Letter (US) or A4 |\r\n| Export font | Font name used in PDF/DOCX output (e.g. `Georgia`) |\r\n| Export font size | Point size for PDF/DOCX output |\r\n| Pandoc path | Full path to the `pandoc` binary if it is not on your system PATH |\r\n| EPUB language | BCP 47 language tag (e.g. `en`, `fr`, `de`) |\r\n| EPUB include cover | Generate a text cover page when no cover image is provided |\r\n\r\n> **Requirement:** Pandoc must be installed for PDF, DOCX, RTF, HTML, and EPUB export. Download from [pandoc.org](https://pandoc.org/installing.html). For PDF export, a LaTeX distribution (e.g. TeX Live or MiKTeX) is also required. Manuscript (HTML) export does not require Pandoc.\r\n>\r\n> **Formatting note:** the built-in converter used for HTML, Manuscript, and EPUB output supports headings, paragraphs, lists, blockquotes, fenced code blocks, tables, images, and links. Nested lists, setext (underline-style) headings, and footnotes are not converted \u2014 use a Pandoc format (PDF, DOCX, RTF) if your manuscript depends on them.\r\n\r\n---\r\n\r\n#### WordPress Publishing\r\n\r\nPublish your finished draft directly to WordPress without leaving Obsidian. The modal lets you choose the target site, set the post title, status, categories, tags, excerpt, and an optional scheduled publication date.\r\n\r\n**To publish:**\r\n- Right-click inside the editor and choose **Publish to WordPress** under **Writing studio options**.\r\n- Use the command **Publish to wordpress** from the command palette.\r\n- Click the **Publish to WordPress** button in the Launcher panel.\r\n- Assign a hotkey to **Publish to wordpress** in Settings \u2192 Hotkeys.\r\n\r\n**Setting up a site (Settings \u2192 WordPress):**\r\n\r\n1. Click **+ add WordPress site**.\r\n2. Enter a nickname, the site URL (e.g. `https://yourblog.com`), and your WordPress username.\r\n3. Generate an application password in WordPress under **Users \u2192 Profile \u2192 Application passwords** and paste it into the **Application password** field.\r\n4. Click **Test connection** to verify.\r\n\r\n**Per-site options:**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Default post status | Draft \xB7 Pending Review \xB7 Published |\r\n| Wikilink handling | **Strip** removes `[[...]]` syntax, leaving plain text \xB7 **Convert** turns wikilinks into URLs |\r\n\r\n**Preserving your credentials across updates**\r\n\r\nWriting Studio stores your WordPress site credentials in your vault\'s `.obsidian/plugins/writing-studio/data.json` file. Obsidian\'s in-app update process does not touch this file \u2014 your credentials are preserved automatically. However, if you uninstall and reinstall the plugin manually, or if a vault sync conflict overwrites `data.json`, credentials will be lost and will need to be re-entered. To avoid this, always use Obsidian\'s built-in Update button rather than uninstalling manually.\r\n\r\n---\r\n\r\n### Supporting Tools\r\n\r\n#### Frontmatter Manager\r\n\r\nWriting Studio automatically manages YAML frontmatter in your documents when **Frontmatter auto-update** is enabled. On every save it updates:\r\n\r\n- `word-count` \u2014 current word count\r\n- `modified` \u2014 last-modified date\r\n\r\nThe `word-count-goal` frontmatter field is read by the inline goal banner and the Word Count Goal modal.\r\n\r\n---\r\n\r\n## Context Menus\r\n\r\nWriting Studio adds items to Obsidian\'s right-click context menus. All Writing Studio items are grouped together under the heading **Writing studio options** to distinguish them from other plugins and Obsidian\'s built-in options.\r\n\r\n### Right-click inside an open document (editor menu)\r\n\r\n| Option | Action |\r\n|--------|--------|\r\n| Export this document | Open the export modal for the current file |\r\n| Publish to WordPress | Open the WordPress publish modal for the current file |\r\n| Set word count goal | Set a word count target for the current document |\r\n| Switch writing mode \u2192 | Open a mode-switcher menu (Draft / Edit / Review / None) |\r\n| Typography font \u2192 | Open a font picker menu to change the typography font (visible only when Typography Mode is active) |\r\n\r\n### Right-click a Markdown file in the file explorer\r\n\r\n| Option | Action |\r\n|--------|--------|\r\n| Add to writing project | Open a project picker and add the file to the selected project |\r\n\r\n### Right-click a folder in the file explorer\r\n\r\n| Option | Action |\r\n|--------|--------|\r\n| Open in sidebar explorer | Open the folder in the Folder Sidebar Explorer panel |\r\n\r\n---\r\n\r\n## Commands Reference\r\n\r\nNo default hotkeys are assigned. All commands can be given a hotkey in **Settings \u2192 Hotkeys**.\r\n\r\n| Command | Description |\r\n|---------|-------------|\r\n| Open launcher | Open the launcher sidebar panel |\r\n| Open binder | Open the writing binder sidebar panel |\r\n| Open writing log | Open the daily writing log panel |\r\n| Toggle focus mode | Enable or disable focus mode |\r\n| Toggle typography mode | Enable or disable typography mode |\r\n| Switch to draft mode | Activate draft writing mode |\r\n| Switch to edit mode | Activate edit writing mode |\r\n| Switch to review mode | Activate review writing mode |\r\n| Start writing sprint | Open the sprint timer modal |\r\n| Export document | Export the current document |\r\n| Export project | Export the full project |\r\n| Preview compiled manuscript | Open the compile preview pane |\r\n| Publish to wordpress | Publish the current document to WordPress |\r\n| New writing project | Create a new writing project |\r\n| Open writing dashboard | Open the statistics dashboard |\r\n| Open targets dashboard | Open the word count targets panel |\r\n| Set word count goal | Set a per-document word count goal |\r\n| Open folder in sidebar explorer | Search and open a vault folder in the sidebar |\r\n| Add files copied to project folder | Scan the active project folder for files not in the binder and import selected files |\r\n\r\n---\r\n\r\n## Settings Overview\r\n\r\nOpen via **Settings \u2192 Writing Studio**.\r\n\r\n| Tab | What it controls |\r\n|-----|-----------------|\r\n| General | Open on startup, default project folder, author name, document type, frontmatter auto-update |\r\n| Focus mode | Focus unit, dim opacity, font override, sidebar behavior, typewriter scroll |\r\n| Typography | Font family, custom font name, line length, font size, line height, letter spacing, persistence |\r\n| Sprint & goals | Sprint duration, daily goal, sound notifications, history retention, inline banner |\r\n| Export | Format, paper size, font, font size, Pandoc path, EPUB language, EPUB cover |\r\n| Writing log | Append sprint summaries to Daily Note |\r\n| WordPress | Site credentials, default post status, wikilink handling |\r\n\r\n---\r\n\r\n## Ribbon Icon\r\n\r\nWriting Studio adds a single icon to the Obsidian ribbon.\r\n\r\n| Icon | Action |\r\n|------|--------|\r\n| Feather | Open the Writing Studio Launcher panel |\r\n\r\nAll other features are accessible from the Launcher panel, the command palette, context menus, or assigned hotkeys.\r\n\r\n---\r\n\r\n## Installation\r\n\r\n1. Download `main.js`, `manifest.json`, and `styles.css` from the latest [GitHub release](../../releases/latest).\r\n2. Create the folder `<vault>/.obsidian/plugins/obsidian-writing-studio/` if it does not exist.\r\n3. Copy the three files into that folder.\r\n4. In Obsidian, go to **Settings \u2192 Community Plugins**, find **Writing Studio**, and enable it.\r\n\r\n> **Building from source:** Clone the repository, run `npm install`, then `npm run build`. Copy the three output files as above.\r\n\r\n---\r\n\r\n## Requirements\r\n\r\nMost features work out of the box. A few require additional software for specific functions, noted below.\r\n\r\n| Requirement | When needed |\r\n|-------------|-------------|\r\n| Obsidian 1.7.2 or later | Always |\r\n| Desktop (Windows, macOS, Linux) | Always \u2014 this plugin does not run on mobile |\r\n| Internet connection | First use of each Typography Mode font (cached after that) |\r\n| [Pandoc](https://pandoc.org/installing.html) | Export to PDF, DOCX, RTF, HTML, EPUB |\r\n| LaTeX (TeX Live / MiKTeX) | Export to PDF only |\r\n| WordPress 5.6+ with REST API enabled | WordPress publishing |\r\n| WordPress Application Password | WordPress publishing |\r\n\r\n---\r\n\r\n## Reporting a Bug\r\n\r\nIf something isn\'t working, please open an issue on GitHub:\r\n\r\n**[Submit a bug report](https://github.com/writerP-777/obsidian-writing-studio/issues/new)**\r\n\r\nInclude the following when you report:\r\n\r\n- Writing Studio version (visible in **Settings \u2192 Community Plugins**)\r\n- Obsidian version (visible in **Settings \u2192 About**)\r\n- Operating system (Windows / macOS / Linux) and version\r\n- What you expected to happen\r\n- What actually happened, and any steps to reproduce it\r\n\r\nFeature requests are welcome in the same place \u2014 please label them as **[Feature Request]** in the issue title.\r\n\r\n---\r\n\r\n## Security\r\n\r\n[![CodeQL](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml)\r\n[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/writerP-777/obsidian-writing-studio/badge)](https://securityscorecards.dev/viewer/?uri=github.com/writerP-777/obsidian-writing-studio)\r\n[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12832/baseline)](https://www.bestpractices.dev/projects/12832)\r\n[![ESLint](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml)\r\n[![ORCID](https://img.shields.io/badge/ORCID-0009--0009--8598--2069-brightgreen?logo=orcid&logoColor=white)](https://orcid.org/0009-0009-8598-2069)\r\n\r\nEvery push and pull request is scanned automatically:\r\n\r\n| Tool | What it checks |\r\n|------|----------------|\r\n| **CodeQL** | Static analysis for security vulnerabilities (XSS, injection, unsafe patterns) in TypeScript/JavaScript source |\r\n| **OpenSSF Scorecard** | Supply-chain security posture: dependency hygiene, branch protection, signed releases, and more |\r\n| **ESLint** (`eslint-plugin-obsidianmd`) | Obsidian plugin guideline compliance \u2014 fails on any warning or error |\r\n\r\nResults are published to the **Security** tab of this repository (GitHub code scanning).\r\n\r\nFor local development, a pre-commit hook runs ESLint (blocking) and a pre-push hook runs a full CodeQL scan (blocks the push if any HIGH or CRITICAL findings are present). Install the [CodeQL CLI](https://github.com/github/codeql-cli-binaries/releases) to enable local scanning (`winget install GitHub.CodeQL` on Windows).\r\n';
@@ -15730,7 +15689,7 @@ content = content.replace(/^!\[[^\]]*\]\((?!https?:\/\/)[^)]*\)[ \t]*$/gm, "");
 var HELP_CONTENT = content;
 
 // src/SettingsTab.ts
-var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab {
+var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab {
   constructor(app, plugin) {
     super(app, plugin);
     this.activeTab = "general";
@@ -15815,57 +15774,57 @@ var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab 
     }
   }
   renderGeneral(el) {
-    new import_obsidian29.Setting(el).setName(t2("settings.general.openOnStartup")).setDesc(t2("settings.general.openOnStartupDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.openOnStartup).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.general.openOnStartup")).setDesc(t2("settings.general.openOnStartupDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.openOnStartup).onChange(async (v) => {
       this.plugin.settings.openOnStartup = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.general.defaultProjectFolder")).setDesc(t2("settings.general.defaultProjectFolderDesc")).addText((text) => text.setPlaceholder(t2("settings.general.defaultProjectFolderPlaceholder")).setValue(this.plugin.settings.defaultProjectFolder).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.general.defaultProjectFolder")).setDesc(t2("settings.general.defaultProjectFolderDesc")).addText((text) => text.setPlaceholder(t2("settings.general.defaultProjectFolderPlaceholder")).setValue(this.plugin.settings.defaultProjectFolder).onChange(async (v) => {
       this.plugin.settings.defaultProjectFolder = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.general.authorName")).setDesc(t2("settings.general.authorNameDesc")).addText((text) => text.setPlaceholder(t2("settings.general.authorNamePlaceholder")).setValue(this.plugin.settings.authorName).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.general.authorName")).setDesc(t2("settings.general.authorNameDesc")).addText((text) => text.setPlaceholder(t2("settings.general.authorNamePlaceholder")).setValue(this.plugin.settings.authorName).onChange(async (v) => {
       this.plugin.settings.authorName = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.general.defaultDocumentType")).addDropdown((d) => d.addOption("chapter", t2("settings.general.docType.chapter")).addOption("section", t2("settings.general.docType.section")).addOption("article", t2("settings.general.docType.article")).addOption("note", t2("settings.general.docType.note")).setValue(this.plugin.settings.defaultDocumentType).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.general.defaultDocumentType")).addDropdown((d) => d.addOption("chapter", t2("settings.general.docType.chapter")).addOption("section", t2("settings.general.docType.section")).addOption("article", t2("settings.general.docType.article")).addOption("note", t2("settings.general.docType.note")).setValue(this.plugin.settings.defaultDocumentType).onChange(async (v) => {
       this.plugin.settings.defaultDocumentType = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.general.frontmatterAutoUpdate")).setDesc(t2("settings.general.frontmatterAutoUpdateDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.frontmatterAutoUpdate).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.general.frontmatterAutoUpdate")).setDesc(t2("settings.general.frontmatterAutoUpdateDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.frontmatterAutoUpdate).onChange(async (v) => {
       this.plugin.settings.frontmatterAutoUpdate = v;
       await this.plugin.saveSettings();
     }));
   }
   renderFocusMode(el) {
-    new import_obsidian29.Setting(el).setName(t2("settings.focus.heading")).setHeading();
-    new import_obsidian29.Setting(el).setName(t2("settings.focus.focusUnit")).setDesc(t2("settings.focus.focusUnitDesc")).addDropdown((d) => d.addOption("paragraph", t2("settings.focus.paragraph")).addOption("sentence", t2("settings.focus.sentence")).setValue(this.plugin.settings.focusUnit).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.focus.heading")).setHeading();
+    new import_obsidian28.Setting(el).setName(t2("settings.focus.focusUnit")).setDesc(t2("settings.focus.focusUnitDesc")).addDropdown((d) => d.addOption("paragraph", t2("settings.focus.paragraph")).addOption("sentence", t2("settings.focus.sentence")).setValue(this.plugin.settings.focusUnit).onChange(async (v) => {
       this.plugin.settings.focusUnit = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.focus.dimOpacity")).setDesc(t2("settings.focus.dimOpacityDesc")).addSlider((s) => s.setLimits(10, 50, 5).setValue(this.plugin.settings.dimOpacity).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.focus.dimOpacity")).setDesc(t2("settings.focus.dimOpacityDesc")).addSlider((s) => s.setLimits(10, 50, 5).setValue(this.plugin.settings.dimOpacity).onChange(async (v) => {
       this.plugin.settings.dimOpacity = v;
       await this.plugin.saveSettings();
       this.plugin.focusMode.applyDimOpacity();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.focus.fontSizeOverride")).setDesc(t2("settings.focus.fontSizeOverrideDesc")).addText((text) => text.setValue(String(this.plugin.settings.focusFontSize || 0)).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.focus.fontSizeOverride")).setDesc(t2("settings.focus.fontSizeOverrideDesc")).addText((text) => text.setValue(String(this.plugin.settings.focusFontSize || 0)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n !== 0 && (n < 8 || n > 72)) return;
       this.plugin.settings.focusFontSize = n;
       await this.plugin.saveSettings();
       this.plugin.focusMode.applyFontSize();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.focus.autoHideSidebars")).addToggle((toggle) => toggle.setValue(this.plugin.settings.focusAutoHideSidebars).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.focus.autoHideSidebars")).addToggle((toggle) => toggle.setValue(this.plugin.settings.focusAutoHideSidebars).onChange(async (v) => {
       this.plugin.settings.focusAutoHideSidebars = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.focus.typewriterScroll")).setDesc(t2("settings.focus.typewriterScrollDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.typewriterScroll).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.focus.typewriterScroll")).setDesc(t2("settings.focus.typewriterScrollDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.typewriterScroll).onChange(async (v) => {
       this.plugin.settings.typewriterScroll = v;
       await this.plugin.saveSettings();
     }));
   }
   renderTypography(el) {
-    new import_obsidian29.Setting(el).setName(t2("settings.typography.heading")).setHeading();
-    new import_obsidian29.Setting(el).setName(t2("settings.typography.fontFamily")).addDropdown((d) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.typography.heading")).setHeading();
+    new import_obsidian28.Setting(el).setName(t2("settings.typography.fontFamily")).addDropdown((d) => {
       d.addOption("mono", t2("settings.typography.font.mono"));
       d.addOption("serif", t2("settings.typography.font.serif"));
       d.addOption("sans", t2("settings.typography.font.sans"));
@@ -15887,110 +15846,110 @@ var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab 
         if (this.plugin.typographyMode.isActive()) this.plugin.typographyMode.refreshStyles();
       });
     });
-    new import_obsidian29.Setting(el).setName(t2("settings.typography.customFontName")).setDesc(t2("settings.typography.customFontNameDesc")).addText((text) => text.setPlaceholder(t2("settings.typography.customFontNamePlaceholder")).setValue(this.plugin.settings.customFontName).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.typography.customFontName")).setDesc(t2("settings.typography.customFontNameDesc")).addText((text) => text.setPlaceholder(t2("settings.typography.customFontNamePlaceholder")).setValue(this.plugin.settings.customFontName).onChange(async (v) => {
       this.plugin.settings.customFontName = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.typography.maxLineLength")).setDesc(t2("settings.typography.maxLineLengthDesc")).addSlider((s) => s.setLimits(55, 80, 1).setValue(this.plugin.settings.maxLineLength).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.typography.maxLineLength")).setDesc(t2("settings.typography.maxLineLengthDesc")).addSlider((s) => s.setLimits(55, 80, 1).setValue(this.plugin.settings.maxLineLength).onChange(async (v) => {
       this.plugin.settings.maxLineLength = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.typography.fontSize")).addText((text) => text.setValue(String(this.plugin.settings.typographyFontSize)).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.typography.fontSize")).addText((text) => text.setValue(String(this.plugin.settings.typographyFontSize)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 8 || n > 72) return;
       this.plugin.settings.typographyFontSize = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.typography.lineHeight")).setDesc(t2("settings.typography.lineHeightDesc")).addText((text) => text.setValue(String(this.plugin.settings.lineHeight)).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.typography.lineHeight")).setDesc(t2("settings.typography.lineHeightDesc")).addText((text) => text.setValue(String(this.plugin.settings.lineHeight)).onChange(async (v) => {
       this.plugin.settings.lineHeight = parseFloat(v) || 1.7;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.typography.letterSpacing")).setDesc(t2("settings.typography.letterSpacingDesc")).addText((text) => text.setValue(this.plugin.settings.letterSpacing).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.typography.letterSpacing")).setDesc(t2("settings.typography.letterSpacingDesc")).addText((text) => text.setValue(this.plugin.settings.letterSpacing).onChange(async (v) => {
       this.plugin.settings.letterSpacing = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.typography.persistAcrossSessions")).setDesc(t2("settings.typography.persistAcrossSessionsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.persistTypography).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.typography.persistAcrossSessions")).setDesc(t2("settings.typography.persistAcrossSessionsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.persistTypography).onChange(async (v) => {
       this.plugin.settings.persistTypography = v;
       await this.plugin.saveSettings();
     }));
   }
   renderSprint(el) {
-    new import_obsidian29.Setting(el).setName(t2("settings.sprint.heading")).setHeading();
-    new import_obsidian29.Setting(el).setName(t2("settings.sprint.defaultDuration")).addText((text) => text.setValue(String(this.plugin.settings.defaultSprintDuration)).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.sprint.heading")).setHeading();
+    new import_obsidian28.Setting(el).setName(t2("settings.sprint.defaultDuration")).addText((text) => text.setValue(String(this.plugin.settings.defaultSprintDuration)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 1 || n > 600) return;
       this.plugin.settings.defaultSprintDuration = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.sprint.defaultDailyGoal")).addText((text) => text.setValue(String(this.plugin.settings.defaultDailyWordGoal)).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.sprint.defaultDailyGoal")).addText((text) => text.setValue(String(this.plugin.settings.defaultDailyWordGoal)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 0 || n > 1e6) return;
       this.plugin.settings.defaultDailyWordGoal = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.sprint.soundNotifications")).setDesc(t2("settings.sprint.soundNotificationsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.soundNotifications).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.sprint.soundNotifications")).setDesc(t2("settings.sprint.soundNotificationsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.soundNotifications).onChange(async (v) => {
       this.plugin.settings.soundNotifications = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.sprint.historyRetention")).addText((text) => text.setValue(String(this.plugin.settings.sprintHistoryRetention)).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.sprint.historyRetention")).addText((text) => text.setValue(String(this.plugin.settings.sprintHistoryRetention)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 1 || n > 3650) return;
       this.plugin.settings.sprintHistoryRetention = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.sprint.inlineGoalBanner")).setDesc(t2("settings.sprint.inlineGoalBannerDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.inlineGoalBanner).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.sprint.inlineGoalBanner")).setDesc(t2("settings.sprint.inlineGoalBannerDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.inlineGoalBanner).onChange(async (v) => {
       this.plugin.settings.inlineGoalBanner = v;
       await this.plugin.saveSettings();
     }));
   }
   renderExport(el) {
-    new import_obsidian29.Setting(el).setName(t2("settings.export.heading")).setHeading();
-    new import_obsidian29.Setting(el).setName(t2("settings.export.defaultFormat")).addDropdown((d) => d.addOption("md", t2("settings.export.format.md")).addOption("html", t2("settings.export.format.html")).addOption("manuscript", t2("exportModal.format.manuscript")).addOption("epub", t2("exportModal.format.epub")).addOption("pdf", t2("settings.export.format.pdf")).addOption("docx", t2("settings.export.format.docx")).addOption("rtf", t2("settings.export.format.rtf")).setValue(this.plugin.settings.defaultExportFormat).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.export.heading")).setHeading();
+    new import_obsidian28.Setting(el).setName(t2("settings.export.defaultFormat")).addDropdown((d) => d.addOption("md", t2("settings.export.format.md")).addOption("html", t2("settings.export.format.html")).addOption("manuscript", t2("exportModal.format.manuscript")).addOption("epub", t2("exportModal.format.epub")).addOption("pdf", t2("settings.export.format.pdf")).addOption("docx", t2("settings.export.format.docx")).addOption("rtf", t2("settings.export.format.rtf")).setValue(this.plugin.settings.defaultExportFormat).onChange(async (v) => {
       this.plugin.settings.defaultExportFormat = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.export.defaultPaperSize")).addDropdown((d) => d.addOption("letter", t2("settings.export.paperSize.letter")).addOption("a4", t2("settings.export.paperSize.a4")).setValue(this.plugin.settings.defaultPaperSize).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.export.defaultPaperSize")).addDropdown((d) => d.addOption("letter", t2("settings.export.paperSize.letter")).addOption("a4", t2("settings.export.paperSize.a4")).setValue(this.plugin.settings.defaultPaperSize).onChange(async (v) => {
       this.plugin.settings.defaultPaperSize = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.export.exportFont")).addText((text) => text.setPlaceholder("Georgia").setValue(this.plugin.settings.defaultExportFont).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.export.exportFont")).addText((text) => text.setPlaceholder("Georgia").setValue(this.plugin.settings.defaultExportFont).onChange(async (v) => {
       this.plugin.settings.defaultExportFont = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.export.exportFontSize")).addText((text) => text.setValue(String(this.plugin.settings.defaultExportFontSize)).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.export.exportFontSize")).addText((text) => text.setValue(String(this.plugin.settings.defaultExportFontSize)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 6 || n > 72) return;
       this.plugin.settings.defaultExportFontSize = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.export.pandocPath")).setDesc(t2("settings.export.pandocPathDesc")).addText((text) => text.setPlaceholder("Pandoc").setValue(this.plugin.settings.pandocPath).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.export.pandocPath")).setDesc(t2("settings.export.pandocPathDesc")).addText((text) => text.setPlaceholder("Pandoc").setValue(this.plugin.settings.pandocPath).onChange(async (v) => {
       this.plugin.settings.pandocPath = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.export.epubHeading")).setHeading();
-    new import_obsidian29.Setting(el).setName(t2("settings.export.epubLanguage")).setDesc(t2("settings.export.epubLanguageDesc")).addText((text) => text.setPlaceholder("en").setValue(this.plugin.settings.epubLanguage).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.export.epubHeading")).setHeading();
+    new import_obsidian28.Setting(el).setName(t2("settings.export.epubLanguage")).setDesc(t2("settings.export.epubLanguageDesc")).addText((text) => text.setPlaceholder("en").setValue(this.plugin.settings.epubLanguage).onChange(async (v) => {
       this.plugin.settings.epubLanguage = v.trim() || "en";
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.export.includeCover")).setDesc(t2("settings.export.includeCoverDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.epubIncludeCover).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.export.includeCover")).setDesc(t2("settings.export.includeCoverDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.epubIncludeCover).onChange(async (v) => {
       this.plugin.settings.epubIncludeCover = v;
       await this.plugin.saveSettings();
     }));
   }
   renderLog(el) {
-    new import_obsidian29.Setting(el).setName(t2("settings.log.heading")).setHeading();
-    new import_obsidian29.Setting(el).setName(t2("settings.log.appendToDailyNote")).setDesc(t2("settings.log.appendToDailyNoteDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.appendToDailyNote).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.log.heading")).setHeading();
+    new import_obsidian28.Setting(el).setName(t2("settings.log.appendToDailyNote")).setDesc(t2("settings.log.appendToDailyNoteDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.appendToDailyNote).onChange(async (v) => {
       this.plugin.settings.appendToDailyNote = v;
       await this.plugin.saveSettings();
     }));
   }
   renderWordPress(el) {
-    new import_obsidian29.Setting(el).setName(t2("settings.wordpress.sitesHeading")).setHeading();
+    new import_obsidian28.Setting(el).setName(t2("settings.wordpress.sitesHeading")).setHeading();
     const sites = this.plugin.settings.wordPressSites;
     for (let i = 0; i < sites.length; i++) {
       this.renderSiteConfig(el, sites[i], i);
     }
-    new import_obsidian29.Setting(el).addButton((b) => b.setButtonText(t2("settings.wordpress.addSite")).onClick(async () => {
+    new import_obsidian28.Setting(el).addButton((b) => b.setButtonText(t2("settings.wordpress.addSite")).onClick(async () => {
       this.plugin.settings.wordPressSites.push({
         id: `site-${Date.now()}`,
         nickname: t2("settings.wordpress.newSiteName"),
@@ -16007,8 +15966,8 @@ var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab 
         this.renderWordPress(contentEl);
       }
     }));
-    new import_obsidian29.Setting(el).setName(t2("settings.wordpress.wikilinksHeading")).setHeading();
-    new import_obsidian29.Setting(el).setName(t2("settings.wordpress.defaultWikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkStrip")).addOption("convert", t2("settings.wordpress.wikilinkConvert")).setValue(this.plugin.settings.wikilinkHandling).onChange(async (v) => {
+    new import_obsidian28.Setting(el).setName(t2("settings.wordpress.wikilinksHeading")).setHeading();
+    new import_obsidian28.Setting(el).setName(t2("settings.wordpress.defaultWikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkStrip")).addOption("convert", t2("settings.wordpress.wikilinkConvert")).setValue(this.plugin.settings.wikilinkHandling).onChange(async (v) => {
       this.plugin.settings.wikilinkHandling = v;
       await this.plugin.saveSettings();
     }));
@@ -16016,35 +15975,35 @@ var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab 
   renderSiteConfig(container, site, index) {
     const siteEl = container.createDiv("ws-wp-site-config");
     const heading = t2("settings.wordpress.siteHeading", { nickname: site.nickname || t2("settings.wordpress.siteUnnamed") });
-    new import_obsidian29.Setting(siteEl).setName(heading).setHeading();
-    new import_obsidian29.Setting(siteEl).setName(t2("settings.wordpress.nickname")).addText((text) => text.setValue(site.nickname).onChange(async (v) => {
+    new import_obsidian28.Setting(siteEl).setName(heading).setHeading();
+    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.nickname")).addText((text) => text.setValue(site.nickname).onChange(async (v) => {
       site.nickname = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(siteEl).setName(t2("settings.wordpress.siteUrl")).addText((text) => text.setPlaceholder("https://example.com").setValue(site.url).onChange(async (v) => {
+    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.siteUrl")).addText((text) => text.setPlaceholder("https://example.com").setValue(site.url).onChange(async (v) => {
       site.url = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(siteEl).setName(t2("settings.wordpress.username")).addText((text) => text.setValue(site.username).onChange(async (v) => {
+    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.username")).addText((text) => text.setValue(site.username).onChange(async (v) => {
       site.username = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(siteEl).setName(t2("settings.wordpress.appPassword")).setDesc(t2("settings.wordpress.appPasswordDesc")).addText((text) => {
+    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.appPassword")).setDesc(t2("settings.wordpress.appPasswordDesc")).addText((text) => {
       text.inputEl.type = "password";
       text.setValue(site.appPassword).onChange(async (v) => {
         site.appPassword = v;
         await this.plugin.saveSettings();
       });
     });
-    new import_obsidian29.Setting(siteEl).setName(t2("settings.wordpress.defaultPostStatus")).addDropdown((d) => d.addOption("draft", t2("settings.wordpress.postStatus.draft")).addOption("pending", t2("settings.wordpress.postStatus.pending")).addOption("publish", t2("settings.wordpress.postStatus.publish")).setValue(site.defaultStatus).onChange(async (v) => {
+    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.defaultPostStatus")).addDropdown((d) => d.addOption("draft", t2("settings.wordpress.postStatus.draft")).addOption("pending", t2("settings.wordpress.postStatus.pending")).addOption("publish", t2("settings.wordpress.postStatus.publish")).setValue(site.defaultStatus).onChange(async (v) => {
       site.defaultStatus = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian29.Setting(siteEl).setName(t2("settings.wordpress.wikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkHandlingStrip")).addOption("convert", t2("settings.wordpress.wikilinkHandlingConvert")).setValue(site.wikilinkHandling).onChange(async (v) => {
+    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.wikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkHandlingStrip")).addOption("convert", t2("settings.wordpress.wikilinkHandlingConvert")).setValue(site.wikilinkHandling).onChange(async (v) => {
       site.wikilinkHandling = v;
       await this.plugin.saveSettings();
     }));
-    const testRow = new import_obsidian29.Setting(siteEl).setName(t2("settings.wordpress.testConnection")).setDesc(t2("settings.wordpress.testConnectionDesc"));
+    const testRow = new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.testConnection")).setDesc(t2("settings.wordpress.testConnectionDesc"));
     const statusEl = siteEl.createDiv("ws-wp-test-status");
     testRow.addButton((b) => b.setButtonText(t2("settings.wordpress.testConnection")).onClick(async () => {
       statusEl.textContent = t2("settings.wordpress.testing");
@@ -16053,7 +16012,7 @@ var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab 
       statusEl.textContent = result.message;
       statusEl.className = `ws-wp-test-status ${result.success ? "ws-wp-test-ok" : "ws-wp-test-err"}`;
     }));
-    new import_obsidian29.Setting(siteEl).addButton((b) => {
+    new import_obsidian28.Setting(siteEl).addButton((b) => {
       b.setButtonText(t2("settings.wordpress.removeSite"));
       b.buttonEl.addClass("mod-warning");
       b.onClick(async () => {
@@ -16068,10 +16027,10 @@ var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab 
     });
   }
   async renderHelp(el) {
-    this.helpComponent = new import_obsidian29.Component();
+    this.helpComponent = new import_obsidian28.Component();
     this.helpComponent.load();
     el.addClass("ws-help-content");
-    await import_obsidian29.MarkdownRenderer.render(this.app, HELP_CONTENT, el, "", this.helpComponent);
+    await import_obsidian28.MarkdownRenderer.render(this.app, HELP_CONTENT, el, "", this.helpComponent);
     const supportDiv = el.createDiv({ cls: "ws-support-footer" });
     supportDiv.createEl("a", {
       href: "https://buymeacoffee.com/writerp777",
@@ -16087,9 +16046,9 @@ var WritingStudioSettingsTab = class extends import_obsidian29.PluginSettingTab 
 };
 
 // src/FolderSidebarView.ts
-var import_obsidian30 = require("obsidian");
+var import_obsidian29 = require("obsidian");
 var FOLDER_SIDEBAR_VIEW_TYPE = "folder-sidebar-explorer-view";
-var FolderSidebarView = class extends import_obsidian30.ItemView {
+var FolderSidebarView = class extends import_obsidian29.ItemView {
   constructor(leaf) {
     super(leaf);
     this.rootFolder = null;
@@ -16139,7 +16098,7 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
     const path = state == null ? void 0 : state.rootFolderPath;
     if (typeof path === "string" && path !== ((_a2 = this.rootFolder) == null ? void 0 : _a2.path)) {
       const folder = this.app.vault.getAbstractFileByPath(path);
-      if (folder instanceof import_obsidian30.TFolder) {
+      if (folder instanceof import_obsidian29.TFolder) {
         this.setRootFolder(folder);
         return;
       }
@@ -16163,10 +16122,10 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
     const active = (_a2 = this.app.workspace.activeEditor) == null ? void 0 : _a2.editor;
     if (active) return active;
     const recent = this.app.workspace.getMostRecentLeaf(this.app.workspace.rootSplit);
-    if ((recent == null ? void 0 : recent.view) instanceof import_obsidian30.MarkdownView) return recent.view.editor;
+    if ((recent == null ? void 0 : recent.view) instanceof import_obsidian29.MarkdownView) return recent.view.editor;
     for (const leaf of this.app.workspace.getLeavesOfType("markdown")) {
       const view = leaf.view;
-      if (view instanceof import_obsidian30.MarkdownView) return view.editor;
+      if (view instanceof import_obsidian29.MarkdownView) return view.editor;
     }
     return null;
   }
@@ -16196,7 +16155,7 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
     if (this.historyStack.length === 0) return;
     const prevPath = this.historyStack.pop();
     const prev = this.app.vault.getAbstractFileByPath(prevPath);
-    if (prev instanceof import_obsidian30.TFolder) {
+    if (prev instanceof import_obsidian29.TFolder) {
       this.currentFolder = prev;
       this.searchQuery = "";
       this.searchResults = null;
@@ -16233,10 +16192,10 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
     const results = [];
     const walk = (f) => {
       for (const child of f.children) {
-        if (child instanceof import_obsidian30.TFolder) {
+        if (child instanceof import_obsidian29.TFolder) {
           results.push(child);
           walk(child);
-        } else if (child instanceof import_obsidian30.TFile) {
+        } else if (child instanceof import_obsidian29.TFile) {
           results.push(child);
         }
       }
@@ -16282,7 +16241,7 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
       }
     }
     const textFiles = allItems.filter(
-      (item) => item instanceof import_obsidian30.TFile && ["md", "txt"].includes(item.extension.toLowerCase()) && !nameMatched.has(item)
+      (item) => item instanceof import_obsidian29.TFile && ["md", "txt"].includes(item.extension.toLowerCase()) && !nameMatched.has(item)
     );
     const contentMatches = await Promise.all(textFiles.map(async (file) => {
       try {
@@ -16321,7 +16280,7 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
     this.tooltipEl = tip;
     tip.createDiv({ cls: "ws-tooltip-name", text: item.name });
     tip.createDiv({ cls: "ws-tooltip-divider" });
-    if (item instanceof import_obsidian30.TFile) {
+    if (item instanceof import_obsidian29.TFile) {
       const modDate = new Date(item.stat.mtime);
       const modStr = modDate.toLocaleDateString(void 0, {
         year: "numeric",
@@ -16351,8 +16310,8 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
       let folderCount = 0;
       const walk = (f) => {
         for (const child of f.children) {
-          if (child instanceof import_obsidian30.TFile) fileCount++;
-          else if (child instanceof import_obsidian30.TFolder) {
+          if (child instanceof import_obsidian29.TFile) fileCount++;
+          else if (child instanceof import_obsidian29.TFolder) {
             folderCount++;
             walk(child);
           }
@@ -16448,9 +16407,9 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
   // One comparator for both the folder listing and search results — the two
   // sort methods previously duplicated this switch block
   compareEntries(a, b) {
-    const aIsFolder = a instanceof import_obsidian30.TFolder;
-    const bIsFolder = b instanceof import_obsidian30.TFolder;
-    const mtime = (x) => x instanceof import_obsidian30.TFile ? x.stat.mtime : 0;
+    const aIsFolder = a instanceof import_obsidian29.TFolder;
+    const bIsFolder = b instanceof import_obsidian29.TFolder;
+    const mtime = (x) => x instanceof import_obsidian29.TFile ? x.stat.mtime : 0;
     switch (this.sortMode) {
       case "folders-az":
         if (aIsFolder !== bIsFolder) return aIsFolder ? -1 : 1;
@@ -16563,7 +16522,7 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
     const toolbar = container.createDiv({ cls: "ws-folder-toolbar" });
     const searchWrap = toolbar.createDiv({ cls: "ws-folder-search-wrap" });
     const searchIcon = searchWrap.createSpan({ cls: "ws-folder-search-icon" });
-    (0, import_obsidian30.setIcon)(searchIcon, "search");
+    (0, import_obsidian29.setIcon)(searchIcon, "search");
     const searchInput = searchWrap.createEl("input", {
       cls: "ws-folder-search-input",
       type: "text",
@@ -16624,7 +16583,7 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
     if (ext === "md") {
       try {
         const text = await this.app.vault.cachedRead(file);
-        await import_obsidian30.MarkdownRenderer.render(this.app, text, content2, file.path, this);
+        await import_obsidian29.MarkdownRenderer.render(this.app, text, content2, file.path, this);
         if (this.searchQuery) this.highlightTextInElement(content2, this.searchQuery);
       } catch (e) {
         content2.createDiv({ cls: "ws-folder-empty", text: t2("folderSidebar.previewError") });
@@ -16673,14 +16632,14 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
         itemEl.setAttribute("aria-selected", "false");
         const topRow = itemEl.createDiv({ cls: "ws-folder-item-row" });
         const iconEl = topRow.createSpan({ cls: "ws-folder-item-icon" });
-        if (item instanceof import_obsidian30.TFolder) {
-          (0, import_obsidian30.setIcon)(iconEl, "folder");
+        if (item instanceof import_obsidian29.TFolder) {
+          (0, import_obsidian29.setIcon)(iconEl, "folder");
         } else {
           const ext = item.extension.toLowerCase();
-          if (ext === "md") (0, import_obsidian30.setIcon)(iconEl, "file-text");
-          else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian30.setIcon)(iconEl, "image");
-          else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian30.setIcon)(iconEl, "file-audio");
-          else (0, import_obsidian30.setIcon)(iconEl, "file");
+          if (ext === "md") (0, import_obsidian29.setIcon)(iconEl, "file-text");
+          else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian29.setIcon)(iconEl, "image");
+          else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian29.setIcon)(iconEl, "file-audio");
+          else (0, import_obsidian29.setIcon)(iconEl, "file");
         }
         const isAtRoot = ((_a2 = item.parent) == null ? void 0 : _a2.path) === ((_c = (_b2 = this.rootFolder) == null ? void 0 : _b2.path) != null ? _c : current.path);
         const label = !isAtRoot && item.path.startsWith(rootPath) ? item.path.slice(rootPath.length) : item.name;
@@ -16698,8 +16657,8 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
           this.renderHighlightedText(snippetEl, snippet, lowerQuery);
         }
         itemEl.addEventListener("click", () => {
-          if (item instanceof import_obsidian30.TFolder) this.navigateTo(item);
-          else if (item instanceof import_obsidian30.TFile) this.openFile(item);
+          if (item instanceof import_obsidian29.TFolder) this.navigateTo(item);
+          else if (item instanceof import_obsidian29.TFile) this.openFile(item);
         });
         this.addTooltip(itemEl, item);
         items2.push(itemEl);
@@ -16736,7 +16695,7 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
       return;
     }
     const displayItems = current.children.filter(
-      (c) => c instanceof import_obsidian30.TFolder || c instanceof import_obsidian30.TFile
+      (c) => c instanceof import_obsidian29.TFolder || c instanceof import_obsidian29.TFile
     );
     const sorted = this.sortItems(displayItems);
     if (sorted.length === 0) {
@@ -16750,19 +16709,19 @@ var FolderSidebarView = class extends import_obsidian30.ItemView {
       item.setAttribute("role", "option");
       item.setAttribute("aria-selected", "false");
       const iconEl = item.createSpan({ cls: "ws-folder-item-icon" });
-      if (child instanceof import_obsidian30.TFolder) {
-        (0, import_obsidian30.setIcon)(iconEl, "folder");
-      } else if (child instanceof import_obsidian30.TFile) {
+      if (child instanceof import_obsidian29.TFolder) {
+        (0, import_obsidian29.setIcon)(iconEl, "folder");
+      } else if (child instanceof import_obsidian29.TFile) {
         const ext = child.extension.toLowerCase();
-        if (ext === "md") (0, import_obsidian30.setIcon)(iconEl, "file-text");
-        else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian30.setIcon)(iconEl, "image");
-        else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian30.setIcon)(iconEl, "file-audio");
-        else (0, import_obsidian30.setIcon)(iconEl, "file");
+        if (ext === "md") (0, import_obsidian29.setIcon)(iconEl, "file-text");
+        else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian29.setIcon)(iconEl, "image");
+        else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian29.setIcon)(iconEl, "file-audio");
+        else (0, import_obsidian29.setIcon)(iconEl, "file");
       }
       item.createSpan({ text: child.name });
       item.addEventListener("click", () => {
-        if (child instanceof import_obsidian30.TFolder) this.navigateTo(child);
-        else if (child instanceof import_obsidian30.TFile) this.openFile(child);
+        if (child instanceof import_obsidian29.TFolder) this.navigateTo(child);
+        else if (child instanceof import_obsidian29.TFile) this.openFile(child);
       });
       this.addTooltip(item, child);
       items.push(item);
@@ -16805,7 +16764,7 @@ function applyFocus(items, index) {
     if (i === index) item.scrollIntoView({ block: "nearest" });
   });
 }
-var FolderPickerModal = class extends import_obsidian30.FuzzySuggestModal {
+var FolderPickerModal = class extends import_obsidian29.FuzzySuggestModal {
   constructor(app, onChoose) {
     super(app);
     this.onChoose = onChoose;
@@ -16816,7 +16775,7 @@ var FolderPickerModal = class extends import_obsidian30.FuzzySuggestModal {
     const walk = (folder) => {
       folders.push(folder);
       for (const child of folder.children) {
-        if (child instanceof import_obsidian30.TFolder) walk(child);
+        if (child instanceof import_obsidian29.TFolder) walk(child);
       }
     };
     walk(this.app.vault.getRoot());
@@ -16831,9 +16790,9 @@ var FolderPickerModal = class extends import_obsidian30.FuzzySuggestModal {
 };
 
 // src/WritingLogView.ts
-var import_obsidian31 = require("obsidian");
+var import_obsidian30 = require("obsidian");
 var WRITING_LOG_VIEW_TYPE = "writing-studio-writing-log";
-var WritingLogView = class extends import_obsidian31.ItemView {
+var WritingLogView = class extends import_obsidian30.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
     this.plugin = plugin;
@@ -16860,7 +16819,7 @@ var WritingLogView = class extends import_obsidian31.ItemView {
     const root = this.containerEl.children[1];
     root.empty();
     root.addClass("ws-log-root");
-    const lang = (0, import_obsidian31.getLanguage)();
+    const lang = (0, import_obsidian30.getLanguage)();
     const header = root.createDiv("ws-log-header");
     header.createDiv({ text: t2("log.title"), cls: "ws-log-title" });
     header.createDiv({
@@ -17052,7 +17011,7 @@ var StatusBar = class {
 };
 
 // src/GoalBanner.ts
-var import_obsidian32 = require("obsidian");
+var import_obsidian31 = require("obsidian");
 var GoalBanner = class {
   constructor(plugin) {
     this.generation = 0;
@@ -17078,7 +17037,7 @@ var GoalBanner = class {
     const leaf = this.plugin.app.workspace.getMostRecentLeaf();
     if (!leaf) return;
     const view = leaf.view;
-    if (!(view instanceof import_obsidian32.MarkdownView)) return;
+    if (!(view instanceof import_obsidian31.MarkdownView)) return;
     const file = view.file;
     if (!file) return;
     const goal = await this.plugin.projectManager.getWordCountGoalForFile(file);
@@ -17103,6 +17062,60 @@ var GoalBanner = class {
   }
   destroy() {
     activeDocument.querySelectorAll(".ws-inline-goal-banner").forEach((el) => el.remove());
+  }
+};
+
+// src/VaultFiles.ts
+var import_obsidian32 = require("obsidian");
+var ObsidianVaultFiles = class {
+  constructor(app) {
+    this.app = app;
+  }
+  async readText(path) {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    return file instanceof import_obsidian32.TFile ? this.app.vault.read(file) : null;
+  }
+  async writeText(path, content2) {
+    const existing = this.app.vault.getAbstractFileByPath(path);
+    if (existing instanceof import_obsidian32.TFile) {
+      await this.app.vault.modify(existing, content2);
+    } else {
+      await this.app.vault.create(path, content2);
+    }
+  }
+  async readBinary(path) {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    return file instanceof import_obsidian32.TFile ? this.app.vault.readBinary(file) : null;
+  }
+  async writeBinary(path, data) {
+    const existing = this.app.vault.getAbstractFileByPath(path);
+    if (existing instanceof import_obsidian32.TFile) {
+      await this.app.vault.modifyBinary(existing, data);
+    } else {
+      await this.app.vault.createBinary(path, data);
+    }
+  }
+  async remove(path) {
+    if (this.app.vault.getAbstractFileByPath(path) instanceof import_obsidian32.TFile) {
+      await this.app.vault.adapter.remove(path);
+    }
+  }
+  exists(path) {
+    return this.app.vault.getAbstractFileByPath(path) !== null;
+  }
+  async ensureFolder(path) {
+    if (!this.app.vault.getAbstractFileByPath(path)) {
+      await this.app.vault.createFolder(path);
+    }
+  }
+  listSubfolders(path) {
+    const folder = this.app.vault.getAbstractFileByPath(path);
+    if (!(folder instanceof import_obsidian32.TFolder)) return [];
+    return folder.children.filter((c) => c instanceof import_obsidian32.TFolder).map((c) => c.path);
+  }
+  absolutePath(path) {
+    const adapter = this.app.vault.adapter;
+    return adapter instanceof import_obsidian32.FileSystemAdapter ? adapter.getFullPath(path) : path;
   }
 };
 
@@ -17216,8 +17229,9 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
   async onload() {
     await initI18n();
     await this.loadSettings();
+    this.vaultFiles = new ObsidianVaultFiles(this.app);
     this.fmManager = new FrontmatterManager(this);
-    this.projectManager = new ProjectManager(this);
+    this.projectManager = new ProjectManager(this, this.vaultFiles);
     this.statsTracker = new StatsTracker(this);
     this.registerEvent(this.projectManager.onBinderChanged(() => {
       this.statsTracker.invalidateWordCountCache();
@@ -17226,7 +17240,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
     this.typographyMode = new TypographyMode(this);
     this.writingModes = new WritingModes(this);
     this.sprintTimer = new SprintTimer(this);
-    this.exportEngine = new ExportEngine(this);
+    this.exportEngine = new ExportEngine(this, this.vaultFiles);
     this.wpClient = new WordPressClient();
     this.goalBanner = new GoalBanner(this);
     this.registerEditorExtension(this.focusMode.getEditorExtension());

--- a/main.ts
+++ b/main.ts
@@ -30,6 +30,7 @@ import { WritingLogView, WRITING_LOG_VIEW_TYPE } from './src/WritingLogView';
 import { registerCommands } from './src/commands';
 import { StatusBar } from './src/StatusBar';
 import { GoalBanner } from './src/GoalBanner';
+import { ObsidianVaultFiles, type VaultFiles } from './src/VaultFiles';
 
 import { AddToProjectModal } from './modals/AddToProjectModal';
 import { SprintModal } from './modals/SprintModal';
@@ -176,6 +177,7 @@ export default class WritingStudioPlugin extends Plugin {
   fmManager!: FrontmatterManager;
   statusBar!: StatusBar;
   goalBanner!: GoalBanner;
+  vaultFiles!: VaultFiles;
 
   private wordCountUpdateTimer: number | null = null;
   private launcherRefreshTimer: number | null = null;
@@ -187,8 +189,9 @@ export default class WritingStudioPlugin extends Plugin {
     await this.loadSettings();
 
     // Initialize modules
+    this.vaultFiles = new ObsidianVaultFiles(this.app);
     this.fmManager = new FrontmatterManager(this);
-    this.projectManager = new ProjectManager(this);
+    this.projectManager = new ProjectManager(this, this.vaultFiles);
     this.statsTracker = new StatsTracker(this);
     this.registerEvent(this.projectManager.onBinderChanged(() => {
       this.statsTracker.invalidateWordCountCache();
@@ -197,7 +200,7 @@ export default class WritingStudioPlugin extends Plugin {
     this.typographyMode = new TypographyMode(this);
     this.writingModes = new WritingModes(this);
     this.sprintTimer = new SprintTimer(this);
-    this.exportEngine = new ExportEngine(this);
+    this.exportEngine = new ExportEngine(this, this.vaultFiles);
     this.wpClient = new WordPressClient();
     this.goalBanner = new GoalBanner(this);
 

--- a/src/EpubEngine.ts
+++ b/src/EpubEngine.ts
@@ -1,6 +1,5 @@
-import { App, TFile } from 'obsidian';
 import { zip, type AsyncZippable } from 'fflate';
-import type WritingStudioPlugin from '../main';
+import type { VaultFiles } from './VaultFiles';
 import { t } from './i18n';
 
 export interface EpubChapter {
@@ -19,15 +18,13 @@ export interface EpubBuildOptions {
 }
 
 export class EpubEngine {
-  private app: App;
-  private plugin: WritingStudioPlugin;
+  private files: VaultFiles;
   // Configured book language — every chapter's xml:lang previously
   // hardcoded "en", contradicting the language declared in content.opf
   private lang = 'en';
 
-  constructor(plugin: WritingStudioPlugin) {
-    this.plugin = plugin;
-    this.app = plugin.app;
+  constructor(files: VaultFiles) {
+    this.files = files;
   }
 
   async build(opts: EpubBuildOptions, outputVaultPath: string): Promise<void> {
@@ -45,9 +42,8 @@ export class EpubEngine {
     let coverImageFile: string | null = null;
     let coverImageMime = 'image/jpeg';
     if (opts.coverImagePath) {
-      const vaultFile = this.app.vault.getAbstractFileByPath(opts.coverImagePath);
-      if (vaultFile instanceof TFile) {
-        const raw = await this.app.vault.readBinary(vaultFile);
+      const raw = await this.files.readBinary(opts.coverImagePath);
+      if (raw !== null) {
         // MIME by actual extension — labeling a .webp/.gif as image/jpeg
         // produced covers some readers reject
         const mimeByExt: Record<string, string> = {
@@ -57,7 +53,7 @@ export class EpubEngine {
           jpg: 'image/jpeg',
           jpeg: 'image/jpeg',
         };
-        const ext = vaultFile.extension.toLowerCase();
+        const ext = (opts.coverImagePath.split('.').pop() ?? '').toLowerCase();
         coverImageMime = mimeByExt[ext] ?? 'image/jpeg';
         coverImageFile = `cover.${ext === 'jpeg' ? 'jpg' : ext || 'jpg'}`;
         entries[`OEBPS/${coverImageFile}`] = [new Uint8Array(raw), { level: 6 }];
@@ -84,12 +80,7 @@ export class EpubEngine {
     });
     const data = new ArrayBuffer(compressed.byteLength);
     new Uint8Array(data).set(compressed);
-    const existing = this.app.vault.getAbstractFileByPath(outputVaultPath);
-    if (existing instanceof TFile) {
-      await this.app.vault.modifyBinary(existing, data);
-    } else {
-      await this.app.vault.createBinary(outputVaultPath, data);
-    }
+    await this.files.writeBinary(outputVaultPath, data);
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/ExportEngine.ts
+++ b/src/ExportEngine.ts
@@ -1,7 +1,8 @@
-import { App, FileSystemAdapter, MarkdownView, TFile, getLanguage, normalizePath, Notice } from 'obsidian';
+import { App, MarkdownView, TFile, getLanguage, normalizePath, Notice } from 'obsidian';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import type WritingStudioPlugin from '../main';
+import type { VaultFiles } from './VaultFiles';
 import { EpubEngine, EpubChapter } from './EpubEngine';
 import { t } from './i18n';
 import { localDateString } from './dates';
@@ -121,10 +122,12 @@ const SECTION_BREAK = '\n\n\u0000WS-SECTION-BREAK\u0000\n\n';
 export class ExportEngine {
   private plugin: WritingStudioPlugin;
   private app: App;
+  private files: VaultFiles;
 
-  constructor(plugin: WritingStudioPlugin) {
+  constructor(plugin: WritingStudioPlugin, files: VaultFiles) {
     this.plugin = plugin;
     this.app = plugin.app;
+    this.files = files;
   }
 
   // Resolve section sentinels to a markdown hr for text-based outputs
@@ -139,7 +142,7 @@ export class ExportEngine {
       ? normalizePath(`${project.folderPath}/Exports`)
       : normalizePath('Exports');
 
-    await this.ensureFolder(outputDir);
+    await this.files.ensureFolder(outputDir);
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
     const projectTitle = project?.title.replace(/[\\/:*?"<>|]/g, '-') || 'export';
@@ -189,7 +192,10 @@ export class ExportEngine {
       if (!(file instanceof TFile)) {
         throw new Error(t('exportEngine.noActiveDocument'));
       }
-      let content = await this.app.vault.read(file);
+      let content = await this.files.readText(file.path);
+      if (content === null) {
+        throw new Error(t('exportEngine.noActiveDocument'));
+      }
       if (!opts.includeFrontmatter) {
         content = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
       }
@@ -204,9 +210,8 @@ export class ExportEngine {
         if (!item.includeInExport) continue;
         if (!item.filePath) continue;
         if (!opts.includeResearch && item.filePath.includes('/Research/')) continue;
-        const file = this.app.vault.getAbstractFileByPath(item.filePath);
-        if (!(file instanceof TFile)) continue;
-        let content = await this.app.vault.read(file);
+        let content = await this.files.readText(item.filePath);
+        if (content === null) continue;
         if (!opts.includeFrontmatter) {
           content = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
         }
@@ -225,7 +230,7 @@ export class ExportEngine {
       throw new Error(t('exportEngine.noActiveDocument'));
     }
 
-    await new EpubEngine(this.plugin).build({
+    await new EpubEngine(this.files).build({
       title,
       author,
       language,
@@ -272,7 +277,11 @@ export class ExportEngine {
       if (!(file instanceof TFile)) {
         throw new Error(t('exportEngine.noActiveDocument'));
       }
-      parts.push(await this.processFile(file, opts));
+      const content = await this.processPath(file.path, opts);
+      if (content === null) {
+        throw new Error(t('exportEngine.noActiveDocument'));
+      }
+      parts.push(content);
     } else if (opts.scope === 'project' && project) {
       const binder = await this.plugin.projectManager.loadBinder(project);
       const flatItems = this.plugin.projectManager.flattenBinder(binder.items);
@@ -281,9 +290,8 @@ export class ExportEngine {
         if (!item.includeInExport) continue;
         if (!item.filePath) continue; // group/part items have no file
         if (!opts.includeResearch && item.filePath.includes('/Research/')) continue;
-        const file = this.app.vault.getAbstractFileByPath(item.filePath);
-        if (!(file instanceof TFile)) continue;
-        const content = await this.processFile(file, opts);
+        const content = await this.processPath(item.filePath, opts);
+        if (content === null) continue;
         if (opts.includeTitlesAsHeadings) {
           // Strip any leading h1 from the document body — the canonical heading
           // comes from item.title, so the in-document heading must not be kept
@@ -296,12 +304,12 @@ export class ExportEngine {
       }
     } else if (opts.scope === 'selected' && opts.selectedFiles) {
       for (const filePath of opts.selectedFiles) {
-        const file = this.app.vault.getAbstractFileByPath(filePath);
-        if (!(file instanceof TFile)) continue;
-        const content = await this.processFile(file, opts);
+        const content = await this.processPath(filePath, opts);
+        if (content === null) continue;
         if (opts.includeTitlesAsHeadings) {
+          const basename = filePath.split('/').pop()?.replace(/\.md$/, '') ?? filePath;
           const body = content.replace(/^# [^\n]*\n+/, '').trim();
-          parts.push(`# ${file.basename}\n\n${body}`);
+          parts.push(`# ${basename}\n\n${body}`);
         } else {
           parts.push(content);
         }
@@ -315,8 +323,10 @@ export class ExportEngine {
     return parts.join(SECTION_BREAK);
   }
 
-  private async processFile(file: TFile, opts: ExportOptions): Promise<string> {
-    let content = await this.app.vault.read(file);
+  // Resolves to null when the file does not exist.
+  private async processPath(path: string, opts: ExportOptions): Promise<string | null> {
+    let content = await this.files.readText(path);
+    if (content === null) return null;
     if (!opts.includeFrontmatter) {
       content = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
     }
@@ -396,13 +406,13 @@ ${bodyHtml}
 </body>
 </html>`;
 
-    await this.writeFile(outputPath, fullHtml);
+    await this.files.writeText(outputPath, fullHtml);
     new Notice(t('exportEngine.manuscriptExported', { path: outputPath }));
     return outputPath;
   }
 
   private async exportMarkdown(content: string, outputPath: string): Promise<string> {
-    await this.writeFile(outputPath, content);
+    await this.files.writeText(outputPath, content);
     new Notice(t('exportEngine.exportedTo', { path: outputPath }));
     return outputPath;
   }
@@ -433,7 +443,7 @@ ${bodyHtml}
 ${markdownToHtml(content)}
 </body>
 </html>`;
-    await this.writeFile(outputPath, html);
+    await this.files.writeText(outputPath, html);
     new Notice(t('exportEngine.exportedHtmlTo', { path: outputPath }));
     return outputPath;
   }
@@ -443,10 +453,10 @@ ${markdownToHtml(content)}
     const tempMdPath = outputPath.replace(/\.[^.]+$/, '.tmp.md');
 
     try {
-      await this.writeFile(tempMdPath, content);
+      await this.files.writeText(tempMdPath, content);
 
-      const absOutput = this.getAbsPath(outputPath);
-      const absInput = this.getAbsPath(tempMdPath);
+      const absOutput = this.files.absolutePath(outputPath);
+      const absInput = this.files.absolutePath(tempMdPath);
 
       // No --pdf-engine flag: pandoc defaults to LaTeX for PDF output, which
       // is what the README tells users to install (TeX Live / MiKTeX)
@@ -465,11 +475,9 @@ ${markdownToHtml(content)}
     } catch (e) {
       throw new Error(`Pandoc export failed: ${e instanceof Error ? e.message : String(e)}\nEnsure pandoc is installed.`);
     } finally {
-      // Remove the temp file outright via the adapter — trashing it
-      // accumulated a .tmp.md in .trash/ on every pandoc export
-      if (this.app.vault.getAbstractFileByPath(tempMdPath) instanceof TFile) {
-        await this.app.vault.adapter.remove(tempMdPath);
-      }
+      // Remove the temp file outright — trashing it accumulated a .tmp.md
+      // in .trash/ on every pandoc export
+      await this.files.remove(tempMdPath);
     }
   }
 
@@ -479,26 +487,6 @@ ${markdownToHtml(content)}
     } catch (e) {
       new Notice(t('exportEngine.pdfRequiresPandoc'));
       throw e; // preserve the original pandoc error for the Export modal to display
-    }
-  }
-
-  private async writeFile(vaultPath: string, content: string): Promise<void> {
-    const existing = this.app.vault.getAbstractFileByPath(vaultPath);
-    if (existing instanceof TFile) {
-      await this.app.vault.modify(existing, content);
-    } else {
-      await this.app.vault.create(vaultPath, content);
-    }
-  }
-
-  private getAbsPath(vaultPath: string): string {
-    const adapter = this.app.vault.adapter;
-    return adapter instanceof FileSystemAdapter ? adapter.getFullPath(vaultPath) : vaultPath;
-  }
-
-  private async ensureFolder(path: string): Promise<void> {
-    if (!this.app.vault.getAbstractFileByPath(path)) {
-      await this.app.vault.createFolder(path);
     }
   }
 

--- a/src/ProjectManager.ts
+++ b/src/ProjectManager.ts
@@ -1,5 +1,6 @@
-import { App, Events, EventRef, Notice, TFolder, TFile, normalizePath } from 'obsidian';
+import { App, Events, EventRef, Notice, TFile, normalizePath } from 'obsidian';
 import type WritingStudioPlugin from '../main';
+import type { VaultFiles } from './VaultFiles';
 import { t } from './i18n';
 import { localDateString } from './dates';
 import { WritingProject, ProjectType } from '../models/Project';
@@ -14,14 +15,16 @@ import { MagazineArticleTemplate } from '../templates/MagazineArticleTemplate';
 export class ProjectManager extends Events {
   private plugin: WritingStudioPlugin;
   private app: App;
+  private files: VaultFiles;
   private projects = new Map<string, WritingProject>();
   private activeProjectId: string | null = null;
   private binderCache = new Map<string, BinderData>();
 
-  constructor(plugin: WritingStudioPlugin) {
+  constructor(plugin: WritingStudioPlugin, files: VaultFiles) {
     super();
     this.plugin = plugin;
     this.app = plugin.app;
+    this.files = files;
   }
 
   // Project state is announced here, not pulled — subscribe instead of
@@ -57,20 +60,15 @@ export class ProjectManager extends Events {
     const rootFolder = this.plugin.settings.defaultProjectFolder;
     if (!rootFolder) return;
 
-    const folder = this.app.vault.getAbstractFileByPath(normalizePath(rootFolder));
-    if (!(folder instanceof TFolder)) return;
-
-    const subfolders = folder.children.filter((c): c is TFolder => c instanceof TFolder);
-    await Promise.all(subfolders.map(f => this.loadProject(f.path)));
+    const subfolders = this.files.listSubfolders(normalizePath(rootFolder));
+    await Promise.all(subfolders.map(f => this.loadProject(f)));
   }
 
   async loadProject(folderPath: string): Promise<WritingProject | null> {
-    const projectFilePath = normalizePath(`${folderPath}/_project.json`);
-    const file = this.app.vault.getAbstractFileByPath(projectFilePath);
-    if (!(file instanceof TFile)) return null;
+    const content = await this.files.readText(normalizePath(`${folderPath}/_project.json`));
+    if (content === null) return null;
 
     try {
-      const content = await this.app.vault.read(file);
       const project = JSON.parse(content) as WritingProject;
       this.projects.set(project.id, project);
       return project;
@@ -93,15 +91,15 @@ export class ProjectManager extends Events {
 
     // Refuse rather than scaffold into an existing folder — writing into one
     // would overwrite the existing project's _project.json and _binder.json
-    if (this.app.vault.getAbstractFileByPath(folderPath)) {
+    if (this.files.exists(folderPath)) {
       throw new Error(t('projectManager.errorFolderExists', { folder: folderName }));
     }
 
     // Create folder structure
-    await this.ensureFolder(folderPath);
-    await this.ensureFolder(normalizePath(`${folderPath}/Chapters`));
-    await this.ensureFolder(normalizePath(`${folderPath}/Research`));
-    await this.ensureFolder(normalizePath(`${folderPath}/Exports`));
+    await this.files.ensureFolder(folderPath);
+    await this.files.ensureFolder(normalizePath(`${folderPath}/Chapters`));
+    await this.files.ensureFolder(normalizePath(`${folderPath}/Research`));
+    await this.files.ensureFolder(normalizePath(`${folderPath}/Exports`));
 
     const now = localDateString();
     const project: WritingProject = {
@@ -167,14 +165,13 @@ export class ProjectManager extends Events {
     if (cached) return cached;
 
     const path = normalizePath(`${project.folderPath}/_binder.json`);
-    const file = this.app.vault.getAbstractFileByPath(path);
-    if (!(file instanceof TFile)) {
+    let content: string | null;
+    try {
+      content = await this.files.readText(path);
+    } catch {
       return { version: '2.0', projectId: project.id, items: [] };
     }
-    let content: string;
-    try {
-      content = await this.app.vault.read(file);
-    } catch {
+    if (content === null) {
       return { version: '2.0', projectId: project.id, items: [] };
     }
     try {
@@ -184,7 +181,7 @@ export class ProjectManager extends Events {
     } catch {
       // Preserve the corrupt file for manual repair; the returned empty binder
       // is deliberately not cached so a repaired file is picked up on next load
-      await this.writeRaw(normalizePath(`${project.folderPath}/_binder.json.bak`), content);
+      await this.files.writeText(normalizePath(`${project.folderPath}/_binder.json.bak`), content);
       new Notice(t('projectManager.corruptBinder', { project: project.title }));
       return { version: '2.0', projectId: project.id, items: [] };
     }
@@ -218,7 +215,7 @@ export class ProjectManager extends Events {
     const now = localDateString();
     const baseName = title.replace(/[\\/:*?"<>|]/g, '-');
     let filePath = normalizePath(`${project.folderPath}/Chapters/${baseName}.md`);
-    for (let n = 2; this.app.vault.getAbstractFileByPath(filePath); n++) {
+    for (let n = 2; this.files.exists(filePath); n++) {
       filePath = normalizePath(`${project.folderPath}/Chapters/${baseName} ${n}.md`);
     }
 
@@ -235,7 +232,7 @@ export class ProjectManager extends Events {
     // Callers that already have the full document body (duplicate) pass it in
     // so the file is written once instead of template-then-overwrite
     const frontmatter = this.buildDocFrontmatter(title, type, item.order, now);
-    await this.app.vault.create(filePath, content ?? frontmatter + '\n\n');
+    await this.files.writeText(filePath, content ?? frontmatter + '\n\n');
 
     if (parentId) {
       const parent = this.findItem(binder.items, parentId);
@@ -315,10 +312,9 @@ tags: [writing-studio]
     const logPath = normalizePath(`${project.folderPath}/_writing-log.json`);
     let log: SprintSession[] = [];
 
-    const file = this.app.vault.getAbstractFileByPath(logPath);
-    if (file instanceof TFile) {
+    const content = await this.files.readText(logPath);
+    if (content !== null) {
       try {
-        const content = await this.app.vault.read(file);
         log = JSON.parse(content) as SprintSession[];
       } catch {
         // Surface the reset — silently starting fresh hid sprint-history loss
@@ -339,11 +335,9 @@ tags: [writing-studio]
 
   async getWritingLog(project: WritingProject): Promise<SprintSession[]> {
     const logPath = normalizePath(`${project.folderPath}/_writing-log.json`);
-    const file = this.app.vault.getAbstractFileByPath(logPath);
-    if (!(file instanceof TFile)) return [];
     try {
-      const content = await this.app.vault.read(file);
-      return JSON.parse(content) as SprintSession[];
+      const content = await this.files.readText(logPath);
+      return content === null ? [] : JSON.parse(content) as SprintSession[];
     } catch {
       return [];
     }
@@ -355,23 +349,7 @@ tags: [writing-studio]
   }
 
   private async writeJson(path: string, data: unknown): Promise<void> {
-    await this.writeRaw(path, JSON.stringify(data, null, 2));
-  }
-
-  private async writeRaw(path: string, content: string): Promise<void> {
-    const existing = this.app.vault.getAbstractFileByPath(path);
-    if (existing instanceof TFile) {
-      await this.app.vault.modify(existing, content);
-    } else {
-      await this.app.vault.create(path, content);
-    }
-  }
-
-  private async ensureFolder(path: string): Promise<void> {
-    const existing = this.app.vault.getAbstractFileByPath(path);
-    if (!existing) {
-      await this.app.vault.createFolder(path);
-    }
+    await this.files.writeText(path, JSON.stringify(data, null, 2));
   }
 
   getProjects(): WritingProject[] {

--- a/src/VaultFiles.ts
+++ b/src/VaultFiles.ts
@@ -1,0 +1,88 @@
+import { App, FileSystemAdapter, TFile, TFolder } from 'obsidian';
+
+// The narrow seam over vault file I/O. Engines and the project manager
+// consume this interface instead of app.vault, so their behavior is testable
+// against the in-memory adapter in tests/inMemoryVaultFiles.ts.
+// Paths are vault-relative and already normalized by callers.
+export interface VaultFiles {
+  // Resolves to null when the file does not exist.
+  readText(path: string): Promise<string | null>;
+  // Creates the file, or overwrites it if it exists.
+  writeText(path: string, content: string): Promise<void>;
+  // Resolves to null when the file does not exist.
+  readBinary(path: string): Promise<ArrayBuffer | null>;
+  // Creates the file, or overwrites it if it exists.
+  writeBinary(path: string, data: ArrayBuffer): Promise<void>;
+  // Permanent removal — not moved to trash.
+  remove(path: string): Promise<void>;
+  exists(path: string): boolean;
+  ensureFolder(path: string): Promise<void>;
+  // Paths of the immediate child folders, or [] if path is not a folder.
+  listSubfolders(path: string): string[];
+  // Absolute filesystem path for external tools (pandoc). Falls back to the
+  // vault-relative path on platforms without filesystem access.
+  absolutePath(path: string): string;
+}
+
+export class ObsidianVaultFiles implements VaultFiles {
+  private app: App;
+
+  constructor(app: App) {
+    this.app = app;
+  }
+
+  async readText(path: string): Promise<string | null> {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    return file instanceof TFile ? this.app.vault.read(file) : null;
+  }
+
+  async writeText(path: string, content: string): Promise<void> {
+    const existing = this.app.vault.getAbstractFileByPath(path);
+    if (existing instanceof TFile) {
+      await this.app.vault.modify(existing, content);
+    } else {
+      await this.app.vault.create(path, content);
+    }
+  }
+
+  async readBinary(path: string): Promise<ArrayBuffer | null> {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    return file instanceof TFile ? this.app.vault.readBinary(file) : null;
+  }
+
+  async writeBinary(path: string, data: ArrayBuffer): Promise<void> {
+    const existing = this.app.vault.getAbstractFileByPath(path);
+    if (existing instanceof TFile) {
+      await this.app.vault.modifyBinary(existing, data);
+    } else {
+      await this.app.vault.createBinary(path, data);
+    }
+  }
+
+  async remove(path: string): Promise<void> {
+    if (this.app.vault.getAbstractFileByPath(path) instanceof TFile) {
+      await this.app.vault.adapter.remove(path);
+    }
+  }
+
+  exists(path: string): boolean {
+    return this.app.vault.getAbstractFileByPath(path) !== null;
+  }
+
+  async ensureFolder(path: string): Promise<void> {
+    if (!this.app.vault.getAbstractFileByPath(path)) {
+      await this.app.vault.createFolder(path);
+    }
+  }
+
+  listSubfolders(path: string): string[] {
+    const folder = this.app.vault.getAbstractFileByPath(path);
+    if (!(folder instanceof TFolder)) return [];
+    return folder.children.filter((c): c is TFolder => c instanceof TFolder).map(c => c.path);
+  }
+
+  absolutePath(path: string): string {
+    const adapter = this.app.vault.adapter;
+    return adapter instanceof FileSystemAdapter ? adapter.getFullPath(path) : path;
+  }
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -55,6 +55,12 @@ export class MarkdownView {}
 
 export class WorkspaceLeaf {}
 
+export class FileSystemAdapter {}
+
+export function getLanguage(): string {
+  return 'en';
+}
+
 export class Notice {
   static messages: string[] = [];
   constructor(message = '') {

--- a/tests/exportEngine.test.ts
+++ b/tests/exportEngine.test.ts
@@ -1,0 +1,133 @@
+import { ExportEngine, ExportOptions } from '../src/ExportEngine';
+import { ProjectManager } from '../src/ProjectManager';
+import { InMemoryVaultFiles } from './inMemoryVaultFiles';
+
+// Integration through the vault seam: a real ProjectManager and ExportEngine
+// run against the in-memory adapter, no Obsidian App required.
+async function makeWorld() {
+  const files = new InMemoryVaultFiles();
+  const plugin = {
+    app: {},
+    settings: { defaultProjectFolder: 'Projects', authorName: 'Avery' },
+    saveSettings: jest.fn().mockResolvedValue(undefined),
+  } as { projectManager?: ProjectManager };
+  const pm = new ProjectManager(plugin as never, files);
+  plugin.projectManager = pm;
+  const engine = new ExportEngine(plugin as never, files);
+
+  await pm.saveProject({
+    id: 'project-1',
+    title: 'My Book',
+    type: 'book',
+    author: 'Avery',
+    created: '2026-06-12',
+    modified: '2026-06-12',
+    description: '',
+    folderPath: 'Projects/My Book',
+    goals: {},
+  });
+  await pm.setActiveProject('project-1');
+
+  files.files.set('Projects/My Book/Chapters/One.md',
+    '---\ntitle: "One"\nword-count: 9\n---\n# One\n\nFirst chapter body.');
+  files.files.set('Projects/My Book/Chapters/Two.md',
+    '---\ntitle: "Two"\n---\nSecond chapter body.');
+  files.files.set('Projects/My Book/Research/Notes.md', 'Research notes body.');
+
+  await pm.saveBinder({
+    version: '2.0',
+    projectId: 'project-1',
+    items: [
+      { id: 'i1', title: 'Chapter One', filePath: 'Projects/My Book/Chapters/One.md', type: 'chapter', order: 1, status: 'draft', includeInExport: true },
+      { id: 'i2', title: 'Chapter Two', filePath: 'Projects/My Book/Chapters/Two.md', type: 'chapter', order: 2, status: 'draft', includeInExport: false },
+      { id: 'i3', title: 'Notes', filePath: 'Projects/My Book/Research/Notes.md', type: 'note', order: 3, status: 'draft', includeInExport: true },
+      { id: 'i4', title: 'Ghost', filePath: 'Projects/My Book/Chapters/Missing.md', type: 'chapter', order: 4, status: 'draft', includeInExport: true },
+    ],
+  });
+
+  return { files, pm, engine };
+}
+
+function projectOpts(overrides: Partial<ExportOptions> = {}): ExportOptions {
+  return {
+    format: 'md',
+    scope: 'project',
+    includeFrontmatter: false,
+    includeResearch: false,
+    includeTitlesAsHeadings: true,
+    paperSize: 'letter',
+    font: '',
+    fontSize: 12,
+    addTitlePage: false,
+    ...overrides,
+  };
+}
+
+describe('ExportEngine.compileContent through the vault seam', () => {
+  it('compiles included items with binder titles as canonical headings', async () => {
+    const { engine } = await makeWorld();
+
+    const compiled = engine.toMarkdown(await engine.compileContent(projectOpts()));
+
+    expect(compiled).toContain('# Chapter One');
+    expect(compiled).toContain('First chapter body.');
+    // The in-document h1 is replaced by the binder title, not duplicated
+    expect(compiled.match(/^# /gm)).toHaveLength(1);
+  });
+
+  it('strips frontmatter when includeFrontmatter is false', async () => {
+    const { engine } = await makeWorld();
+
+    const compiled = await engine.compileContent(projectOpts());
+
+    expect(compiled).not.toContain('word-count');
+    expect(compiled).not.toContain('---\ntitle');
+  });
+
+  it('excludes items marked not for export', async () => {
+    const { engine } = await makeWorld();
+
+    const compiled = await engine.compileContent(projectOpts());
+
+    expect(compiled).not.toContain('Second chapter body.');
+  });
+
+  it('excludes research unless includeResearch is set', async () => {
+    const { engine } = await makeWorld();
+
+    const without = await engine.compileContent(projectOpts());
+    const withResearch = await engine.compileContent(projectOpts({ includeResearch: true }));
+
+    expect(without).not.toContain('Research notes body.');
+    expect(withResearch).toContain('Research notes body.');
+  });
+
+  it('skips binder items whose file is missing', async () => {
+    const { engine } = await makeWorld();
+
+    const compiled = await engine.compileContent(projectOpts());
+
+    expect(compiled).not.toContain('Ghost');
+  });
+
+  it('adds a title page from project metadata when requested', async () => {
+    const { engine } = await makeWorld();
+
+    const compiled = await engine.compileContent(projectOpts({ addTitlePage: true }));
+
+    expect(compiled).toContain('# My Book');
+  });
+});
+
+describe('ExportEngine.export markdown end to end', () => {
+  it('writes the compiled markdown into the project Exports folder', async () => {
+    const { engine, files } = await makeWorld();
+
+    const outputPath = await engine.export(projectOpts());
+
+    expect(outputPath).toMatch(/^Projects\/My Book\/Exports\/My Book-.*\.md$/);
+    const written = files.files.get(outputPath);
+    expect(written).toContain('First chapter body.');
+    expect(files.folders).toContain('Projects/My Book/Exports');
+  });
+});

--- a/tests/inMemoryVaultFiles.ts
+++ b/tests/inMemoryVaultFiles.ts
@@ -1,0 +1,48 @@
+import type { VaultFiles } from '../src/VaultFiles';
+
+// In-memory VaultFiles adapter — the second adapter that makes the seam real.
+// Tests seed `files` and `folders` directly and assert on them after the run.
+export class InMemoryVaultFiles implements VaultFiles {
+  files = new Map<string, string | ArrayBuffer>();
+  folders = new Set<string>();
+
+  async readText(path: string): Promise<string | null> {
+    const value = this.files.get(path);
+    return typeof value === 'string' ? value : null;
+  }
+
+  async writeText(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+
+  async readBinary(path: string): Promise<ArrayBuffer | null> {
+    const value = this.files.get(path);
+    return value instanceof ArrayBuffer ? value : null;
+  }
+
+  async writeBinary(path: string, data: ArrayBuffer): Promise<void> {
+    this.files.set(path, data);
+  }
+
+  async remove(path: string): Promise<void> {
+    this.files.delete(path);
+  }
+
+  exists(path: string): boolean {
+    return this.files.has(path) || this.folders.has(path);
+  }
+
+  async ensureFolder(path: string): Promise<void> {
+    this.folders.add(path);
+  }
+
+  listSubfolders(path: string): string[] {
+    return [...this.folders].filter(f =>
+      f.startsWith(path + '/') && !f.slice(path.length + 1).includes('/')
+    );
+  }
+
+  absolutePath(path: string): string {
+    return `/vault/${path}`;
+  }
+}

--- a/tests/projectManager.test.ts
+++ b/tests/projectManager.test.ts
@@ -1,28 +1,11 @@
 import { ProjectManager } from '../src/ProjectManager';
-import { TFile, TFolder, Notice } from 'obsidian';
+import { Notice } from 'obsidian';
 import { WritingProject } from '../models/Project';
+import { InMemoryVaultFiles } from './inMemoryVaultFiles';
 
-interface MockVault {
-  getAbstractFileByPath: jest.Mock;
-  read: jest.Mock;
-  create: jest.Mock;
-  createFolder: jest.Mock;
-  modify: jest.Mock;
-}
-
-function makeVault(): MockVault {
+function makePlugin() {
   return {
-    getAbstractFileByPath: jest.fn().mockReturnValue(null),
-    read: jest.fn(),
-    create: jest.fn().mockResolvedValue(undefined),
-    createFolder: jest.fn().mockResolvedValue(undefined),
-    modify: jest.fn().mockResolvedValue(undefined),
-  };
-}
-
-function makePlugin(vault: MockVault) {
-  return {
-    app: { vault },
+    app: {},
     settings: { defaultProjectFolder: 'Projects', authorName: '' },
     saveSettings: jest.fn().mockResolvedValue(undefined),
   } as never;
@@ -48,85 +31,101 @@ beforeEach(() => {
 
 describe('ProjectManager.createProject name collision', () => {
   it('refuses to create a project when the target folder already exists', async () => {
-    const vault = makeVault();
-    vault.getAbstractFileByPath.mockImplementation((path: string) =>
-      path === 'Projects/My Book' ? new TFolder('Projects/My Book') : null
-    );
-    const pm = new ProjectManager(makePlugin(vault));
+    const files = new InMemoryVaultFiles();
+    files.folders.add('Projects/My Book');
+    const pm = new ProjectManager(makePlugin(), files);
 
     await expect(pm.createProject('My Book', 'blank', '', '')).rejects.toThrow();
 
     // The existing project's files must be untouched
-    expect(vault.create).not.toHaveBeenCalled();
-    expect(vault.modify).not.toHaveBeenCalled();
-    expect(vault.createFolder).not.toHaveBeenCalled();
+    expect(files.files.size).toBe(0);
   });
 
   it('creates the project when no folder exists', async () => {
-    const vault = makeVault();
-    const pm = new ProjectManager(makePlugin(vault));
+    const files = new InMemoryVaultFiles();
+    const pm = new ProjectManager(makePlugin(), files);
 
     const project = await pm.createProject('Fresh Title', 'blank', '', '');
 
     expect(project.title).toBe('Fresh Title');
-    expect(vault.createFolder).toHaveBeenCalledWith('Projects/Fresh Title');
+    expect(files.folders).toContain('Projects/Fresh Title');
+    expect(files.files.has('Projects/Fresh Title/_project.json')).toBe(true);
+    expect(files.files.has('Projects/Fresh Title/_binder.json')).toBe(true);
+  });
+});
+
+describe('ProjectManager.loadAllProjects', () => {
+  it('loads projects from the immediate subfolders of the root', async () => {
+    const files = new InMemoryVaultFiles();
+    files.folders.add('Projects/Book A');
+    files.files.set('Projects/Book A/_project.json', JSON.stringify({ ...makeProject(), id: 'a', folderPath: 'Projects/Book A' }));
+    const pm = new ProjectManager(makePlugin(), files);
+
+    await pm.loadAllProjects();
+
+    expect(pm.getProject('a')).toBeDefined();
+  });
+
+  it('skips subfolders without a project file', async () => {
+    const files = new InMemoryVaultFiles();
+    files.folders.add('Projects/Not A Project');
+    const pm = new ProjectManager(makePlugin(), files);
+
+    await pm.loadAllProjects();
+
+    expect(pm.getProjects()).toHaveLength(0);
   });
 });
 
 describe('ProjectManager.loadBinder corrupt file handling', () => {
-  function corruptVault(): MockVault {
-    const vault = makeVault();
-    vault.getAbstractFileByPath.mockImplementation((path: string) =>
-      path === 'Projects/My Book/_binder.json' ? new TFile(path) : null
-    );
-    vault.read.mockResolvedValue('{ not valid json');
-    return vault;
+  function corruptFiles(): InMemoryVaultFiles {
+    const files = new InMemoryVaultFiles();
+    files.files.set('Projects/My Book/_binder.json', '{ not valid json');
+    return files;
   }
 
   it('backs up a corrupt binder before returning an empty one', async () => {
-    const vault = corruptVault();
-    const pm = new ProjectManager(makePlugin(vault));
+    const files = corruptFiles();
+    const pm = new ProjectManager(makePlugin(), files);
 
     const binder = await pm.loadBinder(makeProject());
 
     expect(binder.items).toEqual([]);
-    expect(vault.create).toHaveBeenCalledWith(
-      'Projects/My Book/_binder.json.bak',
-      '{ not valid json'
-    );
+    expect(files.files.get('Projects/My Book/_binder.json.bak')).toBe('{ not valid json');
     expect(Notice.messages.length).toBe(1);
   });
 
   it('does not cache the empty binder so a repaired file is picked up', async () => {
-    const vault = corruptVault();
-    const pm = new ProjectManager(makePlugin(vault));
+    const files = corruptFiles();
+    const read = jest.spyOn(files, 'readText');
+    const pm = new ProjectManager(makePlugin(), files);
     const project = makeProject();
 
     await pm.loadBinder(project);
     await pm.loadBinder(project);
 
     // Cached results would skip the second read
-    expect(vault.read).toHaveBeenCalledTimes(2);
+    expect(read).toHaveBeenCalledTimes(2);
   });
 
   it('caches a valid binder', async () => {
-    const vault = corruptVault();
-    vault.read.mockResolvedValue('{"version":"2.0","projectId":"project-1","items":[]}');
-    const pm = new ProjectManager(makePlugin(vault));
+    const files = new InMemoryVaultFiles();
+    files.files.set('Projects/My Book/_binder.json', '{"version":"2.0","projectId":"project-1","items":[]}');
+    const read = jest.spyOn(files, 'readText');
+    const pm = new ProjectManager(makePlugin(), files);
     const project = makeProject();
 
     await pm.loadBinder(project);
     await pm.loadBinder(project);
 
-    expect(vault.read).toHaveBeenCalledTimes(1);
-    expect(vault.create).not.toHaveBeenCalled();
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(files.files.has('Projects/My Book/_binder.json.bak')).toBe(false);
   });
 });
 
 describe('ProjectManager change notification', () => {
   it('announces the active project on setActiveProject', async () => {
-    const vault = makeVault();
-    const pm = new ProjectManager(makePlugin(vault));
+    const pm = new ProjectManager(makePlugin(), new InMemoryVaultFiles());
     const project = makeProject();
     await pm.saveProject(project);
     const seen: (WritingProject | null)[] = [];
@@ -139,8 +138,7 @@ describe('ProjectManager change notification', () => {
   });
 
   it('announces binder-changed with the saved binder', async () => {
-    const vault = makeVault();
-    const pm = new ProjectManager(makePlugin(vault));
+    const pm = new ProjectManager(makePlugin(), new InMemoryVaultFiles());
     await pm.saveProject(makeProject());
     const seen: string[] = [];
     pm.onBinderChanged(binder => { seen.push(binder.projectId); });
@@ -151,8 +149,7 @@ describe('ProjectManager change notification', () => {
   });
 
   it('announces projects-changed when a project is saved', async () => {
-    const vault = makeVault();
-    const pm = new ProjectManager(makePlugin(vault));
+    const pm = new ProjectManager(makePlugin(), new InMemoryVaultFiles());
     const events = jest.fn();
     pm.onProjectsChanged(events);
 
@@ -162,8 +159,7 @@ describe('ProjectManager change notification', () => {
   });
 
   it('does not announce binder-changed for an unknown project', async () => {
-    const vault = makeVault();
-    const pm = new ProjectManager(makePlugin(vault));
+    const pm = new ProjectManager(makePlugin(), new InMemoryVaultFiles());
     const events = jest.fn();
     pm.onBinderChanged(events);
 
@@ -174,8 +170,7 @@ describe('ProjectManager change notification', () => {
   });
 
   it('stops announcing after offref', async () => {
-    const vault = makeVault();
-    const pm = new ProjectManager(makePlugin(vault));
+    const pm = new ProjectManager(makePlugin(), new InMemoryVaultFiles());
     const events = jest.fn();
     const ref = pm.onProjectsChanged(events);
     pm.offref(ref);
@@ -188,29 +183,23 @@ describe('ProjectManager change notification', () => {
 
 describe('ProjectManager.addDocumentToBinder filename de-duplication', () => {
   it('suffixes the filename when the target file already exists', async () => {
-    const vault = makeVault();
-    const existing = new Set([
-      'Projects/My Book/Chapters/Interlude.md',
-      'Projects/My Book/Chapters/Interlude 2.md',
-    ]);
-    vault.getAbstractFileByPath.mockImplementation((path: string) =>
-      existing.has(path) ? new TFile(path) : null
-    );
-    const pm = new ProjectManager(makePlugin(vault));
+    const files = new InMemoryVaultFiles();
+    files.files.set('Projects/My Book/Chapters/Interlude.md', 'x');
+    files.files.set('Projects/My Book/Chapters/Interlude 2.md', 'x');
+    const pm = new ProjectManager(makePlugin(), files);
+    await pm.saveProject(makeProject());
 
     const item = await pm.addDocumentToBinder(makeProject(), 'Interlude', 'chapter');
 
     expect(item.filePath).toBe('Projects/My Book/Chapters/Interlude 3.md');
     expect(item.title).toBe('Interlude');
-    expect(vault.create).toHaveBeenCalledWith(
-      'Projects/My Book/Chapters/Interlude 3.md',
-      expect.stringContaining('title: "Interlude"')
-    );
+    expect(files.files.get('Projects/My Book/Chapters/Interlude 3.md')).toContain('title: "Interlude"');
   });
 
   it('uses the plain filename when no collision exists', async () => {
-    const vault = makeVault();
-    const pm = new ProjectManager(makePlugin(vault));
+    const files = new InMemoryVaultFiles();
+    const pm = new ProjectManager(makePlugin(), files);
+    await pm.saveProject(makeProject());
 
     const item = await pm.addDocumentToBinder(makeProject(), 'Chapter One', 'chapter');
 


### PR DESCRIPTION
Closes #140. Post-audit improvement 3 of 7 — accumulates under [Unreleased]; no release until all seven land.

## What changed
- **`src/VaultFiles.ts`** — the one narrow interface over vault file I/O: `readText` / `writeText` (create-or-modify) / `readBinary` / `writeBinary` / `remove` / `exists` / `ensureFolder` / `listSubfolders` / `absolutePath`. `ObsidianVaultFiles` wraps the live vault; `tests/inMemoryVaultFiles.ts` is the second adapter that makes the seam real.
- **ProjectManager** — all `_project.json` / `_binder.json` / `_writing-log.json` and document-file I/O goes through the seam. Private `writeRaw`/`ensureFolder` helpers deleted.
- **ExportEngine** — compile reads, export writes, pandoc temp-file handling, and absolute-path resolution converted; private `writeFile`/`getAbsPath`/`ensureFolder` deleted (they duplicated ProjectManager's).
- **EpubEngine** — cover read and epub write converted; it needed nothing else from the plugin, so its constructor is now just `(files: VaultFiles)`.
- main.ts creates one `ObsidianVaultFiles` and injects it into both consumers.

## Test surface unlock
`tests/exportEngine.test.ts` runs a **real ProjectManager + ExportEngine** against the in-memory adapter — the compile/export pipeline has automated coverage for the first time: binder-title heading canonicalization (no duplicate h1), frontmatter stripping, export-exclusion and research filtering, missing-file skips, title page, and a full markdown export landing in the project Exports folder. projectManager tests were rewritten to the seam (state-based assertions instead of mock-call counting) and gained `loadAllProjects` coverage.

132 tests passing (15 suites). Out of scope: templates keep using `app` directly until item 5 (the scaffolder, #141) replaces them; views are item 4/6 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)