### PR TITLE
refactor: project templates become declarative manifests (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Writing Studio are documented here.
 ### Internal
 - The plugin entry point (main.ts) was decomposed: the 19 palette commands now live in a declarative registry (`src/commands.ts`), the four status bar items and their fixed ordering in `src/StatusBar.ts`, and the inline goal banner in `src/GoalBanner.ts`. New tests enforce command-table integrity (unique ids, valid i18n keys, sentence-case names) and the status bar ordering invariant. (#139)
 - File access now goes through a narrow vault adapter (`src/VaultFiles.ts`) consumed by the project manager and both export engines, with an in-memory implementation for tests. The compile/export pipeline — frontmatter stripping, binder-title headings, research and export-exclusion filtering — is covered by automated tests for the first time. (#140)
+- The five project templates are now declarative manifests applied by a single scaffolder (`src/scaffold.ts`); the per-template file-creation boilerplate is gone and template scaffolding (tree shape, sibling ordering, never-overwrite guard) is covered by tests. Adding a project type is now data entry. (#141)
 - Removed the deprecated `setDynamicTooltip()` call on the focus dim opacity and line length sliders — Obsidian 1.13 always shows the slider value inline. (On Obsidian versions before 1.13 the value tooltip while dragging is no longer shown.)
 
 ### Internal

--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ __export(main_exports, {
   default: () => WritingStudioPlugin
 });
 module.exports = __toCommonJS(main_exports);
-var import_obsidian34 = require("obsidian");
+var import_obsidian30 = require("obsidian");
 
 // src/BinderView.ts
 var import_obsidian9 = require("obsidian");
@@ -14631,183 +14631,156 @@ var WordPressClient = class {
 };
 
 // src/ProjectManager.ts
-var import_obsidian25 = require("obsidian");
+var import_obsidian21 = require("obsidian");
+
+// src/scaffold.ts
+var import_obsidian20 = require("obsidian");
+function templateDoc(f) {
+  var _a2, _b2, _c;
+  const extra = Object.entries((_a2 = f.extraFields) != null ? _a2 : {}).map(([k, v]) => `
+${k}: "${v}"`).join("");
+  const goalLine = f.goal && f.goal > 0 ? `
+word-count-goal: ${f.goal}` : "";
+  const exportLine = f.exportExcluded ? "\ninclude-in-export: false" : "";
+  const tags = ((_b2 = f.tags) != null ? _b2 : ["writing-studio"]).join(", ");
+  return `---
+title: "${f.title}"${extra}
+type: ${f.fmType}
+order: ${f.order}
+status: draft${goalLine}${exportLine}
+word-count: 0
+created: ${f.date}
+modified: ${f.date}
+tags: [${tags}]
+---
+
+# ${(_c = f.heading) != null ? _c : f.title}
+
+${f.body}
+`;
+}
+function placeholderHint(text) {
+  return `> [!note] Placeholder
+> *${text}*`;
+}
+var TemplateScaffolder = class {
+  constructor(files) {
+    this.files = files;
+  }
+  async apply(project, manifest) {
+    var _a2;
+    const chapters = (0, import_obsidian20.normalizePath)(`${project.folderPath}/Chapters`);
+    for (const folder of (_a2 = manifest.folders) != null ? _a2 : []) {
+      await this.files.ensureFolder((0, import_obsidian20.normalizePath)(`${chapters}/${folder}`));
+    }
+    const items = await this.buildItems(manifest.items, chapters);
+    return { version: "2.0", projectId: project.id, items };
+  }
+  async buildItems(nodes, chapters) {
+    var _a2, _b2;
+    const items = [];
+    let order = 1;
+    for (const node of nodes) {
+      let filePath = "";
+      if (node.fileName) {
+        filePath = (0, import_obsidian20.normalizePath)(`${chapters}/${node.fileName}.md`);
+        if (!this.files.exists(filePath)) {
+          await this.files.writeText(filePath, (_a2 = node.content) != null ? _a2 : "");
+        }
+      }
+      const item = {
+        id: node.id,
+        title: node.title,
+        filePath,
+        type: node.type,
+        order: order++,
+        status: "draft",
+        includeInExport: (_b2 = node.includeInExport) != null ? _b2 : true
+      };
+      if (node.wordCountGoal) item.wordCountGoal = node.wordCountGoal;
+      if (node.children) item.children = await this.buildItems(node.children, chapters);
+      items.push(item);
+    }
+    return items;
+  }
+};
 
 // templates/BookTemplate.ts
-var import_obsidian20 = require("obsidian");
-var BookTemplate = class _BookTemplate {
-  static async apply(app, project) {
-    const now = localDateString();
-    const chaptersPath = (0, import_obsidian20.normalizePath)(`${project.folderPath}/Chapters`);
-    const frontMatterFile = (0, import_obsidian20.normalizePath)(`${chaptersPath}/Front Matter.md`);
-    const chapter1File = (0, import_obsidian20.normalizePath)(`${chaptersPath}/Part 1 - Chapter 1.md`);
-    const backMatterFile = (0, import_obsidian20.normalizePath)(`${chaptersPath}/Back Matter.md`);
-    await _BookTemplate.createFile(app, frontMatterFile, _BookTemplate.frontMatterDoc(now));
-    await _BookTemplate.createFile(app, chapter1File, _BookTemplate.chapter1Doc(project.title, now));
-    await _BookTemplate.createFile(app, backMatterFile, _BookTemplate.backMatterDoc(now));
-    const items = [
+function bookManifest(_project) {
+  const date = localDateString();
+  return {
+    items: [
       {
         id: "item-front-matter",
         title: "Front Matter",
-        filePath: frontMatterFile,
         type: "section",
-        order: 1,
-        status: "draft",
-        includeInExport: true
+        fileName: "Front Matter",
+        content: templateDoc({
+          title: "Front Matter",
+          fmType: "section",
+          order: 1,
+          date,
+          body: "*Title page, dedication, table of contents, and other front matter goes here.*"
+        })
       },
       {
         id: "item-part-1",
         title: "Part 1",
-        filePath: "",
         type: "part",
-        order: 2,
-        status: "draft",
-        includeInExport: true,
         children: [
           {
             id: "item-chapter-1",
             title: "Chapter 1",
-            filePath: chapter1File,
             type: "chapter",
-            order: 1,
-            status: "draft",
+            fileName: "Part 1 - Chapter 1",
             wordCountGoal: 3e3,
-            includeInExport: true
+            content: templateDoc({
+              title: "Chapter 1",
+              fmType: "chapter",
+              order: 1,
+              goal: 3e3,
+              date,
+              body: "*Begin your story here.*"
+            })
           }
         ]
       },
       {
         id: "item-back-matter",
         title: "Back Matter",
-        filePath: backMatterFile,
         type: "section",
-        order: 3,
-        status: "draft",
-        includeInExport: true
+        fileName: "Back Matter",
+        content: templateDoc({
+          title: "Back Matter",
+          fmType: "section",
+          order: 3,
+          date,
+          body: "*Acknowledgments, bibliography, author bio, and other back matter goes here.*"
+        })
       }
-    ];
-    return {
-      version: "2.0",
-      projectId: project.id,
-      items
-    };
-  }
-  static async createFile(app, path, content2) {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content2);
-    }
-  }
-  static frontMatterDoc(date) {
-    return `---
-title: "Front Matter"
-type: section
-order: 1
-status: draft
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# Front Matter
-
-*Title page, dedication, table of contents, and other front matter goes here.*
-`;
-  }
-  static chapter1Doc(_projectTitle, date) {
-    return `---
-title: "Chapter 1"
-type: chapter
-order: 1
-status: draft
-word-count-goal: 3000
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# Chapter 1
-
-*Begin your story here.*
-`;
-  }
-  static backMatterDoc(date) {
-    return `---
-title: "Back Matter"
-type: section
-order: 3
-status: draft
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# Back Matter
-
-*Acknowledgments, bibliography, author bio, and other back matter goes here.*
-`;
-  }
-};
+    ]
+  };
+}
 
 // templates/ArticleSeriesTemplate.ts
-var import_obsidian21 = require("obsidian");
-var ArticleSeriesTemplate = class _ArticleSeriesTemplate {
-  static async apply(app, project) {
-    const now = localDateString();
-    const chaptersPath = (0, import_obsidian21.normalizePath)(`${project.folderPath}/Chapters`);
-    const seriesMetaFile = (0, import_obsidian21.normalizePath)(`${chaptersPath}/Series Overview.md`);
-    const article1File = (0, import_obsidian21.normalizePath)(`${chaptersPath}/Article 1.md`);
-    await _ArticleSeriesTemplate.createFile(app, seriesMetaFile, _ArticleSeriesTemplate.seriesOverviewDoc(project.title, now));
-    await _ArticleSeriesTemplate.createFile(app, article1File, _ArticleSeriesTemplate.article1Doc(project.title, now));
-    const items = [
+function articleSeriesManifest(project) {
+  const date = localDateString();
+  return {
+    items: [
       {
         id: "item-series-overview",
         title: "Series Overview",
-        filePath: seriesMetaFile,
         type: "note",
-        order: 1,
-        status: "draft",
-        includeInExport: false
-      },
-      {
-        id: "item-article-1",
-        title: "Article 1",
-        filePath: article1File,
-        type: "article",
-        order: 2,
-        status: "draft",
-        wordCountGoal: 1500,
-        includeInExport: true
-      }
-    ];
-    return {
-      version: "2.0",
-      projectId: project.id,
-      items
-    };
-  }
-  static async createFile(app, path, content2) {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content2);
-    }
-  }
-  static seriesOverviewDoc(title, date) {
-    return `---
-title: "Series Overview"
-type: note
-order: 1
-status: draft
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio, series-meta]
----
-
-# ${title} \u2014 Series Overview
-
-## Series Description
+        fileName: "Series Overview",
+        includeInExport: false,
+        content: templateDoc({
+          title: "Series Overview",
+          fmType: "note",
+          order: 1,
+          date,
+          tags: ["writing-studio", "series-meta"],
+          heading: `${project.title} \u2014 Series Overview`,
+          body: `## Series Description
 
 *Describe the series premise, target audience, and goals here.*
 
@@ -14820,283 +14793,298 @@ tags: [writing-studio, series-meta]
 ## WordPress Settings
 
 - **Site:** *(configure in Settings \u2192 WordPress)*
-- **Category:** *(set in Project Settings)*
-`;
-  }
-  static article1Doc(_seriesTitle, date) {
-    return `---
-title: "Article 1"
-type: article
-order: 1
-status: draft
-word-count-goal: 1500
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# Article 1
-
-*Write your first article here.*
-`;
-  }
-};
+- **Category:** *(set in Project Settings)*`
+        })
+      },
+      {
+        id: "item-article-1",
+        title: "Article 1",
+        type: "article",
+        fileName: "Article 1",
+        wordCountGoal: 1500,
+        content: templateDoc({
+          title: "Article 1",
+          fmType: "article",
+          order: 1,
+          goal: 1500,
+          date,
+          body: "*Write your first article here.*"
+        })
+      }
+    ]
+  };
+}
 
 // templates/BlogCollectionTemplate.ts
-var import_obsidian22 = require("obsidian");
-var BlogCollectionTemplate = class _BlogCollectionTemplate {
-  static async apply(app, project) {
-    const now = localDateString();
-    const chaptersPath = (0, import_obsidian22.normalizePath)(`${project.folderPath}/Chapters`);
-    const year = (/* @__PURE__ */ new Date()).getFullYear();
-    await _BlogCollectionTemplate.createFolder(app, (0, import_obsidian22.normalizePath)(`${chaptersPath}/${year}`));
-    const firstPostFile = (0, import_obsidian22.normalizePath)(`${chaptersPath}/${year}/${now}-first-post.md`);
-    await _BlogCollectionTemplate.createFile(app, firstPostFile, _BlogCollectionTemplate.firstPostDoc(now));
-    const items = [
+function blogCollectionManifest(_project) {
+  const date = localDateString();
+  const year = (/* @__PURE__ */ new Date()).getFullYear();
+  return {
+    folders: [String(year)],
+    items: [
       {
         id: `item-year-${year}`,
         title: String(year),
-        filePath: "",
         type: "group",
-        order: 1,
-        status: "draft",
         includeInExport: false,
         children: [
           {
             id: "item-first-post",
             title: "First Post",
-            filePath: firstPostFile,
             type: "article",
-            order: 1,
-            status: "draft",
+            fileName: `${year}/${date}-first-post`,
             wordCountGoal: 800,
-            includeInExport: true
+            content: templateDoc({
+              title: "First Post",
+              fmType: "article",
+              order: 1,
+              goal: 800,
+              date,
+              body: "*Write your first blog post here.*"
+            })
           }
         ]
       }
-    ];
-    return {
-      version: "2.0",
-      projectId: project.id,
-      items
-    };
-  }
-  static async createFile(app, path, content2) {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content2);
-    }
-  }
-  static async createFolder(app, path) {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.createFolder(path);
-    }
-  }
-  static firstPostDoc(date) {
-    return `---
-title: "First Post"
-type: article
-order: 1
-status: draft
-word-count-goal: 800
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# First Post
-
-*Write your first blog post here.*
-`;
-  }
-};
+    ]
+  };
+}
 
 // templates/JournalArticleTemplate.ts
-var import_obsidian23 = require("obsidian");
-var JournalArticleTemplate = class _JournalArticleTemplate {
-  static async apply(app, project) {
-    const now = localDateString();
-    const p = (name) => (0, import_obsidian23.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
-    const docs = [
-      [p("Title Page"), _JournalArticleTemplate.titlePageDoc(project.title, project.author, now)],
-      [p("Abstract"), _JournalArticleTemplate.standardDoc("Abstract", "abstract", 2, 250, now, "Write a concise summary of the article in 150\u2013250 words. Include research question, methodology, key findings, and conclusion.")],
-      [p("Keywords"), _JournalArticleTemplate.standardDoc("Keywords", "keywords", 3, 0, now, "List 4\u20136 keywords separated by commas.")],
-      [p("Introduction"), _JournalArticleTemplate.standardDoc("Introduction", "section", 4, 600, now, "Introduce the topic, state the research question or thesis, and outline the structure of the article.")],
-      [p("Literature Review"), _JournalArticleTemplate.standardDoc("Literature Review", "section", 5, 1e3, now, "Survey the relevant scholarship. Identify gaps your article addresses.")],
-      [p("Methodology"), _JournalArticleTemplate.standardDoc("Methodology", "section", 6, 600, now, "Describe your research method, sources, and analytical approach.")],
-      [p("Findings - Analysis"), _JournalArticleTemplate.standardDoc("Findings / Analysis", "section", 7, 1500, now, "Present and analyze your findings. Use subheadings as needed.")],
-      [p("Discussion"), _JournalArticleTemplate.standardDoc("Discussion", "section", 8, 800, now, "Interpret findings in light of the literature. Address implications and limitations.")],
-      [p("Conclusion"), _JournalArticleTemplate.standardDoc("Conclusion", "section", 9, 400, now, "Summarize the argument, restate significance, and suggest future research directions.")],
-      [p("References"), _JournalArticleTemplate.standardDoc("References", "references", 10, 0, now, "List all cited works here. Format according to target journal style (APA, MLA, Chicago, etc.).")],
-      [p("Appendices"), _JournalArticleTemplate.standardDoc("Appendices", "appendix", 11, 0, now, "Include supplementary materials, data tables, or extended quotations here if needed.")]
-    ];
-    for (const [filePath, content2] of docs) {
-      await _JournalArticleTemplate.createFile(app, filePath, content2);
-    }
-    const items = [
-      { id: "ja-title-page", title: "Title Page", filePath: p("Title Page"), type: "section", order: 1, status: "draft", wordCountGoal: 500, includeInExport: true },
-      { id: "ja-abstract", title: "Abstract", filePath: p("Abstract"), type: "section", order: 2, status: "draft", wordCountGoal: 250, includeInExport: true },
-      { id: "ja-keywords", title: "Keywords", filePath: p("Keywords"), type: "section", order: 3, status: "draft", includeInExport: true },
-      { id: "ja-introduction", title: "Introduction", filePath: p("Introduction"), type: "section", order: 4, status: "draft", wordCountGoal: 600, includeInExport: true },
-      { id: "ja-literature-review", title: "Literature Review", filePath: p("Literature Review"), type: "section", order: 5, status: "draft", wordCountGoal: 1e3, includeInExport: true },
-      { id: "ja-methodology", title: "Methodology", filePath: p("Methodology"), type: "section", order: 6, status: "draft", wordCountGoal: 600, includeInExport: true },
-      { id: "ja-findings", title: "Findings / Analysis", filePath: p("Findings - Analysis"), type: "section", order: 7, status: "draft", wordCountGoal: 1500, includeInExport: true },
-      { id: "ja-discussion", title: "Discussion", filePath: p("Discussion"), type: "section", order: 8, status: "draft", wordCountGoal: 800, includeInExport: true },
-      { id: "ja-conclusion", title: "Conclusion", filePath: p("Conclusion"), type: "section", order: 9, status: "draft", wordCountGoal: 400, includeInExport: true },
-      { id: "ja-references", title: "References", filePath: p("References"), type: "section", order: 10, status: "draft", includeInExport: true },
-      { id: "ja-appendices", title: "Appendices", filePath: p("Appendices"), type: "section", order: 11, status: "draft", includeInExport: true }
-    ];
-    return { version: "2.0", projectId: project.id, items };
+var SECTIONS = [
+  {
+    id: "ja-abstract",
+    title: "Abstract",
+    fmType: "abstract",
+    goal: 250,
+    hint: "Write a concise summary of the article in 150\u2013250 words. Include research question, methodology, key findings, and conclusion."
+  },
+  {
+    id: "ja-keywords",
+    title: "Keywords",
+    fmType: "keywords",
+    hint: "List 4\u20136 keywords separated by commas."
+  },
+  {
+    id: "ja-introduction",
+    title: "Introduction",
+    fmType: "section",
+    goal: 600,
+    hint: "Introduce the topic, state the research question or thesis, and outline the structure of the article."
+  },
+  {
+    id: "ja-literature-review",
+    title: "Literature Review",
+    fmType: "section",
+    goal: 1e3,
+    hint: "Survey the relevant scholarship. Identify gaps your article addresses."
+  },
+  {
+    id: "ja-methodology",
+    title: "Methodology",
+    fmType: "section",
+    goal: 600,
+    hint: "Describe your research method, sources, and analytical approach."
+  },
+  {
+    id: "ja-findings",
+    title: "Findings / Analysis",
+    fileName: "Findings - Analysis",
+    fmType: "section",
+    goal: 1500,
+    hint: "Present and analyze your findings. Use subheadings as needed."
+  },
+  {
+    id: "ja-discussion",
+    title: "Discussion",
+    fmType: "section",
+    goal: 800,
+    hint: "Interpret findings in light of the literature. Address implications and limitations."
+  },
+  {
+    id: "ja-conclusion",
+    title: "Conclusion",
+    fmType: "section",
+    goal: 400,
+    hint: "Summarize the argument, restate significance, and suggest future research directions."
+  },
+  {
+    id: "ja-references",
+    title: "References",
+    fmType: "references",
+    hint: "List all cited works here. Format according to target journal style (APA, MLA, Chicago, etc.)."
+  },
+  {
+    id: "ja-appendices",
+    title: "Appendices",
+    fmType: "appendix",
+    hint: "Include supplementary materials, data tables, or extended quotations here if needed."
   }
-  static async createFile(app, path, content2) {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content2);
-    }
-  }
-  static hint(text) {
-    return `> [!note] Placeholder
-> *${text}*`;
-  }
-  static titlePageDoc(title, author, date) {
-    return `---
-title: "${title}"
-author: "${author}"
-institutional-affiliation: ""
-submission-date: "${date}"
-journal-target: ""
-submission-deadline: ""
-type: section
-order: 1
-status: draft
-word-count-goal: 500
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# ${title}
-
-${_JournalArticleTemplate.hint("Enter the article title, author name, institutional affiliation, submission date, and target journal name.")}
-`;
-  }
-  static standardDoc(title, type, order, goal, date, hintText) {
-    const goalLine = goal > 0 ? `
-word-count-goal: ${goal}` : "";
-    return `---
-title: "${title}"
-type: ${type}
-order: ${order}
-status: draft${goalLine}
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# ${title}
-
-${_JournalArticleTemplate.hint(hintText)}
-`;
-  }
-};
+];
+function journalArticleManifest(project) {
+  const date = localDateString();
+  const titlePage = {
+    id: "ja-title-page",
+    title: "Title Page",
+    type: "section",
+    fileName: "Title Page",
+    wordCountGoal: 500,
+    content: templateDoc({
+      title: project.title,
+      fmType: "section",
+      order: 1,
+      goal: 500,
+      date,
+      extraFields: {
+        author: project.author,
+        "institutional-affiliation": "",
+        "submission-date": date,
+        "journal-target": "",
+        "submission-deadline": ""
+      },
+      body: placeholderHint("Enter the article title, author name, institutional affiliation, submission date, and target journal name.")
+    })
+  };
+  const sections = SECTIONS.map((s, i) => {
+    var _a2;
+    return {
+      id: s.id,
+      title: s.title,
+      type: "section",
+      fileName: (_a2 = s.fileName) != null ? _a2 : s.title,
+      wordCountGoal: s.goal,
+      content: templateDoc({
+        title: s.title,
+        fmType: s.fmType,
+        order: i + 2,
+        goal: s.goal,
+        date,
+        body: placeholderHint(s.hint)
+      })
+    };
+  });
+  return { items: [titlePage, ...sections] };
+}
 
 // templates/MagazineArticleTemplate.ts
-var import_obsidian24 = require("obsidian");
-var MagazineArticleTemplate = class _MagazineArticleTemplate {
-  static async apply(app, project) {
-    const now = localDateString();
-    const p = (name) => (0, import_obsidian24.normalizePath)(`${project.folderPath}/Chapters/${name}.md`);
-    const docs = [
-      [p("Pitch - Query Notes"), _MagazineArticleTemplate.notesDoc(
-        "Pitch / Query Notes",
-        "notes",
-        1,
-        300,
-        now,
-        "Record your pitch angle, target publication, editor contact, and deadline here.",
-        { "target-publication": "", "editor-contact": "", "deadline": "" }
-      )],
-      [p("Headline and Deck"), _MagazineArticleTemplate.standardDoc("Headline & Deck", "headline", 2, 30, now, "Write your working headline and subheadline (deck) here. Headline: punchy, specific. Deck: expands the promise of the headline.")],
-      [p("Lede"), _MagazineArticleTemplate.standardDoc("Lede (Opening)", "section", 3, 150, now, "Write your opening paragraph. Anecdote, scene, provocative statement, or surprising fact. Hook the reader immediately.")],
-      [p("Nut Graf"), _MagazineArticleTemplate.standardDoc("Nut Graf", "section", 4, 100, now, "Tell the reader what this story is about and why it matters now. Usually 1\u20132 paragraphs following the lede.")],
-      [p("Body"), _MagazineArticleTemplate.standardDoc("Body", "section", 5, 1500, now, "Develop the story. Alternate between narrative, quotes, data, and analysis. Use subheadings to organize long sections.")],
-      [p("Quotes and Sources"), _MagazineArticleTemplate.notesDoc("Quotes & Sources", "notes", 6, 0, now, "Collect key quotes and source attributions here for reference while writing.")],
-      [p("Kicker"), _MagazineArticleTemplate.standardDoc("Kicker (Closing)", "section", 7, 150, now, "Write your closing. Return to the opening anecdote, deliver the payoff, or leave the reader with a resonant final thought.")],
-      [p("Fact-Check Notes"), _MagazineArticleTemplate.notesDoc("Fact-Check Notes", "notes", 8, 0, now, "List every factual claim that requires verification, with source links or contact info.")],
-      [p("Author Bio"), _MagazineArticleTemplate.standardDoc("Author Bio", "bio", 9, 75, now, "Write a third-person author bio of 50\u201375 words for publication.")]
-    ];
-    for (const [filePath, content2] of docs) {
-      await _MagazineArticleTemplate.createFile(app, filePath, content2);
-    }
-    const items = [
-      { id: "ma-pitch", title: "Pitch / Query Notes", filePath: p("Pitch - Query Notes"), type: "note", order: 1, status: "draft", wordCountGoal: 300, includeInExport: false },
-      { id: "ma-headline", title: "Headline & Deck", filePath: p("Headline and Deck"), type: "section", order: 2, status: "draft", wordCountGoal: 30, includeInExport: true },
-      { id: "ma-lede", title: "Lede (Opening)", filePath: p("Lede"), type: "section", order: 3, status: "draft", wordCountGoal: 150, includeInExport: true },
-      { id: "ma-nut-graf", title: "Nut Graf", filePath: p("Nut Graf"), type: "section", order: 4, status: "draft", wordCountGoal: 100, includeInExport: true },
-      { id: "ma-body", title: "Body", filePath: p("Body"), type: "section", order: 5, status: "draft", wordCountGoal: 1500, includeInExport: true },
-      { id: "ma-quotes", title: "Quotes & Sources", filePath: p("Quotes and Sources"), type: "note", order: 6, status: "draft", includeInExport: false },
-      { id: "ma-kicker", title: "Kicker (Closing)", filePath: p("Kicker"), type: "section", order: 7, status: "draft", wordCountGoal: 150, includeInExport: true },
-      { id: "ma-fact-check", title: "Fact-Check Notes", filePath: p("Fact-Check Notes"), type: "note", order: 8, status: "draft", includeInExport: false },
-      { id: "ma-author-bio", title: "Author Bio", filePath: p("Author Bio"), type: "section", order: 9, status: "draft", wordCountGoal: 75, includeInExport: true }
-    ];
-    return { version: "2.0", projectId: project.id, items };
+var SECTIONS2 = [
+  {
+    id: "ma-pitch",
+    title: "Pitch / Query Notes",
+    fileName: "Pitch - Query Notes",
+    type: "note",
+    fmType: "notes",
+    goal: 300,
+    exportExcluded: true,
+    extraFields: { "target-publication": "", "editor-contact": "", "deadline": "" },
+    hint: "Record your pitch angle, target publication, editor contact, and deadline here."
+  },
+  {
+    id: "ma-headline",
+    title: "Headline & Deck",
+    fileName: "Headline and Deck",
+    type: "section",
+    fmType: "headline",
+    goal: 30,
+    hint: "Write your working headline and subheadline (deck) here. Headline: punchy, specific. Deck: expands the promise of the headline."
+  },
+  {
+    id: "ma-lede",
+    title: "Lede (Opening)",
+    fileName: "Lede",
+    type: "section",
+    fmType: "section",
+    goal: 150,
+    hint: "Write your opening paragraph. Anecdote, scene, provocative statement, or surprising fact. Hook the reader immediately."
+  },
+  {
+    id: "ma-nut-graf",
+    title: "Nut Graf",
+    fileName: "Nut Graf",
+    type: "section",
+    fmType: "section",
+    goal: 100,
+    hint: "Tell the reader what this story is about and why it matters now. Usually 1\u20132 paragraphs following the lede."
+  },
+  {
+    id: "ma-body",
+    title: "Body",
+    fileName: "Body",
+    type: "section",
+    fmType: "section",
+    goal: 1500,
+    hint: "Develop the story. Alternate between narrative, quotes, data, and analysis. Use subheadings to organize long sections."
+  },
+  {
+    id: "ma-quotes",
+    title: "Quotes & Sources",
+    fileName: "Quotes and Sources",
+    type: "note",
+    fmType: "notes",
+    exportExcluded: true,
+    hint: "Collect key quotes and source attributions here for reference while writing."
+  },
+  {
+    id: "ma-kicker",
+    title: "Kicker (Closing)",
+    fileName: "Kicker",
+    type: "section",
+    fmType: "section",
+    goal: 150,
+    hint: "Write your closing. Return to the opening anecdote, deliver the payoff, or leave the reader with a resonant final thought."
+  },
+  {
+    id: "ma-fact-check",
+    title: "Fact-Check Notes",
+    fileName: "Fact-Check Notes",
+    type: "note",
+    fmType: "notes",
+    exportExcluded: true,
+    hint: "List every factual claim that requires verification, with source links or contact info."
+  },
+  {
+    id: "ma-author-bio",
+    title: "Author Bio",
+    fileName: "Author Bio",
+    type: "section",
+    fmType: "bio",
+    goal: 75,
+    hint: "Write a third-person author bio of 50\u201375 words for publication."
   }
-  static async createFile(app, path, content2) {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content2);
-    }
-  }
-  static hint(text) {
-    return `> [!note] Placeholder
-> *${text}*`;
-  }
-  static standardDoc(title, type, order, goal, date, hintText) {
-    const goalLine = goal > 0 ? `
-word-count-goal: ${goal}` : "";
-    return `---
-title: "${title}"
-type: ${type}
-order: ${order}
-status: draft${goalLine}
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
+];
+function magazineArticleManifest(_project) {
+  const date = localDateString();
+  const items = SECTIONS2.map((s, i) => ({
+    id: s.id,
+    title: s.title,
+    type: s.type,
+    fileName: s.fileName,
+    wordCountGoal: s.goal,
+    includeInExport: !s.exportExcluded,
+    content: templateDoc({
+      title: s.title,
+      fmType: s.fmType,
+      order: i + 1,
+      goal: s.goal,
+      date,
+      exportExcluded: s.exportExcluded,
+      extraFields: s.extraFields,
+      body: placeholderHint(s.hint)
+    })
+  }));
+  return { items };
+}
 
-# ${title}
-
-${_MagazineArticleTemplate.hint(hintText)}
-`;
-  }
-  static notesDoc(title, type, order, goal, date, hintText, extraFields = {}) {
-    const goalLine = goal > 0 ? `
-word-count-goal: ${goal}` : "";
-    const extra = Object.entries(extraFields).map(([k, v]) => `
-${k}: "${v}"`).join("");
-    return `---
-title: "${title}"
-type: ${type}
-order: ${order}
-status: draft${goalLine}
-include-in-export: false
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]${extra}
----
-
-# ${title}
-
-${_MagazineArticleTemplate.hint(hintText)}
-`;
-  }
+// templates/manifests.ts
+var TEMPLATE_MANIFESTS = {
+  book: bookManifest,
+  series: articleSeriesManifest,
+  blog: blogCollectionManifest,
+  "journal-article": journalArticleManifest,
+  "magazine-article": magazineArticleManifest
 };
 
 // src/ProjectManager.ts
-var ProjectManager = class extends import_obsidian25.Events {
+var ProjectManager = class extends import_obsidian21.Events {
   constructor(plugin, files) {
     super();
     this.projects = /* @__PURE__ */ new Map();
@@ -15134,18 +15122,18 @@ var ProjectManager = class extends import_obsidian25.Events {
     this.projects.clear();
     const rootFolder = this.plugin.settings.defaultProjectFolder;
     if (!rootFolder) return;
-    const subfolders = this.files.listSubfolders((0, import_obsidian25.normalizePath)(rootFolder));
+    const subfolders = this.files.listSubfolders((0, import_obsidian21.normalizePath)(rootFolder));
     await Promise.all(subfolders.map((f) => this.loadProject(f)));
   }
   async loadProject(folderPath) {
-    const content2 = await this.files.readText((0, import_obsidian25.normalizePath)(`${folderPath}/_project.json`));
+    const content2 = await this.files.readText((0, import_obsidian21.normalizePath)(`${folderPath}/_project.json`));
     if (content2 === null) return null;
     try {
       const project = JSON.parse(content2);
       this.projects.set(project.id, project);
       return project;
     } catch (e) {
-      new import_obsidian25.Notice(t2("projectManager.corruptProject", { folder: folderPath }));
+      new import_obsidian21.Notice(t2("projectManager.corruptProject", { folder: folderPath }));
       return null;
     }
   }
@@ -15153,14 +15141,14 @@ var ProjectManager = class extends import_obsidian25.Events {
     const rootFolder = this.plugin.settings.defaultProjectFolder || "Writing Projects";
     const id = this.uniqueId("project");
     const folderName = title.replace(/[\\/:*?"<>|]/g, "-");
-    const folderPath = (0, import_obsidian25.normalizePath)(`${rootFolder}/${folderName}`);
+    const folderPath = (0, import_obsidian21.normalizePath)(`${rootFolder}/${folderName}`);
     if (this.files.exists(folderPath)) {
       throw new Error(t2("projectManager.errorFolderExists", { folder: folderName }));
     }
     await this.files.ensureFolder(folderPath);
-    await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/Chapters`));
-    await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/Research`));
-    await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/Exports`));
+    await this.files.ensureFolder((0, import_obsidian21.normalizePath)(`${folderPath}/Chapters`));
+    await this.files.ensureFolder((0, import_obsidian21.normalizePath)(`${folderPath}/Research`));
+    await this.files.ensureFolder((0, import_obsidian21.normalizePath)(`${folderPath}/Exports`));
     const now = localDateString();
     const project = {
       id,
@@ -15173,26 +15161,8 @@ var ProjectManager = class extends import_obsidian25.Events {
       folderPath,
       goals: {}
     };
-    let binderData;
-    switch (type) {
-      case "book":
-        binderData = await BookTemplate.apply(this.app, project);
-        break;
-      case "series":
-        binderData = await ArticleSeriesTemplate.apply(this.app, project);
-        break;
-      case "blog":
-        binderData = await BlogCollectionTemplate.apply(this.app, project);
-        break;
-      case "journal-article":
-        binderData = await JournalArticleTemplate.apply(this.app, project);
-        break;
-      case "magazine-article":
-        binderData = await MagazineArticleTemplate.apply(this.app, project);
-        break;
-      default:
-        binderData = this.createBlankBinder(project);
-    }
+    const manifestBuilder = TEMPLATE_MANIFESTS[type];
+    const binderData = manifestBuilder ? await new TemplateScaffolder(this.files).apply(project, manifestBuilder(project)) : this.createBlankBinder(project);
     await this.saveProject(project);
     await this.saveBinder(binderData);
     await this.initWritingLog(project);
@@ -15208,7 +15178,7 @@ var ProjectManager = class extends import_obsidian25.Events {
   }
   async saveProject(project) {
     project.modified = localDateString();
-    const path = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_project.json`);
+    const path = (0, import_obsidian21.normalizePath)(`${project.folderPath}/_project.json`);
     await this.writeJson(path, project);
     this.projects.set(project.id, project);
     this.trigger("projects-changed");
@@ -15216,7 +15186,7 @@ var ProjectManager = class extends import_obsidian25.Events {
   async loadBinder(project) {
     const cached = this.binderCache.get(project.id);
     if (cached) return cached;
-    const path = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_binder.json`);
+    const path = (0, import_obsidian21.normalizePath)(`${project.folderPath}/_binder.json`);
     let content2;
     try {
       content2 = await this.files.readText(path);
@@ -15231,8 +15201,8 @@ var ProjectManager = class extends import_obsidian25.Events {
       this.binderCache.set(project.id, data);
       return data;
     } catch (e) {
-      await this.files.writeText((0, import_obsidian25.normalizePath)(`${project.folderPath}/_binder.json.bak`), content2);
-      new import_obsidian25.Notice(t2("projectManager.corruptBinder", { project: project.title }));
+      await this.files.writeText((0, import_obsidian21.normalizePath)(`${project.folderPath}/_binder.json.bak`), content2);
+      new import_obsidian21.Notice(t2("projectManager.corruptBinder", { project: project.title }));
       return { version: "2.0", projectId: project.id, items: [] };
     }
   }
@@ -15244,7 +15214,7 @@ var ProjectManager = class extends import_obsidian25.Events {
     const project = this.projects.get(binder.projectId);
     if (!project) return;
     this.binderCache.set(binder.projectId, binder);
-    const path = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_binder.json`);
+    const path = (0, import_obsidian21.normalizePath)(`${project.folderPath}/_binder.json`);
     await this.writeJson(path, binder);
     this.trigger("binder-changed", binder);
   }
@@ -15252,9 +15222,9 @@ var ProjectManager = class extends import_obsidian25.Events {
     const binder = await this.loadBinder(project);
     const now = localDateString();
     const baseName = title.replace(/[\\/:*?"<>|]/g, "-");
-    let filePath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/Chapters/${baseName}.md`);
+    let filePath = (0, import_obsidian21.normalizePath)(`${project.folderPath}/Chapters/${baseName}.md`);
     for (let n = 2; this.files.exists(filePath); n++) {
-      filePath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/Chapters/${baseName} ${n}.md`);
+      filePath = (0, import_obsidian21.normalizePath)(`${project.folderPath}/Chapters/${baseName} ${n}.md`);
     }
     const item = {
       id: this.uniqueId("item"),
@@ -15331,14 +15301,14 @@ tags: [writing-studio]
     }
   }
   async logSprintSession(project, session) {
-    const logPath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_writing-log.json`);
+    const logPath = (0, import_obsidian21.normalizePath)(`${project.folderPath}/_writing-log.json`);
     let log = [];
     const content2 = await this.files.readText(logPath);
     if (content2 !== null) {
       try {
         log = JSON.parse(content2);
       } catch (e) {
-        new import_obsidian25.Notice(t2("projectManager.corruptLog", { project: project.title }));
+        new import_obsidian21.Notice(t2("projectManager.corruptLog", { project: project.title }));
       }
     }
     log.push(session);
@@ -15349,7 +15319,7 @@ tags: [writing-studio]
     await this.writeJson(logPath, log);
   }
   async getWritingLog(project) {
-    const logPath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_writing-log.json`);
+    const logPath = (0, import_obsidian21.normalizePath)(`${project.folderPath}/_writing-log.json`);
     try {
       const content2 = await this.files.readText(logPath);
       return content2 === null ? [] : JSON.parse(content2);
@@ -15358,7 +15328,7 @@ tags: [writing-studio]
     }
   }
   async initWritingLog(project) {
-    const logPath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/_writing-log.json`);
+    const logPath = (0, import_obsidian21.normalizePath)(`${project.folderPath}/_writing-log.json`);
     await this.writeJson(logPath, []);
   }
   async writeJson(path, data) {
@@ -15416,7 +15386,7 @@ tags: [writing-studio]
 };
 
 // src/StatsTracker.ts
-var import_obsidian26 = require("obsidian");
+var import_obsidian22 = require("obsidian");
 var StatsTracker = class {
   constructor(plugin) {
     this.sessionBaselines = /* @__PURE__ */ new Map();
@@ -15473,7 +15443,7 @@ ${t2("statsTracker.dailyNote.heading")}
 - ${t2("statsTracker.dailyNote.sessionTotal")} ${t2("statsTracker.dailyNote.sessionTotalValue", { duration: session.duration })}
 `;
     const dailyFile = this.app.vault.getAbstractFileByPath(dailyNotePath);
-    if (dailyFile instanceof import_obsidian26.TFile) {
+    if (dailyFile instanceof import_obsidian22.TFile) {
       await this.app.vault.append(dailyFile, "\n" + entry);
       return;
     }
@@ -15487,7 +15457,7 @@ ${t2("statsTracker.dailyNote.heading")}
     const options = (_d = (_c = (_b2 = (_a2 = this.app.internalPlugins) == null ? void 0 : _a2.plugins) == null ? void 0 : _b2["daily-notes"]) == null ? void 0 : _c.instance) == null ? void 0 : _d.options;
     const fileName = moment().format((options == null ? void 0 : options.format) || "YYYY-MM-DD");
     const folder = (options == null ? void 0 : options.folder) || "";
-    return (0, import_obsidian26.normalizePath)(folder ? `${folder}/${fileName}.md` : `${fileName}.md`);
+    return (0, import_obsidian22.normalizePath)(folder ? `${folder}/${fileName}.md` : `${fileName}.md`);
   }
   updateFileWordCount(path, wordCount) {
     if (!this.sessionBaselines.has(path)) {
@@ -15526,7 +15496,7 @@ ${t2("statsTracker.dailyNote.heading")}
     const items = this.plugin.projectManager.flattenBinder(binder.items);
     const counts = await Promise.all(items.map(async (item) => {
       const file = this.app.vault.getAbstractFileByPath(item.filePath);
-      if (!(file instanceof import_obsidian26.TFile)) return 0;
+      if (!(file instanceof import_obsidian22.TFile)) return 0;
       const content2 = await this.app.vault.cachedRead(file);
       return this.plugin.fmManager.countWords(content2);
     }));
@@ -15608,7 +15578,7 @@ ${t2("statsTracker.dailyNote.heading")}
 };
 
 // src/FrontmatterManager.ts
-var import_obsidian27 = require("obsidian");
+var import_obsidian23 = require("obsidian");
 
 // src/words.ts
 function countWords(content2) {
@@ -15644,7 +15614,7 @@ var FrontmatterManager = class {
     if (file.extension !== "md") return false;
     const projectFolder = this.plugin.settings.defaultProjectFolder;
     if (!projectFolder) return false;
-    return file.path.startsWith((0, import_obsidian27.normalizePath)(projectFolder) + "/");
+    return file.path.startsWith((0, import_obsidian23.normalizePath)(projectFolder) + "/");
   }
   async updateFrontmatter(file) {
     this.writingFiles.add(file.path);
@@ -15675,7 +15645,7 @@ var FrontmatterManager = class {
 };
 
 // src/SettingsTab.ts
-var import_obsidian28 = require("obsidian");
+var import_obsidian24 = require("obsidian");
 
 // README.md
 var README_default = '<p align="center">\r\n  <img src="assets/logo.png" width="120" alt="Writing Studio logo">\r\n</p>\r\n\r\n# Writing Studio\r\n\r\n**Version 2.6.1** \xB7 Desktop only\r\n\r\n![GitHub all releases](https://img.shields.io/github/downloads/writerP-777/obsidian-writing-studio/total)\r\n[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12832/badge)](https://www.bestpractices.dev/projects/12832)\r\n\r\nWriting Studio turns Obsidian into a dedicated environment for serious nonfiction work \u2014 from your first research notes to a finished, exported manuscript. It bundles a project binder, writing modes, focus and typography tools, sprint timer, progress tracking, manuscript export, and WordPress publishing into a single plugin. A built-in sidebar file explorer lets you browse, preview, and pull content from anywhere in your vault without leaving your draft.\r\n\r\n<p align="center">\r\n  <img src="assets/sidebar-explorer-screenshot.png" alt="Writing Studio with the Launcher panel open on the left, an active draft in the center, and the Folder Sidebar Explorer open to a research folder on the right" width="900">\r\n  <br>\r\n  <em>Writing Studio in use \u2014 Launcher (left), active draft with word count goal banner (center), Folder Sidebar Explorer open to a research folder (right).</em>\r\n</p>\r\n\r\n<p align="center">\r\n  <a href="https://buymeacoffee.com/writerp777">\r\n    <img src="https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&slug=writerp777&button_colour=c9a84c&font_colour=000000&font_family=Georgia&outline_colour=000000&coffee_colour=ffffff" alt="Buy me a coffee" height="40">\r\n  </a>\r\n</p>\r\n\r\n## Contents\r\n\r\n- [Features](#features)\r\n- [Language support](#language-support)\r\n- [Writing Studio Launcher](#writing-studio-launcher)\r\n- [Folder Sidebar Explorer](#folder-sidebar-explorer)\r\n- [Your Project](#your-project)\r\n- [Your Writing Environment](#your-writing-environment)\r\n- [Tracking Your Progress](#tracking-your-progress)\r\n- [Getting Your Work Out](#getting-your-work-out)\r\n- [Supporting Tools](#supporting-tools)\r\n- [Context Menus](#context-menus)\r\n- [Commands Reference](#commands-reference)\r\n- [Settings Overview](#settings-overview)\r\n- [Ribbon Icon](#ribbon-icon)\r\n- [Installation](#installation)\r\n- [Requirements](#requirements)\r\n- [Reporting a Bug](#reporting-a-bug)\r\n- [Security](#security)\r\n\r\n---\r\n\r\n## Features\r\n\r\n**Writing Binder** \u2014 Organize your manuscript as an ordered collection of documents with per-item status, word count, and export flags. Drag chapters into order, toggle items in or out of export, and add files from anywhere in your vault.\r\n\r\n**Project Manager** \u2014 Create projects from six templates (blank, book, article series, blog collection, journal article, magazine article), set a total word count goal, and switch between projects from the Launcher.\r\n\r\n**Compile Preview** \u2014 Concatenate all binder documents in order and render them as a finished manuscript in a split pane, without exporting.\r\n\r\n**Writing Modes** \u2014 Switch between Draft (distraction-free), Edit (full tooling), and Review (read-only) modes from the status bar, command palette, context menu, or Launcher.\r\n\r\n**Focus Mode** \u2014 Dim everything except the paragraph or sentence you are writing. Configurable dim level, font size override, sidebar collapse, and typewriter scroll.\r\n\r\n**Typography Mode** \u2014 Apply a curated font, constrained line length, and controlled line height to the editor. Fourteen font options including iA Writer fonts, Google Fonts, and custom system fonts.\r\n\r\n**Sprint Timer** \u2014 Run timed writing sessions with a draggable floating overlay. Set duration, word goal, and scope (file or project). Quick-start presets (10 m, 15 m, 25 m) available from the Launcher.\r\n\r\n**Progress Tracking** \u2014 Live word counts in the status bar and Launcher, session delta tracking, per-document and per-project word count goals with inline progress banners, and a 30-day writing log with streak tracking.\r\n\r\n**Export Engine** \u2014 Export to Manuscript (HTML), PDF, Word (.docx), RTF, HTML, Markdown, and EPUB. Manuscript format produces industry-standard layout with no external tools; other formats require Pandoc.\r\n\r\n**WordPress Publishing** \u2014 Publish directly to WordPress from Obsidian. Set post title, status, categories, tags, excerpt, and scheduled date. Supports multiple sites with per-site credentials and connection testing.\r\n\r\n**Folder Sidebar Explorer** \u2014 Browse any vault folder in a sidebar panel. Search by name or file content, preview Markdown files and images inline, and insert selected text directly into the active editor.\r\n\r\n## Language support\r\n\r\nWriting Studio is available in the following languages in addition to English:\r\n\r\n- Arabic\r\n- Chinese (Simplified)\r\n- French\r\n- German\r\n- Japanese\r\n- Korean\r\n- Portuguese (Brazil)\r\n- Russian\r\n- Spanish\r\n\r\n**To change the language:** Open **Settings \u2192 General** in Obsidian, scroll to **Language**, and select your preferred language from the list. Restart Obsidian for the change to take effect. Writing Studio will display in the selected language if it is supported.\r\n\r\n**Found a translation error or missing text?** Please open an issue on GitHub \u2014 [Submit a bug report or enhancement request](https://github.com/writerP-777/obsidian-writing-studio/issues/new) \u2014 and include the language, the location in the plugin where the text appears, and what it currently says. We will address it in the next release.\r\n\r\n### Writing Studio Launcher\r\n\r\nThe Launcher is your home base in Writing Studio \u2014 a sidebar panel that shows your active project, progress toward your goals, and one-click access to every major feature.\r\n\r\nBy default it opens automatically when Obsidian loads. To disable this, turn off **Open on startup** in **Settings \u2192 General**.\r\n\r\n**To open manually:** Click the feather ribbon icon, or assign a hotkey to **Open launcher** in Settings \u2192 Hotkeys.\r\n\r\n**The Launcher includes:**\r\n- Active project name, total word count, and progress toward your project word count goal\r\n- Writing mode selector (Draft / Edit / Review)\r\n- Focus Mode and Typography Mode toggles\r\n- Sprint timer with "Set up sprint" button and Quick Sprint Options presets (10 m, 15 m, 25 m)\r\n- Today card showing words written, sprints completed, session word count, and streak\r\n- Quick-action buttons: Targets Dashboard, Writing Dashboard, Preview manuscript, Export, Writing Log, Publish to WordPress\r\n\r\n---\r\n\r\n### Folder Sidebar Explorer\r\n\r\nThe Folder Sidebar Explorer opens any vault folder in a right-sidebar panel, letting you browse reference material, research notes, or any folder outside your active project without leaving your draft. Unlike the Binder \u2014 which is scoped to your writing project \u2014 the sidebar explorer works with any folder in your vault.\r\n\r\n**To open:**\r\n- Use the command **Open folder in sidebar explorer** from the command palette \u2014 a folder picker appears so you can choose which folder to explore.\r\n- Right-click any folder in the file explorer and choose **Open in sidebar explorer** under **Writing studio options**.\r\n- Right-click any folder in [Notebook Navigator](https://github.com/johansan/notebook-navigator) and choose **Open in sidebar explorer** (requires Notebook Navigator to be installed).\r\n- Assign a hotkey in Settings \u2192 Hotkeys.\r\n\r\nThe panel opens in the **right sidebar**. The folder you open becomes the **root folder** for that session \u2014 the breadcrumb trail, the \u2302 root button, and search all operate relative to it.\r\n\r\n**Browsing and navigation:**\r\n\r\n| Feature | How to use |\r\n|---------|-----------|\r\n| Browse into a subfolder | Click the folder |\r\n| Preview a Markdown file | Click the file \u2014 the folder listing is replaced by a rendered preview inside the panel |\r\n| Preview an image | Click the file \u2014 displayed inline |\r\n| Preview audio | Click the file \u2014 player appears inline |\r\n| Other file types | Click the file \u2014 an **Open in editor** button appears |\r\n| Go back | Click **\u2190 back**, or press `Backspace` when the list has keyboard focus |\r\n| Return to root folder | Click **\u2302 root** to jump back to the folder you originally opened |\r\n| Keyboard navigation | Tab to focus the list, then `\u2191` / `\u2193` to move, `Enter` to open, `Backspace` to go back |\r\n| Breadcrumb navigation | Click any segment in the breadcrumb trail to jump directly to that folder |\r\n\r\n**Search:**\r\n\r\nA search bar appears at the top of the folder list. Type your query and press **Enter** to run the search.\r\n\r\n- Searches **both folder/file names and file contents** (`.md` and `.txt` files).\r\n- Frontmatter is excluded from content search to avoid false positives from YAML fields.\r\n- Name matches show the matched term highlighted in the result title.\r\n- Content matches show a text snippet around the match with the term highlighted, plus a **CONTENT** badge to distinguish them from name matches.\r\n- Results always search from the root folder, regardless of which subfolder you are currently browsing.\r\n- Click **\xD7** to clear the search and return to the normal folder view.\r\n\r\n**Sort:**\r\n\r\nA sort dropdown sits next to the search bar. Options:\r\n\r\n| Option | Description |\r\n|--------|-------------|\r\n| Folders \u2191 A-Z | Folders first, then files, both alphabetical (default) |\r\n| Folders \u2191 Z-A | Folders first, then files, both reverse-alphabetical |\r\n| Name A-Z | All items alphabetical, folders and files mixed |\r\n| Name Z-A | All items reverse-alphabetical, mixed |\r\n| Newest first | Sort by last-modified date, newest at top |\r\n| Oldest first | Sort by last-modified date, oldest at top |\r\n\r\n**Copy content to the editor:**\r\n\r\nWhen a Markdown file is open in preview mode (after clicking it in the file list), its text is selectable. To insert a passage into the active editor:\r\n\r\n1. Click a file in the list \u2014 the panel switches to preview mode showing the rendered file.\r\n2. Select the text you want in the preview pane.\r\n3. Click the **\u21A9 insert selection** button in the nav bar.\r\n4. The selected text is inserted at the cursor position in the active editor.\r\n\r\nThe preview is read-only \u2014 you cannot edit the file from the sidebar.\r\n\r\n**Hover tooltips:**\r\n\r\nHover over any file or folder in the list to see an information card:\r\n\r\n| Item type | Information shown |\r\n|-----------|------------------|\r\n| Markdown / text file | Last modified date and time \xB7 File size \xB7 Word count (frontmatter excluded) |\r\n| Image / audio / other file | Last modified date and time \xB7 File size |\r\n| Folder | Total file count \xB7 Subfolder count |\r\n\r\nThe word count updates asynchronously from Obsidian\'s file cache and appears within a moment of hover.\r\n\r\n---\r\n\r\n### Your Project\r\n\r\n#### Project Manager\r\n\r\nProjects group a set of documents (binder items) and act as the scope for export, statistics, and the word count goal banner.\r\n\r\n**To create a project:** Use the command **New writing project** from the command palette, or click **+ New** in the Launcher panel.\r\n\r\n**To switch projects:** Use the Launcher panel or the project selector at the top of the Binder panel.\r\n\r\nEach project stores:\r\n- Title, type, author, and description\r\n- Ordered binder with chapters, sections, articles, and notes\r\n- Per-item word count goals, statuses, and export flags\r\n- Optional total word count goal (shown in the Launcher and status bar)\r\n\r\n**Project templates available at creation:**\r\n\r\n| Template | Structure created |\r\n|----------|------------------|\r\n| Blank | Empty \u2014 build your own structure |\r\n| Book | Front Matter, Part 1 / Chapter 1, Back Matter |\r\n| Article series | Series folder, Article 1 placeholder, series metadata |\r\n| Blog collection | Date-organized folder, first post placeholder |\r\n| Journal article | Title Page, Abstract, Keywords, Introduction, Literature Review, Methodology, Findings / Analysis, Discussion, Conclusion, References, Appendices |\r\n| Magazine article | Pitch / Query Notes, Headline & Deck, Lede, Nut Graf, Body, Quotes & Sources, Kicker, Fact-Check Notes, Author Bio |\r\n\r\n---\r\n\r\n#### Writing Binder\r\n\r\nKeeping a book-length manuscript organized means knowing at a glance which chapters are drafted, which are in progress, and how each contributes to your total word count. The Binder is a sidebar panel that shows all of that for your active project.\r\n\r\nEach document shows its title, type (Chapter, Section, Article, Note), status (Draft, In Progress, Complete), and live word count. Documents can be reordered by drag-and-drop and toggled in or out of export.\r\n\r\n**To open:** Use the command **Open binder** from the command palette, or assign a hotkey in Settings \u2192 Hotkeys.\r\n\r\n**Adding a file to a project:**\r\n1. Right-click any Markdown file in the file explorer and choose **Add to writing project** under **Writing studio options**.\r\n2. A modal appears with a dropdown listing all your writing projects.\r\n3. Select the target project and click **Add to project**.\r\n\r\n**Adding files copied directly to the project folder:**\r\n\r\nIf you copied or moved files into the project folder outside of Obsidian and they do not appear in the binder, use the **Add files copied to this folder** button in the binder toolbar (immediately to the right of the **+ document** button). The plugin scans the project folder, lists any files not yet in the binder, and lets you select which ones to add before making any changes.\r\n\r\n---\r\n\r\n#### Compile Preview\r\n\r\nThe Compile Preview opens a split pane showing all binder documents for the active project concatenated in order, rendered as a finished manuscript.\r\n\r\n**To open:** Use the command **Preview compiled manuscript** from the command palette, or click the **Preview manuscript** button in the Launcher panel.\r\n\r\n---\r\n\r\n### Your Writing Environment\r\n\r\n#### Writing Modes\r\n\r\nThree modes shape how the editor behaves. The current mode is always shown in the status bar. Click the mode pill in the status bar to switch modes.\r\n\r\n| Mode | Purpose |\r\n|------|---------|\r\n| **Draft** | Distraction-free drafting; spell-check and formatting hints suppressed |\r\n| **Edit** | Revision pass; full editor tooling active |\r\n| **Review** | Read-only style; ideal for a final proofread |\r\n| **None** | Normal Obsidian behavior |\r\n\r\n**To switch modes:**\r\n- Click the mode indicator in the status bar.\r\n- Right-click inside the editor, then choose **Switch writing mode \u2192** under **Writing studio options**.\r\n- Assign hotkeys to **Switch to draft mode / Edit mode / Review mode** in Settings \u2192 Hotkeys.\r\n- Use the Writing Studio Launcher panel.\r\n\r\nThe active mode persists across Obsidian restarts.\r\n\r\n---\r\n\r\n#### Focus Mode\r\n\r\nFocus Mode dims everything in the editor except the paragraph or sentence you are currently writing, reducing visual noise and keeping attention on the active thought.\r\n\r\n**To toggle:** Assign a hotkey to **Toggle focus mode** in Settings \u2192 Hotkeys, or use the toggle in the Launcher panel. Press `Escape` to exit.\r\n\r\n**Settings (Settings \u2192 Focus mode):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Focus unit | Highlight at the **paragraph** or **sentence (line)** level |\r\n| Dim opacity | How opaque the dimmed text appears (10\u201350%) |\r\n| Font size override | Override the editor font size while focused; 0 = use theme default. Takes precedence over Typography Mode\'s font size while Focus Mode is active |\r\n| Auto-hide sidebars | Collapse left and right sidebars when Focus Mode activates |\r\n| Typewriter scroll | Keep the active line vertically centered as you type |\r\n\r\n---\r\n\r\n#### Typography Mode\r\n\r\nTypography Mode applies a consistent, reader-friendly text treatment to the editor: a curated font, constrained line length, controlled line height, and optional letter spacing.\r\n\r\n**To toggle:** Assign a hotkey to **Toggle typography mode** in Settings \u2192 Hotkeys, or use the toggle in the Launcher panel.\r\n\r\n**To change the font while Typography Mode is active:** Right-click inside the editor and choose **Typography font \u2192** under **Writing studio options**. A font picker menu appears with all available fonts; the active font is shown with a checkmark. Selecting a font applies it immediately and saves the setting.\r\n\r\n> **Note on fonts:** Typography fonts are loaded from Google Fonts and require an internet connection the first time each font is used. After the initial load they are cached and work offline.\r\n\r\n**Settings (Settings \u2192 Typography):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Font family | Choose from the curated font list or enter a custom font name |\r\n| Custom font name | Used when **Custom font name\u2026** is selected above |\r\n| Max line length | Characters per line (55\u201380); constrains the editor column width |\r\n| Font size | Editor font size in pixels |\r\n| Line height | Multiplier; default 1.7 |\r\n| Letter spacing | CSS `letter-spacing` value (e.g. `normal`, `0.02em`) |\r\n| Persist across sessions | Keep Typography Mode active when Obsidian reopens |\r\n\r\n**Available fonts:**\r\n\r\n| Option | Font |\r\n|--------|------|\r\n| Monospaced | iA Writer Mono (falls back to Roboto Mono / Courier New) |\r\n| Serif | iA Writer Duo Serif (falls back to Georgia) |\r\n| Sans-serif | iA Writer Quattro (falls back to system sans-serif) |\r\n| Cormorant Garamond | Elegant display serif |\r\n| Crimson Text | Classic book serif |\r\n| EB Garamond | Traditional Garamond revival |\r\n| Libre Baskerville | Readable web serif |\r\n| Libre Caslon Text | Clean slab serif |\r\n| Literata | Designed for long-form reading |\r\n| Lora | Contemporary calligraphic serif |\r\n| Inter | Modern humanist sans-serif |\r\n| Lato | Friendly rounded sans-serif |\r\n| Source Sans 3 | Clean UI sans-serif |\r\n| Custom font name\u2026 | Use any font installed on your system |\r\n\r\n---\r\n\r\n### Tracking Your Progress\r\n\r\n#### Writing Sprint Timer\r\n\r\nThe Sprint Timer runs a timed writing session. When a sprint is active, a floating overlay displays the countdown and gives you full control \u2014 without requiring you to stay on the dashboard.\r\n\r\n**To set up a sprint:**\r\n\r\n- Click **Set up sprint** in the Launcher panel to open the sprint configuration modal.\r\n- Or click one of the **Quick Sprint Options** preset buttons (10 m, 15 m, 25 m) in the Launcher panel to load a duration directly.\r\n\r\nEither path opens the floating overlay in a ready state \u2014 the timer does not start until you press \u25B6 on the overlay itself. This gives you time to navigate to your draft or open the Binder before the clock begins.\r\n\r\n**Sprint configuration modal:**\r\n\r\nThe modal lets you set:\r\n\r\n- Duration (preset or custom, in minutes)\r\n- Word count goal for the session\r\n- Scope (current file or entire project)\r\n\r\nClick **Launch sprint timer** to open the overlay in ready state.\r\n\r\n**Using the floating overlay:**\r\n\r\n| Control | Action |\r\n|---------|--------|\r\n| \u25B6 | Start or resume the sprint |\r\n| \u23F8 | Pause the sprint |\r\n| \u25A0 | Stop and end the sprint |\r\n\r\nThe overlay is draggable \u2014 click and drag the header to reposition it anywhere on screen. It stays on top regardless of writing mode or Focus Mode. The current countdown is also shown in the Obsidian status bar (`\u23F1 MM:SS`) and, when Focus Mode is active, in the focus toolbar.\r\n\r\nWhen the sprint ends, a summary modal shows words written, duration, and words-per-minute. The session is logged to sprint history and optionally appended to your Daily Note.\r\n\r\n**Settings (Settings \u2192 Sprint & goals):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Default sprint duration | Starting value in the sprint modal (minutes) |\r\n| Default daily word goal | Target used in the Writing Dashboard and Launcher |\r\n| Sound notifications | Play a tone when the sprint ends |\r\n| Sprint history retention | Days to keep sprint records before purging |\r\n| Inline goal banner | Show a progress bar below the editor toolbar when a document has a word count goal set |\r\n\r\n---\r\n\r\n#### Word Count Goal\r\n\r\nA per-document word count goal can be set and tracked inline.\r\n\r\n**To set a goal:**\r\n- Use the command **Set word count goal** from the command palette.\r\n- Right-click inside the editor and choose **Set word count goal** under **Writing studio options**.\r\n\r\nWhen a goal is set and **Inline goal banner** is enabled, a progress bar appears below the editor toolbar showing current words, goal, and percentage. It updates in real time as you type.\r\n\r\n---\r\n\r\n#### Session Word Count\r\n\r\nThe status bar shows a `(+N)` delta next to the current file\'s word count, indicating how many words you have added since opening that file this session. The Launcher\'s **Today** card also shows a cumulative session total across all files opened during the current Obsidian session. Both counts reset when Obsidian restarts.\r\n\r\n---\r\n\r\n#### Project Word Count Goal\r\n\r\nWhen an active project has a total word count goal set, a dedicated status bar item shows `{current} / {goal} project words`. This updates automatically as you write. Set a project goal in the Project modal when creating or editing a project.\r\n\r\n---\r\n\r\n#### Writing Dashboard\r\n\r\nThe Writing Dashboard shows session statistics (words written, sprints completed, time), sprint history, daily progress toward your goal, and per-project word counts with reading time.\r\n\r\n**To open:** Use the command **Open writing dashboard** from the command palette, or click the **Writing dashboard** button in the Launcher panel.\r\n\r\n---\r\n\r\n#### Targets Dashboard\r\n\r\nThe Targets Dashboard lets you assign word count goals to individual documents in the active project\'s binder and track progress across the whole project at a glance. Goals can be edited inline in the table. Rows are sortable and filterable by status.\r\n\r\n**To open:** Use the command **Open targets dashboard**, click the **Targets dashboard** button in the Launcher panel, or assign a hotkey in Settings \u2192 Hotkeys.\r\n\r\n---\r\n\r\n#### Daily Writing Log\r\n\r\nThe Writing Log is a sidebar panel that shows your writing history at a glance.\r\n\r\n**To open:** Use the command **Open writing log** from the command palette, or click the **Writing log** button in the Launcher panel.\r\n\r\n**The Writing Log shows:**\r\n- Current streak (days in a row with at least one sprint)\r\n- This session: total session words, sprint words, sprints completed, and minutes written\r\n- Last 30 days: a bar chart with one row per day showing word count, sprints completed, and a visual bar proportional to the day\'s output\r\n\r\nWhen **Append to daily note** is enabled (Settings \u2192 Writing log), a summary of each completed sprint is also appended to today\'s Daily Note.\r\n\r\n---\r\n\r\n### Getting Your Work Out\r\n\r\n#### Export Engine\r\n\r\nWhen your draft is ready, the Export Engine converts it to a finished file in your chosen format \u2014 no reformatting required.\r\n\r\n**Supported formats:** Manuscript (HTML) \xB7 PDF \xB7 Word (.docx) \xB7 RTF \xB7 HTML \xB7 Markdown \xB7 EPUB\r\n\r\n**To export:**\r\n- Right-click inside the editor and choose **Export this document** under **Writing studio options**.\r\n- Use the command **Export document** from the command palette.\r\n- Click the **Export** button in the Launcher panel.\r\n- Assign a hotkey to **Export document** in Settings \u2192 Hotkeys.\r\n\r\n**Manuscript format**\r\n\r\nThe Manuscript format produces a self-contained HTML file formatted to industry-standard manuscript conventions:\r\n- Courier New 12 pt, double-spaced, 1-inch margins\r\n- Title page with project title, author name, approximate word count, and optional contact information\r\n- Chapter headings in uppercase, page-break before each\r\n- Scene breaks rendered as `#` (the standard manuscript convention)\r\n\r\nNo external tools are required for manuscript export.\r\n\r\n**Settings (Settings \u2192 Export):**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Default export format | Pre-selected format in the export modal |\r\n| Default paper size | Letter (US) or A4 |\r\n| Export font | Font name used in PDF/DOCX output (e.g. `Georgia`) |\r\n| Export font size | Point size for PDF/DOCX output |\r\n| Pandoc path | Full path to the `pandoc` binary if it is not on your system PATH |\r\n| EPUB language | BCP 47 language tag (e.g. `en`, `fr`, `de`) |\r\n| EPUB include cover | Generate a text cover page when no cover image is provided |\r\n\r\n> **Requirement:** Pandoc must be installed for PDF, DOCX, RTF, HTML, and EPUB export. Download from [pandoc.org](https://pandoc.org/installing.html). For PDF export, a LaTeX distribution (e.g. TeX Live or MiKTeX) is also required. Manuscript (HTML) export does not require Pandoc.\r\n>\r\n> **Formatting note:** the built-in converter used for HTML, Manuscript, and EPUB output supports headings, paragraphs, lists, blockquotes, fenced code blocks, tables, images, and links. Nested lists, setext (underline-style) headings, and footnotes are not converted \u2014 use a Pandoc format (PDF, DOCX, RTF) if your manuscript depends on them.\r\n\r\n---\r\n\r\n#### WordPress Publishing\r\n\r\nPublish your finished draft directly to WordPress without leaving Obsidian. The modal lets you choose the target site, set the post title, status, categories, tags, excerpt, and an optional scheduled publication date.\r\n\r\n**To publish:**\r\n- Right-click inside the editor and choose **Publish to WordPress** under **Writing studio options**.\r\n- Use the command **Publish to wordpress** from the command palette.\r\n- Click the **Publish to WordPress** button in the Launcher panel.\r\n- Assign a hotkey to **Publish to wordpress** in Settings \u2192 Hotkeys.\r\n\r\n**Setting up a site (Settings \u2192 WordPress):**\r\n\r\n1. Click **+ add WordPress site**.\r\n2. Enter a nickname, the site URL (e.g. `https://yourblog.com`), and your WordPress username.\r\n3. Generate an application password in WordPress under **Users \u2192 Profile \u2192 Application passwords** and paste it into the **Application password** field.\r\n4. Click **Test connection** to verify.\r\n\r\n**Per-site options:**\r\n\r\n| Setting | Description |\r\n|---------|-------------|\r\n| Default post status | Draft \xB7 Pending Review \xB7 Published |\r\n| Wikilink handling | **Strip** removes `[[...]]` syntax, leaving plain text \xB7 **Convert** turns wikilinks into URLs |\r\n\r\n**Preserving your credentials across updates**\r\n\r\nWriting Studio stores your WordPress site credentials in your vault\'s `.obsidian/plugins/writing-studio/data.json` file. Obsidian\'s in-app update process does not touch this file \u2014 your credentials are preserved automatically. However, if you uninstall and reinstall the plugin manually, or if a vault sync conflict overwrites `data.json`, credentials will be lost and will need to be re-entered. To avoid this, always use Obsidian\'s built-in Update button rather than uninstalling manually.\r\n\r\n---\r\n\r\n### Supporting Tools\r\n\r\n#### Frontmatter Manager\r\n\r\nWriting Studio automatically manages YAML frontmatter in your documents when **Frontmatter auto-update** is enabled. On every save it updates:\r\n\r\n- `word-count` \u2014 current word count\r\n- `modified` \u2014 last-modified date\r\n\r\nThe `word-count-goal` frontmatter field is read by the inline goal banner and the Word Count Goal modal.\r\n\r\n---\r\n\r\n## Context Menus\r\n\r\nWriting Studio adds items to Obsidian\'s right-click context menus. All Writing Studio items are grouped together under the heading **Writing studio options** to distinguish them from other plugins and Obsidian\'s built-in options.\r\n\r\n### Right-click inside an open document (editor menu)\r\n\r\n| Option | Action |\r\n|--------|--------|\r\n| Export this document | Open the export modal for the current file |\r\n| Publish to WordPress | Open the WordPress publish modal for the current file |\r\n| Set word count goal | Set a word count target for the current document |\r\n| Switch writing mode \u2192 | Open a mode-switcher menu (Draft / Edit / Review / None) |\r\n| Typography font \u2192 | Open a font picker menu to change the typography font (visible only when Typography Mode is active) |\r\n\r\n### Right-click a Markdown file in the file explorer\r\n\r\n| Option | Action |\r\n|--------|--------|\r\n| Add to writing project | Open a project picker and add the file to the selected project |\r\n\r\n### Right-click a folder in the file explorer\r\n\r\n| Option | Action |\r\n|--------|--------|\r\n| Open in sidebar explorer | Open the folder in the Folder Sidebar Explorer panel |\r\n\r\n---\r\n\r\n## Commands Reference\r\n\r\nNo default hotkeys are assigned. All commands can be given a hotkey in **Settings \u2192 Hotkeys**.\r\n\r\n| Command | Description |\r\n|---------|-------------|\r\n| Open launcher | Open the launcher sidebar panel |\r\n| Open binder | Open the writing binder sidebar panel |\r\n| Open writing log | Open the daily writing log panel |\r\n| Toggle focus mode | Enable or disable focus mode |\r\n| Toggle typography mode | Enable or disable typography mode |\r\n| Switch to draft mode | Activate draft writing mode |\r\n| Switch to edit mode | Activate edit writing mode |\r\n| Switch to review mode | Activate review writing mode |\r\n| Start writing sprint | Open the sprint timer modal |\r\n| Export document | Export the current document |\r\n| Export project | Export the full project |\r\n| Preview compiled manuscript | Open the compile preview pane |\r\n| Publish to wordpress | Publish the current document to WordPress |\r\n| New writing project | Create a new writing project |\r\n| Open writing dashboard | Open the statistics dashboard |\r\n| Open targets dashboard | Open the word count targets panel |\r\n| Set word count goal | Set a per-document word count goal |\r\n| Open folder in sidebar explorer | Search and open a vault folder in the sidebar |\r\n| Add files copied to project folder | Scan the active project folder for files not in the binder and import selected files |\r\n\r\n---\r\n\r\n## Settings Overview\r\n\r\nOpen via **Settings \u2192 Writing Studio**.\r\n\r\n| Tab | What it controls |\r\n|-----|-----------------|\r\n| General | Open on startup, default project folder, author name, document type, frontmatter auto-update |\r\n| Focus mode | Focus unit, dim opacity, font override, sidebar behavior, typewriter scroll |\r\n| Typography | Font family, custom font name, line length, font size, line height, letter spacing, persistence |\r\n| Sprint & goals | Sprint duration, daily goal, sound notifications, history retention, inline banner |\r\n| Export | Format, paper size, font, font size, Pandoc path, EPUB language, EPUB cover |\r\n| Writing log | Append sprint summaries to Daily Note |\r\n| WordPress | Site credentials, default post status, wikilink handling |\r\n\r\n---\r\n\r\n## Ribbon Icon\r\n\r\nWriting Studio adds a single icon to the Obsidian ribbon.\r\n\r\n| Icon | Action |\r\n|------|--------|\r\n| Feather | Open the Writing Studio Launcher panel |\r\n\r\nAll other features are accessible from the Launcher panel, the command palette, context menus, or assigned hotkeys.\r\n\r\n---\r\n\r\n## Installation\r\n\r\n1. Download `main.js`, `manifest.json`, and `styles.css` from the latest [GitHub release](../../releases/latest).\r\n2. Create the folder `<vault>/.obsidian/plugins/obsidian-writing-studio/` if it does not exist.\r\n3. Copy the three files into that folder.\r\n4. In Obsidian, go to **Settings \u2192 Community Plugins**, find **Writing Studio**, and enable it.\r\n\r\n> **Building from source:** Clone the repository, run `npm install`, then `npm run build`. Copy the three output files as above.\r\n\r\n---\r\n\r\n## Requirements\r\n\r\nMost features work out of the box. A few require additional software for specific functions, noted below.\r\n\r\n| Requirement | When needed |\r\n|-------------|-------------|\r\n| Obsidian 1.7.2 or later | Always |\r\n| Desktop (Windows, macOS, Linux) | Always \u2014 this plugin does not run on mobile |\r\n| Internet connection | First use of each Typography Mode font (cached after that) |\r\n| [Pandoc](https://pandoc.org/installing.html) | Export to PDF, DOCX, RTF, HTML, EPUB |\r\n| LaTeX (TeX Live / MiKTeX) | Export to PDF only |\r\n| WordPress 5.6+ with REST API enabled | WordPress publishing |\r\n| WordPress Application Password | WordPress publishing |\r\n\r\n---\r\n\r\n## Reporting a Bug\r\n\r\nIf something isn\'t working, please open an issue on GitHub:\r\n\r\n**[Submit a bug report](https://github.com/writerP-777/obsidian-writing-studio/issues/new)**\r\n\r\nInclude the following when you report:\r\n\r\n- Writing Studio version (visible in **Settings \u2192 Community Plugins**)\r\n- Obsidian version (visible in **Settings \u2192 About**)\r\n- Operating system (Windows / macOS / Linux) and version\r\n- What you expected to happen\r\n- What actually happened, and any steps to reproduce it\r\n\r\nFeature requests are welcome in the same place \u2014 please label them as **[Feature Request]** in the issue title.\r\n\r\n---\r\n\r\n## Security\r\n\r\n[![CodeQL](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/codeql.yml)\r\n[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/writerP-777/obsidian-writing-studio/badge)](https://securityscorecards.dev/viewer/?uri=github.com/writerP-777/obsidian-writing-studio)\r\n[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12832/baseline)](https://www.bestpractices.dev/projects/12832)\r\n[![ESLint](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml/badge.svg)](https://github.com/writerP-777/obsidian-writing-studio/actions/workflows/eslint.yml)\r\n[![ORCID](https://img.shields.io/badge/ORCID-0009--0009--8598--2069-brightgreen?logo=orcid&logoColor=white)](https://orcid.org/0009-0009-8598-2069)\r\n\r\nEvery push and pull request is scanned automatically:\r\n\r\n| Tool | What it checks |\r\n|------|----------------|\r\n| **CodeQL** | Static analysis for security vulnerabilities (XSS, injection, unsafe patterns) in TypeScript/JavaScript source |\r\n| **OpenSSF Scorecard** | Supply-chain security posture: dependency hygiene, branch protection, signed releases, and more |\r\n| **ESLint** (`eslint-plugin-obsidianmd`) | Obsidian plugin guideline compliance \u2014 fails on any warning or error |\r\n\r\nResults are published to the **Security** tab of this repository (GitHub code scanning).\r\n\r\nFor local development, a pre-commit hook runs ESLint (blocking) and a pre-push hook runs a full CodeQL scan (blocks the push if any HIGH or CRITICAL findings are present). Install the [CodeQL CLI](https://github.com/github/codeql-cli-binaries/releases) to enable local scanning (`winget install GitHub.CodeQL` on Windows).\r\n';
@@ -15689,7 +15659,7 @@ content = content.replace(/^!\[[^\]]*\]\((?!https?:\/\/)[^)]*\)[ \t]*$/gm, "");
 var HELP_CONTENT = content;
 
 // src/SettingsTab.ts
-var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab {
+var WritingStudioSettingsTab = class extends import_obsidian24.PluginSettingTab {
   constructor(app, plugin) {
     super(app, plugin);
     this.activeTab = "general";
@@ -15774,57 +15744,57 @@ var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab 
     }
   }
   renderGeneral(el) {
-    new import_obsidian28.Setting(el).setName(t2("settings.general.openOnStartup")).setDesc(t2("settings.general.openOnStartupDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.openOnStartup).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.general.openOnStartup")).setDesc(t2("settings.general.openOnStartupDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.openOnStartup).onChange(async (v) => {
       this.plugin.settings.openOnStartup = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.general.defaultProjectFolder")).setDesc(t2("settings.general.defaultProjectFolderDesc")).addText((text) => text.setPlaceholder(t2("settings.general.defaultProjectFolderPlaceholder")).setValue(this.plugin.settings.defaultProjectFolder).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.general.defaultProjectFolder")).setDesc(t2("settings.general.defaultProjectFolderDesc")).addText((text) => text.setPlaceholder(t2("settings.general.defaultProjectFolderPlaceholder")).setValue(this.plugin.settings.defaultProjectFolder).onChange(async (v) => {
       this.plugin.settings.defaultProjectFolder = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.general.authorName")).setDesc(t2("settings.general.authorNameDesc")).addText((text) => text.setPlaceholder(t2("settings.general.authorNamePlaceholder")).setValue(this.plugin.settings.authorName).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.general.authorName")).setDesc(t2("settings.general.authorNameDesc")).addText((text) => text.setPlaceholder(t2("settings.general.authorNamePlaceholder")).setValue(this.plugin.settings.authorName).onChange(async (v) => {
       this.plugin.settings.authorName = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.general.defaultDocumentType")).addDropdown((d) => d.addOption("chapter", t2("settings.general.docType.chapter")).addOption("section", t2("settings.general.docType.section")).addOption("article", t2("settings.general.docType.article")).addOption("note", t2("settings.general.docType.note")).setValue(this.plugin.settings.defaultDocumentType).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.general.defaultDocumentType")).addDropdown((d) => d.addOption("chapter", t2("settings.general.docType.chapter")).addOption("section", t2("settings.general.docType.section")).addOption("article", t2("settings.general.docType.article")).addOption("note", t2("settings.general.docType.note")).setValue(this.plugin.settings.defaultDocumentType).onChange(async (v) => {
       this.plugin.settings.defaultDocumentType = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.general.frontmatterAutoUpdate")).setDesc(t2("settings.general.frontmatterAutoUpdateDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.frontmatterAutoUpdate).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.general.frontmatterAutoUpdate")).setDesc(t2("settings.general.frontmatterAutoUpdateDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.frontmatterAutoUpdate).onChange(async (v) => {
       this.plugin.settings.frontmatterAutoUpdate = v;
       await this.plugin.saveSettings();
     }));
   }
   renderFocusMode(el) {
-    new import_obsidian28.Setting(el).setName(t2("settings.focus.heading")).setHeading();
-    new import_obsidian28.Setting(el).setName(t2("settings.focus.focusUnit")).setDesc(t2("settings.focus.focusUnitDesc")).addDropdown((d) => d.addOption("paragraph", t2("settings.focus.paragraph")).addOption("sentence", t2("settings.focus.sentence")).setValue(this.plugin.settings.focusUnit).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.focus.heading")).setHeading();
+    new import_obsidian24.Setting(el).setName(t2("settings.focus.focusUnit")).setDesc(t2("settings.focus.focusUnitDesc")).addDropdown((d) => d.addOption("paragraph", t2("settings.focus.paragraph")).addOption("sentence", t2("settings.focus.sentence")).setValue(this.plugin.settings.focusUnit).onChange(async (v) => {
       this.plugin.settings.focusUnit = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.focus.dimOpacity")).setDesc(t2("settings.focus.dimOpacityDesc")).addSlider((s) => s.setLimits(10, 50, 5).setValue(this.plugin.settings.dimOpacity).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.focus.dimOpacity")).setDesc(t2("settings.focus.dimOpacityDesc")).addSlider((s) => s.setLimits(10, 50, 5).setValue(this.plugin.settings.dimOpacity).onChange(async (v) => {
       this.plugin.settings.dimOpacity = v;
       await this.plugin.saveSettings();
       this.plugin.focusMode.applyDimOpacity();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.focus.fontSizeOverride")).setDesc(t2("settings.focus.fontSizeOverrideDesc")).addText((text) => text.setValue(String(this.plugin.settings.focusFontSize || 0)).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.focus.fontSizeOverride")).setDesc(t2("settings.focus.fontSizeOverrideDesc")).addText((text) => text.setValue(String(this.plugin.settings.focusFontSize || 0)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n !== 0 && (n < 8 || n > 72)) return;
       this.plugin.settings.focusFontSize = n;
       await this.plugin.saveSettings();
       this.plugin.focusMode.applyFontSize();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.focus.autoHideSidebars")).addToggle((toggle) => toggle.setValue(this.plugin.settings.focusAutoHideSidebars).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.focus.autoHideSidebars")).addToggle((toggle) => toggle.setValue(this.plugin.settings.focusAutoHideSidebars).onChange(async (v) => {
       this.plugin.settings.focusAutoHideSidebars = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.focus.typewriterScroll")).setDesc(t2("settings.focus.typewriterScrollDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.typewriterScroll).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.focus.typewriterScroll")).setDesc(t2("settings.focus.typewriterScrollDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.typewriterScroll).onChange(async (v) => {
       this.plugin.settings.typewriterScroll = v;
       await this.plugin.saveSettings();
     }));
   }
   renderTypography(el) {
-    new import_obsidian28.Setting(el).setName(t2("settings.typography.heading")).setHeading();
-    new import_obsidian28.Setting(el).setName(t2("settings.typography.fontFamily")).addDropdown((d) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.typography.heading")).setHeading();
+    new import_obsidian24.Setting(el).setName(t2("settings.typography.fontFamily")).addDropdown((d) => {
       d.addOption("mono", t2("settings.typography.font.mono"));
       d.addOption("serif", t2("settings.typography.font.serif"));
       d.addOption("sans", t2("settings.typography.font.sans"));
@@ -15846,110 +15816,110 @@ var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab 
         if (this.plugin.typographyMode.isActive()) this.plugin.typographyMode.refreshStyles();
       });
     });
-    new import_obsidian28.Setting(el).setName(t2("settings.typography.customFontName")).setDesc(t2("settings.typography.customFontNameDesc")).addText((text) => text.setPlaceholder(t2("settings.typography.customFontNamePlaceholder")).setValue(this.plugin.settings.customFontName).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.typography.customFontName")).setDesc(t2("settings.typography.customFontNameDesc")).addText((text) => text.setPlaceholder(t2("settings.typography.customFontNamePlaceholder")).setValue(this.plugin.settings.customFontName).onChange(async (v) => {
       this.plugin.settings.customFontName = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.typography.maxLineLength")).setDesc(t2("settings.typography.maxLineLengthDesc")).addSlider((s) => s.setLimits(55, 80, 1).setValue(this.plugin.settings.maxLineLength).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.typography.maxLineLength")).setDesc(t2("settings.typography.maxLineLengthDesc")).addSlider((s) => s.setLimits(55, 80, 1).setValue(this.plugin.settings.maxLineLength).onChange(async (v) => {
       this.plugin.settings.maxLineLength = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.typography.fontSize")).addText((text) => text.setValue(String(this.plugin.settings.typographyFontSize)).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.typography.fontSize")).addText((text) => text.setValue(String(this.plugin.settings.typographyFontSize)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 8 || n > 72) return;
       this.plugin.settings.typographyFontSize = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.typography.lineHeight")).setDesc(t2("settings.typography.lineHeightDesc")).addText((text) => text.setValue(String(this.plugin.settings.lineHeight)).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.typography.lineHeight")).setDesc(t2("settings.typography.lineHeightDesc")).addText((text) => text.setValue(String(this.plugin.settings.lineHeight)).onChange(async (v) => {
       this.plugin.settings.lineHeight = parseFloat(v) || 1.7;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.typography.letterSpacing")).setDesc(t2("settings.typography.letterSpacingDesc")).addText((text) => text.setValue(this.plugin.settings.letterSpacing).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.typography.letterSpacing")).setDesc(t2("settings.typography.letterSpacingDesc")).addText((text) => text.setValue(this.plugin.settings.letterSpacing).onChange(async (v) => {
       this.plugin.settings.letterSpacing = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.typography.persistAcrossSessions")).setDesc(t2("settings.typography.persistAcrossSessionsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.persistTypography).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.typography.persistAcrossSessions")).setDesc(t2("settings.typography.persistAcrossSessionsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.persistTypography).onChange(async (v) => {
       this.plugin.settings.persistTypography = v;
       await this.plugin.saveSettings();
     }));
   }
   renderSprint(el) {
-    new import_obsidian28.Setting(el).setName(t2("settings.sprint.heading")).setHeading();
-    new import_obsidian28.Setting(el).setName(t2("settings.sprint.defaultDuration")).addText((text) => text.setValue(String(this.plugin.settings.defaultSprintDuration)).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.sprint.heading")).setHeading();
+    new import_obsidian24.Setting(el).setName(t2("settings.sprint.defaultDuration")).addText((text) => text.setValue(String(this.plugin.settings.defaultSprintDuration)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 1 || n > 600) return;
       this.plugin.settings.defaultSprintDuration = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.sprint.defaultDailyGoal")).addText((text) => text.setValue(String(this.plugin.settings.defaultDailyWordGoal)).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.sprint.defaultDailyGoal")).addText((text) => text.setValue(String(this.plugin.settings.defaultDailyWordGoal)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 0 || n > 1e6) return;
       this.plugin.settings.defaultDailyWordGoal = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.sprint.soundNotifications")).setDesc(t2("settings.sprint.soundNotificationsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.soundNotifications).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.sprint.soundNotifications")).setDesc(t2("settings.sprint.soundNotificationsDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.soundNotifications).onChange(async (v) => {
       this.plugin.settings.soundNotifications = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.sprint.historyRetention")).addText((text) => text.setValue(String(this.plugin.settings.sprintHistoryRetention)).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.sprint.historyRetention")).addText((text) => text.setValue(String(this.plugin.settings.sprintHistoryRetention)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 1 || n > 3650) return;
       this.plugin.settings.sprintHistoryRetention = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.sprint.inlineGoalBanner")).setDesc(t2("settings.sprint.inlineGoalBannerDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.inlineGoalBanner).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.sprint.inlineGoalBanner")).setDesc(t2("settings.sprint.inlineGoalBannerDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.inlineGoalBanner).onChange(async (v) => {
       this.plugin.settings.inlineGoalBanner = v;
       await this.plugin.saveSettings();
     }));
   }
   renderExport(el) {
-    new import_obsidian28.Setting(el).setName(t2("settings.export.heading")).setHeading();
-    new import_obsidian28.Setting(el).setName(t2("settings.export.defaultFormat")).addDropdown((d) => d.addOption("md", t2("settings.export.format.md")).addOption("html", t2("settings.export.format.html")).addOption("manuscript", t2("exportModal.format.manuscript")).addOption("epub", t2("exportModal.format.epub")).addOption("pdf", t2("settings.export.format.pdf")).addOption("docx", t2("settings.export.format.docx")).addOption("rtf", t2("settings.export.format.rtf")).setValue(this.plugin.settings.defaultExportFormat).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.export.heading")).setHeading();
+    new import_obsidian24.Setting(el).setName(t2("settings.export.defaultFormat")).addDropdown((d) => d.addOption("md", t2("settings.export.format.md")).addOption("html", t2("settings.export.format.html")).addOption("manuscript", t2("exportModal.format.manuscript")).addOption("epub", t2("exportModal.format.epub")).addOption("pdf", t2("settings.export.format.pdf")).addOption("docx", t2("settings.export.format.docx")).addOption("rtf", t2("settings.export.format.rtf")).setValue(this.plugin.settings.defaultExportFormat).onChange(async (v) => {
       this.plugin.settings.defaultExportFormat = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.export.defaultPaperSize")).addDropdown((d) => d.addOption("letter", t2("settings.export.paperSize.letter")).addOption("a4", t2("settings.export.paperSize.a4")).setValue(this.plugin.settings.defaultPaperSize).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.export.defaultPaperSize")).addDropdown((d) => d.addOption("letter", t2("settings.export.paperSize.letter")).addOption("a4", t2("settings.export.paperSize.a4")).setValue(this.plugin.settings.defaultPaperSize).onChange(async (v) => {
       this.plugin.settings.defaultPaperSize = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.export.exportFont")).addText((text) => text.setPlaceholder("Georgia").setValue(this.plugin.settings.defaultExportFont).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.export.exportFont")).addText((text) => text.setPlaceholder("Georgia").setValue(this.plugin.settings.defaultExportFont).onChange(async (v) => {
       this.plugin.settings.defaultExportFont = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.export.exportFontSize")).addText((text) => text.setValue(String(this.plugin.settings.defaultExportFontSize)).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.export.exportFontSize")).addText((text) => text.setValue(String(this.plugin.settings.defaultExportFontSize)).onChange(async (v) => {
       const n = Number(v.trim());
       if (!Number.isInteger(n) || n < 6 || n > 72) return;
       this.plugin.settings.defaultExportFontSize = n;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.export.pandocPath")).setDesc(t2("settings.export.pandocPathDesc")).addText((text) => text.setPlaceholder("Pandoc").setValue(this.plugin.settings.pandocPath).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.export.pandocPath")).setDesc(t2("settings.export.pandocPathDesc")).addText((text) => text.setPlaceholder("Pandoc").setValue(this.plugin.settings.pandocPath).onChange(async (v) => {
       this.plugin.settings.pandocPath = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.export.epubHeading")).setHeading();
-    new import_obsidian28.Setting(el).setName(t2("settings.export.epubLanguage")).setDesc(t2("settings.export.epubLanguageDesc")).addText((text) => text.setPlaceholder("en").setValue(this.plugin.settings.epubLanguage).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.export.epubHeading")).setHeading();
+    new import_obsidian24.Setting(el).setName(t2("settings.export.epubLanguage")).setDesc(t2("settings.export.epubLanguageDesc")).addText((text) => text.setPlaceholder("en").setValue(this.plugin.settings.epubLanguage).onChange(async (v) => {
       this.plugin.settings.epubLanguage = v.trim() || "en";
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.export.includeCover")).setDesc(t2("settings.export.includeCoverDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.epubIncludeCover).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.export.includeCover")).setDesc(t2("settings.export.includeCoverDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.epubIncludeCover).onChange(async (v) => {
       this.plugin.settings.epubIncludeCover = v;
       await this.plugin.saveSettings();
     }));
   }
   renderLog(el) {
-    new import_obsidian28.Setting(el).setName(t2("settings.log.heading")).setHeading();
-    new import_obsidian28.Setting(el).setName(t2("settings.log.appendToDailyNote")).setDesc(t2("settings.log.appendToDailyNoteDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.appendToDailyNote).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.log.heading")).setHeading();
+    new import_obsidian24.Setting(el).setName(t2("settings.log.appendToDailyNote")).setDesc(t2("settings.log.appendToDailyNoteDesc")).addToggle((toggle) => toggle.setValue(this.plugin.settings.appendToDailyNote).onChange(async (v) => {
       this.plugin.settings.appendToDailyNote = v;
       await this.plugin.saveSettings();
     }));
   }
   renderWordPress(el) {
-    new import_obsidian28.Setting(el).setName(t2("settings.wordpress.sitesHeading")).setHeading();
+    new import_obsidian24.Setting(el).setName(t2("settings.wordpress.sitesHeading")).setHeading();
     const sites = this.plugin.settings.wordPressSites;
     for (let i = 0; i < sites.length; i++) {
       this.renderSiteConfig(el, sites[i], i);
     }
-    new import_obsidian28.Setting(el).addButton((b) => b.setButtonText(t2("settings.wordpress.addSite")).onClick(async () => {
+    new import_obsidian24.Setting(el).addButton((b) => b.setButtonText(t2("settings.wordpress.addSite")).onClick(async () => {
       this.plugin.settings.wordPressSites.push({
         id: `site-${Date.now()}`,
         nickname: t2("settings.wordpress.newSiteName"),
@@ -15966,8 +15936,8 @@ var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab 
         this.renderWordPress(contentEl);
       }
     }));
-    new import_obsidian28.Setting(el).setName(t2("settings.wordpress.wikilinksHeading")).setHeading();
-    new import_obsidian28.Setting(el).setName(t2("settings.wordpress.defaultWikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkStrip")).addOption("convert", t2("settings.wordpress.wikilinkConvert")).setValue(this.plugin.settings.wikilinkHandling).onChange(async (v) => {
+    new import_obsidian24.Setting(el).setName(t2("settings.wordpress.wikilinksHeading")).setHeading();
+    new import_obsidian24.Setting(el).setName(t2("settings.wordpress.defaultWikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkStrip")).addOption("convert", t2("settings.wordpress.wikilinkConvert")).setValue(this.plugin.settings.wikilinkHandling).onChange(async (v) => {
       this.plugin.settings.wikilinkHandling = v;
       await this.plugin.saveSettings();
     }));
@@ -15975,35 +15945,35 @@ var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab 
   renderSiteConfig(container, site, index) {
     const siteEl = container.createDiv("ws-wp-site-config");
     const heading = t2("settings.wordpress.siteHeading", { nickname: site.nickname || t2("settings.wordpress.siteUnnamed") });
-    new import_obsidian28.Setting(siteEl).setName(heading).setHeading();
-    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.nickname")).addText((text) => text.setValue(site.nickname).onChange(async (v) => {
+    new import_obsidian24.Setting(siteEl).setName(heading).setHeading();
+    new import_obsidian24.Setting(siteEl).setName(t2("settings.wordpress.nickname")).addText((text) => text.setValue(site.nickname).onChange(async (v) => {
       site.nickname = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.siteUrl")).addText((text) => text.setPlaceholder("https://example.com").setValue(site.url).onChange(async (v) => {
+    new import_obsidian24.Setting(siteEl).setName(t2("settings.wordpress.siteUrl")).addText((text) => text.setPlaceholder("https://example.com").setValue(site.url).onChange(async (v) => {
       site.url = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.username")).addText((text) => text.setValue(site.username).onChange(async (v) => {
+    new import_obsidian24.Setting(siteEl).setName(t2("settings.wordpress.username")).addText((text) => text.setValue(site.username).onChange(async (v) => {
       site.username = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.appPassword")).setDesc(t2("settings.wordpress.appPasswordDesc")).addText((text) => {
+    new import_obsidian24.Setting(siteEl).setName(t2("settings.wordpress.appPassword")).setDesc(t2("settings.wordpress.appPasswordDesc")).addText((text) => {
       text.inputEl.type = "password";
       text.setValue(site.appPassword).onChange(async (v) => {
         site.appPassword = v;
         await this.plugin.saveSettings();
       });
     });
-    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.defaultPostStatus")).addDropdown((d) => d.addOption("draft", t2("settings.wordpress.postStatus.draft")).addOption("pending", t2("settings.wordpress.postStatus.pending")).addOption("publish", t2("settings.wordpress.postStatus.publish")).setValue(site.defaultStatus).onChange(async (v) => {
+    new import_obsidian24.Setting(siteEl).setName(t2("settings.wordpress.defaultPostStatus")).addDropdown((d) => d.addOption("draft", t2("settings.wordpress.postStatus.draft")).addOption("pending", t2("settings.wordpress.postStatus.pending")).addOption("publish", t2("settings.wordpress.postStatus.publish")).setValue(site.defaultStatus).onChange(async (v) => {
       site.defaultStatus = v;
       await this.plugin.saveSettings();
     }));
-    new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.wikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkHandlingStrip")).addOption("convert", t2("settings.wordpress.wikilinkHandlingConvert")).setValue(site.wikilinkHandling).onChange(async (v) => {
+    new import_obsidian24.Setting(siteEl).setName(t2("settings.wordpress.wikilinkHandling")).addDropdown((d) => d.addOption("strip", t2("settings.wordpress.wikilinkHandlingStrip")).addOption("convert", t2("settings.wordpress.wikilinkHandlingConvert")).setValue(site.wikilinkHandling).onChange(async (v) => {
       site.wikilinkHandling = v;
       await this.plugin.saveSettings();
     }));
-    const testRow = new import_obsidian28.Setting(siteEl).setName(t2("settings.wordpress.testConnection")).setDesc(t2("settings.wordpress.testConnectionDesc"));
+    const testRow = new import_obsidian24.Setting(siteEl).setName(t2("settings.wordpress.testConnection")).setDesc(t2("settings.wordpress.testConnectionDesc"));
     const statusEl = siteEl.createDiv("ws-wp-test-status");
     testRow.addButton((b) => b.setButtonText(t2("settings.wordpress.testConnection")).onClick(async () => {
       statusEl.textContent = t2("settings.wordpress.testing");
@@ -16012,7 +15982,7 @@ var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab 
       statusEl.textContent = result.message;
       statusEl.className = `ws-wp-test-status ${result.success ? "ws-wp-test-ok" : "ws-wp-test-err"}`;
     }));
-    new import_obsidian28.Setting(siteEl).addButton((b) => {
+    new import_obsidian24.Setting(siteEl).addButton((b) => {
       b.setButtonText(t2("settings.wordpress.removeSite"));
       b.buttonEl.addClass("mod-warning");
       b.onClick(async () => {
@@ -16027,10 +15997,10 @@ var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab 
     });
   }
   async renderHelp(el) {
-    this.helpComponent = new import_obsidian28.Component();
+    this.helpComponent = new import_obsidian24.Component();
     this.helpComponent.load();
     el.addClass("ws-help-content");
-    await import_obsidian28.MarkdownRenderer.render(this.app, HELP_CONTENT, el, "", this.helpComponent);
+    await import_obsidian24.MarkdownRenderer.render(this.app, HELP_CONTENT, el, "", this.helpComponent);
     const supportDiv = el.createDiv({ cls: "ws-support-footer" });
     supportDiv.createEl("a", {
       href: "https://buymeacoffee.com/writerp777",
@@ -16046,9 +16016,9 @@ var WritingStudioSettingsTab = class extends import_obsidian28.PluginSettingTab 
 };
 
 // src/FolderSidebarView.ts
-var import_obsidian29 = require("obsidian");
+var import_obsidian25 = require("obsidian");
 var FOLDER_SIDEBAR_VIEW_TYPE = "folder-sidebar-explorer-view";
-var FolderSidebarView = class extends import_obsidian29.ItemView {
+var FolderSidebarView = class extends import_obsidian25.ItemView {
   constructor(leaf) {
     super(leaf);
     this.rootFolder = null;
@@ -16098,7 +16068,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     const path = state == null ? void 0 : state.rootFolderPath;
     if (typeof path === "string" && path !== ((_a2 = this.rootFolder) == null ? void 0 : _a2.path)) {
       const folder = this.app.vault.getAbstractFileByPath(path);
-      if (folder instanceof import_obsidian29.TFolder) {
+      if (folder instanceof import_obsidian25.TFolder) {
         this.setRootFolder(folder);
         return;
       }
@@ -16122,10 +16092,10 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     const active = (_a2 = this.app.workspace.activeEditor) == null ? void 0 : _a2.editor;
     if (active) return active;
     const recent = this.app.workspace.getMostRecentLeaf(this.app.workspace.rootSplit);
-    if ((recent == null ? void 0 : recent.view) instanceof import_obsidian29.MarkdownView) return recent.view.editor;
+    if ((recent == null ? void 0 : recent.view) instanceof import_obsidian25.MarkdownView) return recent.view.editor;
     for (const leaf of this.app.workspace.getLeavesOfType("markdown")) {
       const view = leaf.view;
-      if (view instanceof import_obsidian29.MarkdownView) return view.editor;
+      if (view instanceof import_obsidian25.MarkdownView) return view.editor;
     }
     return null;
   }
@@ -16155,7 +16125,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     if (this.historyStack.length === 0) return;
     const prevPath = this.historyStack.pop();
     const prev = this.app.vault.getAbstractFileByPath(prevPath);
-    if (prev instanceof import_obsidian29.TFolder) {
+    if (prev instanceof import_obsidian25.TFolder) {
       this.currentFolder = prev;
       this.searchQuery = "";
       this.searchResults = null;
@@ -16192,10 +16162,10 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     const results = [];
     const walk = (f) => {
       for (const child of f.children) {
-        if (child instanceof import_obsidian29.TFolder) {
+        if (child instanceof import_obsidian25.TFolder) {
           results.push(child);
           walk(child);
-        } else if (child instanceof import_obsidian29.TFile) {
+        } else if (child instanceof import_obsidian25.TFile) {
           results.push(child);
         }
       }
@@ -16241,7 +16211,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
       }
     }
     const textFiles = allItems.filter(
-      (item) => item instanceof import_obsidian29.TFile && ["md", "txt"].includes(item.extension.toLowerCase()) && !nameMatched.has(item)
+      (item) => item instanceof import_obsidian25.TFile && ["md", "txt"].includes(item.extension.toLowerCase()) && !nameMatched.has(item)
     );
     const contentMatches = await Promise.all(textFiles.map(async (file) => {
       try {
@@ -16280,7 +16250,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     this.tooltipEl = tip;
     tip.createDiv({ cls: "ws-tooltip-name", text: item.name });
     tip.createDiv({ cls: "ws-tooltip-divider" });
-    if (item instanceof import_obsidian29.TFile) {
+    if (item instanceof import_obsidian25.TFile) {
       const modDate = new Date(item.stat.mtime);
       const modStr = modDate.toLocaleDateString(void 0, {
         year: "numeric",
@@ -16310,8 +16280,8 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
       let folderCount = 0;
       const walk = (f) => {
         for (const child of f.children) {
-          if (child instanceof import_obsidian29.TFile) fileCount++;
-          else if (child instanceof import_obsidian29.TFolder) {
+          if (child instanceof import_obsidian25.TFile) fileCount++;
+          else if (child instanceof import_obsidian25.TFolder) {
             folderCount++;
             walk(child);
           }
@@ -16407,9 +16377,9 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
   // One comparator for both the folder listing and search results — the two
   // sort methods previously duplicated this switch block
   compareEntries(a, b) {
-    const aIsFolder = a instanceof import_obsidian29.TFolder;
-    const bIsFolder = b instanceof import_obsidian29.TFolder;
-    const mtime = (x) => x instanceof import_obsidian29.TFile ? x.stat.mtime : 0;
+    const aIsFolder = a instanceof import_obsidian25.TFolder;
+    const bIsFolder = b instanceof import_obsidian25.TFolder;
+    const mtime = (x) => x instanceof import_obsidian25.TFile ? x.stat.mtime : 0;
     switch (this.sortMode) {
       case "folders-az":
         if (aIsFolder !== bIsFolder) return aIsFolder ? -1 : 1;
@@ -16522,7 +16492,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     const toolbar = container.createDiv({ cls: "ws-folder-toolbar" });
     const searchWrap = toolbar.createDiv({ cls: "ws-folder-search-wrap" });
     const searchIcon = searchWrap.createSpan({ cls: "ws-folder-search-icon" });
-    (0, import_obsidian29.setIcon)(searchIcon, "search");
+    (0, import_obsidian25.setIcon)(searchIcon, "search");
     const searchInput = searchWrap.createEl("input", {
       cls: "ws-folder-search-input",
       type: "text",
@@ -16583,7 +16553,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
     if (ext === "md") {
       try {
         const text = await this.app.vault.cachedRead(file);
-        await import_obsidian29.MarkdownRenderer.render(this.app, text, content2, file.path, this);
+        await import_obsidian25.MarkdownRenderer.render(this.app, text, content2, file.path, this);
         if (this.searchQuery) this.highlightTextInElement(content2, this.searchQuery);
       } catch (e) {
         content2.createDiv({ cls: "ws-folder-empty", text: t2("folderSidebar.previewError") });
@@ -16632,14 +16602,14 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
         itemEl.setAttribute("aria-selected", "false");
         const topRow = itemEl.createDiv({ cls: "ws-folder-item-row" });
         const iconEl = topRow.createSpan({ cls: "ws-folder-item-icon" });
-        if (item instanceof import_obsidian29.TFolder) {
-          (0, import_obsidian29.setIcon)(iconEl, "folder");
+        if (item instanceof import_obsidian25.TFolder) {
+          (0, import_obsidian25.setIcon)(iconEl, "folder");
         } else {
           const ext = item.extension.toLowerCase();
-          if (ext === "md") (0, import_obsidian29.setIcon)(iconEl, "file-text");
-          else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian29.setIcon)(iconEl, "image");
-          else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian29.setIcon)(iconEl, "file-audio");
-          else (0, import_obsidian29.setIcon)(iconEl, "file");
+          if (ext === "md") (0, import_obsidian25.setIcon)(iconEl, "file-text");
+          else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian25.setIcon)(iconEl, "image");
+          else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian25.setIcon)(iconEl, "file-audio");
+          else (0, import_obsidian25.setIcon)(iconEl, "file");
         }
         const isAtRoot = ((_a2 = item.parent) == null ? void 0 : _a2.path) === ((_c = (_b2 = this.rootFolder) == null ? void 0 : _b2.path) != null ? _c : current.path);
         const label = !isAtRoot && item.path.startsWith(rootPath) ? item.path.slice(rootPath.length) : item.name;
@@ -16657,8 +16627,8 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
           this.renderHighlightedText(snippetEl, snippet, lowerQuery);
         }
         itemEl.addEventListener("click", () => {
-          if (item instanceof import_obsidian29.TFolder) this.navigateTo(item);
-          else if (item instanceof import_obsidian29.TFile) this.openFile(item);
+          if (item instanceof import_obsidian25.TFolder) this.navigateTo(item);
+          else if (item instanceof import_obsidian25.TFile) this.openFile(item);
         });
         this.addTooltip(itemEl, item);
         items2.push(itemEl);
@@ -16695,7 +16665,7 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
       return;
     }
     const displayItems = current.children.filter(
-      (c) => c instanceof import_obsidian29.TFolder || c instanceof import_obsidian29.TFile
+      (c) => c instanceof import_obsidian25.TFolder || c instanceof import_obsidian25.TFile
     );
     const sorted = this.sortItems(displayItems);
     if (sorted.length === 0) {
@@ -16709,19 +16679,19 @@ var FolderSidebarView = class extends import_obsidian29.ItemView {
       item.setAttribute("role", "option");
       item.setAttribute("aria-selected", "false");
       const iconEl = item.createSpan({ cls: "ws-folder-item-icon" });
-      if (child instanceof import_obsidian29.TFolder) {
-        (0, import_obsidian29.setIcon)(iconEl, "folder");
-      } else if (child instanceof import_obsidian29.TFile) {
+      if (child instanceof import_obsidian25.TFolder) {
+        (0, import_obsidian25.setIcon)(iconEl, "folder");
+      } else if (child instanceof import_obsidian25.TFile) {
         const ext = child.extension.toLowerCase();
-        if (ext === "md") (0, import_obsidian29.setIcon)(iconEl, "file-text");
-        else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian29.setIcon)(iconEl, "image");
-        else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian29.setIcon)(iconEl, "file-audio");
-        else (0, import_obsidian29.setIcon)(iconEl, "file");
+        if (ext === "md") (0, import_obsidian25.setIcon)(iconEl, "file-text");
+        else if (["png", "jpg", "jpeg", "webp", "gif", "svg"].includes(ext)) (0, import_obsidian25.setIcon)(iconEl, "image");
+        else if (["mp3", "wav", "m4a", "ogg", "flac"].includes(ext)) (0, import_obsidian25.setIcon)(iconEl, "file-audio");
+        else (0, import_obsidian25.setIcon)(iconEl, "file");
       }
       item.createSpan({ text: child.name });
       item.addEventListener("click", () => {
-        if (child instanceof import_obsidian29.TFolder) this.navigateTo(child);
-        else if (child instanceof import_obsidian29.TFile) this.openFile(child);
+        if (child instanceof import_obsidian25.TFolder) this.navigateTo(child);
+        else if (child instanceof import_obsidian25.TFile) this.openFile(child);
       });
       this.addTooltip(item, child);
       items.push(item);
@@ -16764,7 +16734,7 @@ function applyFocus(items, index) {
     if (i === index) item.scrollIntoView({ block: "nearest" });
   });
 }
-var FolderPickerModal = class extends import_obsidian29.FuzzySuggestModal {
+var FolderPickerModal = class extends import_obsidian25.FuzzySuggestModal {
   constructor(app, onChoose) {
     super(app);
     this.onChoose = onChoose;
@@ -16775,7 +16745,7 @@ var FolderPickerModal = class extends import_obsidian29.FuzzySuggestModal {
     const walk = (folder) => {
       folders.push(folder);
       for (const child of folder.children) {
-        if (child instanceof import_obsidian29.TFolder) walk(child);
+        if (child instanceof import_obsidian25.TFolder) walk(child);
       }
     };
     walk(this.app.vault.getRoot());
@@ -16790,9 +16760,9 @@ var FolderPickerModal = class extends import_obsidian29.FuzzySuggestModal {
 };
 
 // src/WritingLogView.ts
-var import_obsidian30 = require("obsidian");
+var import_obsidian26 = require("obsidian");
 var WRITING_LOG_VIEW_TYPE = "writing-studio-writing-log";
-var WritingLogView = class extends import_obsidian30.ItemView {
+var WritingLogView = class extends import_obsidian26.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
     this.plugin = plugin;
@@ -16819,7 +16789,7 @@ var WritingLogView = class extends import_obsidian30.ItemView {
     const root = this.containerEl.children[1];
     root.empty();
     root.addClass("ws-log-root");
-    const lang = (0, import_obsidian30.getLanguage)();
+    const lang = (0, import_obsidian26.getLanguage)();
     const header = root.createDiv("ws-log-header");
     header.createDiv({ text: t2("log.title"), cls: "ws-log-title" });
     header.createDiv({
@@ -17011,7 +16981,7 @@ var StatusBar = class {
 };
 
 // src/GoalBanner.ts
-var import_obsidian31 = require("obsidian");
+var import_obsidian27 = require("obsidian");
 var GoalBanner = class {
   constructor(plugin) {
     this.generation = 0;
@@ -17037,7 +17007,7 @@ var GoalBanner = class {
     const leaf = this.plugin.app.workspace.getMostRecentLeaf();
     if (!leaf) return;
     const view = leaf.view;
-    if (!(view instanceof import_obsidian31.MarkdownView)) return;
+    if (!(view instanceof import_obsidian27.MarkdownView)) return;
     const file = view.file;
     if (!file) return;
     const goal = await this.plugin.projectManager.getWordCountGoalForFile(file);
@@ -17066,18 +17036,18 @@ var GoalBanner = class {
 };
 
 // src/VaultFiles.ts
-var import_obsidian32 = require("obsidian");
+var import_obsidian28 = require("obsidian");
 var ObsidianVaultFiles = class {
   constructor(app) {
     this.app = app;
   }
   async readText(path) {
     const file = this.app.vault.getAbstractFileByPath(path);
-    return file instanceof import_obsidian32.TFile ? this.app.vault.read(file) : null;
+    return file instanceof import_obsidian28.TFile ? this.app.vault.read(file) : null;
   }
   async writeText(path, content2) {
     const existing = this.app.vault.getAbstractFileByPath(path);
-    if (existing instanceof import_obsidian32.TFile) {
+    if (existing instanceof import_obsidian28.TFile) {
       await this.app.vault.modify(existing, content2);
     } else {
       await this.app.vault.create(path, content2);
@@ -17085,18 +17055,18 @@ var ObsidianVaultFiles = class {
   }
   async readBinary(path) {
     const file = this.app.vault.getAbstractFileByPath(path);
-    return file instanceof import_obsidian32.TFile ? this.app.vault.readBinary(file) : null;
+    return file instanceof import_obsidian28.TFile ? this.app.vault.readBinary(file) : null;
   }
   async writeBinary(path, data) {
     const existing = this.app.vault.getAbstractFileByPath(path);
-    if (existing instanceof import_obsidian32.TFile) {
+    if (existing instanceof import_obsidian28.TFile) {
       await this.app.vault.modifyBinary(existing, data);
     } else {
       await this.app.vault.createBinary(path, data);
     }
   }
   async remove(path) {
-    if (this.app.vault.getAbstractFileByPath(path) instanceof import_obsidian32.TFile) {
+    if (this.app.vault.getAbstractFileByPath(path) instanceof import_obsidian28.TFile) {
       await this.app.vault.adapter.remove(path);
     }
   }
@@ -17110,18 +17080,18 @@ var ObsidianVaultFiles = class {
   }
   listSubfolders(path) {
     const folder = this.app.vault.getAbstractFileByPath(path);
-    if (!(folder instanceof import_obsidian32.TFolder)) return [];
-    return folder.children.filter((c) => c instanceof import_obsidian32.TFolder).map((c) => c.path);
+    if (!(folder instanceof import_obsidian28.TFolder)) return [];
+    return folder.children.filter((c) => c instanceof import_obsidian28.TFolder).map((c) => c.path);
   }
   absolutePath(path) {
     const adapter = this.app.vault.adapter;
-    return adapter instanceof import_obsidian32.FileSystemAdapter ? adapter.getFullPath(path) : path;
+    return adapter instanceof import_obsidian28.FileSystemAdapter ? adapter.getFullPath(path) : path;
   }
 };
 
 // modals/AddToProjectModal.ts
-var import_obsidian33 = require("obsidian");
-var AddToProjectModal = class extends import_obsidian33.Modal {
+var import_obsidian29 = require("obsidian");
+var AddToProjectModal = class extends import_obsidian29.Modal {
   constructor(app, plugin, file, onConfirm) {
     super(app);
     this.selectedProjectId = "";
@@ -17143,7 +17113,7 @@ var AddToProjectModal = class extends import_obsidian33.Modal {
     }
     this.selectedProjectId = projects[0].id;
     contentEl.createEl("p", { text: t2("addToProject.file", { path: this.file.path }), cls: "ws-add-to-project-path" });
-    new import_obsidian33.Setting(contentEl).setName(t2("addToProject.projectName")).setDesc(t2("addToProject.projectDesc")).addDropdown((d) => {
+    new import_obsidian29.Setting(contentEl).setName(t2("addToProject.projectName")).setDesc(t2("addToProject.projectDesc")).addDropdown((d) => {
       projects.forEach((p) => {
         d.addOption(p.id, p.title);
       });
@@ -17219,7 +17189,7 @@ var DEFAULT_SETTINGS = {
   activeProjectId: null,
   currentWritingMode: "none"
 };
-var WritingStudioPlugin = class extends import_obsidian34.Plugin {
+var WritingStudioPlugin = class extends import_obsidian30.Plugin {
   constructor() {
     super(...arguments);
     this.wordCountUpdateTimer = null;
@@ -17280,7 +17250,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
     );
     this.registerEvent(
       this.app.workspace.on("file-menu", (menu, file) => {
-        if (file instanceof import_obsidian34.TFile && file.extension === "md") {
+        if (file instanceof import_obsidian30.TFile && file.extension === "md") {
           menu.addItem((i) => i.setTitle(t2("main.menu.studioOptions")).setSection("writing-studio").setDisabled(true));
           menu.addItem(
             (i) => i.setTitle(t2("main.menu.addToProject")).setIcon("book-open").setSection("writing-studio").onClick(() => {
@@ -17288,7 +17258,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
             })
           );
         }
-        if (file instanceof import_obsidian34.TFolder) {
+        if (file instanceof import_obsidian30.TFolder) {
           menu.addItem((i) => i.setTitle(t2("main.menu.studioOptions")).setSection("writing-studio").setDisabled(true));
           menu.addItem(
             (i) => i.setTitle(t2("main.menu.openSidebar")).setIcon("folder").setSection("writing-studio").onClick(() => {
@@ -17300,7 +17270,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
     );
     this.registerEvent(
       this.app.vault.on("modify", (file) => {
-        if (file instanceof import_obsidian34.TFile) {
+        if (file instanceof import_obsidian30.TFile) {
           this.fmManager.scheduleUpdate(file);
           this.scheduleWordCountUpdate();
           this.statusBar.scheduleProjectGoalUpdate();
@@ -17310,7 +17280,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
     );
     this.registerEvent(
       this.app.vault.on("rename", (file, oldPath) => {
-        if (!(file instanceof import_obsidian34.TFile)) return;
+        if (!(file instanceof import_obsidian30.TFile)) return;
         if (file.extension === "md") {
           void this.repairBinderPaths(oldPath, file.path, file.basename);
         }
@@ -17464,9 +17434,9 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
   publishCurrentFile() {
     const leaf = this.app.workspace.getMostRecentLeaf();
     const view = leaf == null ? void 0 : leaf.view;
-    const file = view instanceof import_obsidian34.MarkdownView ? view.file : null;
-    if (!(file instanceof import_obsidian34.TFile)) {
-      new import_obsidian34.Notice(t2("main.notice.noMarkdownOpen"));
+    const file = view instanceof import_obsidian30.MarkdownView ? view.file : null;
+    if (!(file instanceof import_obsidian30.TFile)) {
+      new import_obsidian30.Notice(t2("main.notice.noMarkdownOpen"));
       return;
     }
     new PublishModal(this.app, this, file.path).open();
@@ -17508,7 +17478,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
     }
   }
   showModeSwitcher(e) {
-    const menu = new import_obsidian34.Menu();
+    const menu = new import_obsidian30.Menu();
     menu.addItem((i) => i.setTitle(t2("main.menu.draftMode")).setIcon("pencil").onClick(() => this.writingModes.switchMode("draft")));
     menu.addItem((i) => i.setTitle(t2("main.menu.editMode")).setIcon("edit-3").onClick(() => this.writingModes.switchMode("edit")));
     menu.addItem((i) => i.setTitle(t2("main.menu.reviewMode")).setIcon("eye").onClick(() => this.writingModes.switchMode("review")));
@@ -17517,7 +17487,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
     if (e instanceof MouseEvent) menu.showAtMouseEvent(e);
   }
   showFontPicker(e) {
-    const menu = new import_obsidian34.Menu();
+    const menu = new import_obsidian30.Menu();
     TYPOGRAPHY_FONT_OPTIONS.forEach(({ key }) => {
       menu.addItem((i) => {
         i.setTitle(t2(`settings.typography.font.${key}`)).onClick(() => {
@@ -17535,7 +17505,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
   addFileToProject(file) {
     const projects = this.projectManager.getProjects();
     if (projects.length === 0) {
-      new import_obsidian34.Notice(t2("addToProject.noProjects"));
+      new import_obsidian30.Notice(t2("addToProject.noProjects"));
       return;
     }
     new AddToProjectModal(this.app, this, file, async (projectId) => {
@@ -17553,7 +17523,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
       };
       binder.items.push(item);
       await this.projectManager.saveBinder(binder);
-      new import_obsidian34.Notice(t2("main.notice.addedToProject", { file: file.basename, project: project.title }));
+      new import_obsidian30.Notice(t2("main.notice.addedToProject", { file: file.basename, project: project.title }));
     }).open();
   }
   scheduleLauncherRefresh() {
@@ -17573,7 +17543,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
   async updateWordCount() {
     const leaf = this.app.workspace.getMostRecentLeaf();
     const view = leaf == null ? void 0 : leaf.view;
-    if (!(view instanceof import_obsidian34.MarkdownView) || !view.editor) {
+    if (!(view instanceof import_obsidian30.MarkdownView) || !view.editor) {
       this.statusBar.clearWordCount();
       return;
     }
@@ -17598,7 +17568,7 @@ var WritingStudioPlugin = class extends import_obsidian34.Plugin {
     }
   }
 };
-var SprintSummaryModal = class extends import_obsidian34.Modal {
+var SprintSummaryModal = class extends import_obsidian30.Modal {
   constructor(app, session) {
     super(app);
     this.session = session;
@@ -17629,7 +17599,7 @@ var SprintSummaryModal = class extends import_obsidian34.Modal {
     this.contentEl.empty();
   }
 };
-var WordCountGoalModal = class extends import_obsidian34.Modal {
+var WordCountGoalModal = class extends import_obsidian30.Modal {
   constructor(app, plugin, file) {
     super(app);
     this.goal = 0;
@@ -17644,7 +17614,7 @@ var WordCountGoalModal = class extends import_obsidian34.Modal {
     contentEl.createEl("h2", { text: t2("wordCountGoal.title") });
     const cache = this.app.metadataCache.getFileCache(this.file);
     this.goal = Number((_a2 = cache == null ? void 0 : cache.frontmatter) == null ? void 0 : _a2["word-count-goal"]) || 0;
-    new import_obsidian34.Setting(contentEl).setName(t2("wordCountGoal.name")).setDesc(t2("wordCountGoal.desc")).addText((tx) => tx.setValue(String(this.goal || "")).setPlaceholder(t2("wordCountGoal.placeholder")).onChange((v) => {
+    new import_obsidian30.Setting(contentEl).setName(t2("wordCountGoal.name")).setDesc(t2("wordCountGoal.desc")).addText((tx) => tx.setValue(String(this.goal || "")).setPlaceholder(t2("wordCountGoal.placeholder")).onChange((v) => {
       this.goal = parseInt(v) || 0;
     }));
     const btnRow = contentEl.createDiv("ws-modal-btn-row");

--- a/src/ProjectManager.ts
+++ b/src/ProjectManager.ts
@@ -6,11 +6,8 @@ import { localDateString } from './dates';
 import { WritingProject, ProjectType } from '../models/Project';
 import { BinderData, BinderItem } from '../models/BinderItem';
 import { SprintSession } from '../models/SprintSession';
-import { BookTemplate } from '../templates/BookTemplate';
-import { ArticleSeriesTemplate } from '../templates/ArticleSeriesTemplate';
-import { BlogCollectionTemplate } from '../templates/BlogCollectionTemplate';
-import { JournalArticleTemplate } from '../templates/JournalArticleTemplate';
-import { MagazineArticleTemplate } from '../templates/MagazineArticleTemplate';
+import { TemplateScaffolder } from './scaffold';
+import { TEMPLATE_MANIFESTS } from '../templates/manifests';
 
 export class ProjectManager extends Events {
   private plugin: WritingStudioPlugin;
@@ -115,26 +112,10 @@ export class ProjectManager extends Events {
     };
 
     // Apply template
-    let binderData: BinderData;
-    switch (type) {
-      case 'book':
-        binderData = await BookTemplate.apply(this.app, project);
-        break;
-      case 'series':
-        binderData = await ArticleSeriesTemplate.apply(this.app, project);
-        break;
-      case 'blog':
-        binderData = await BlogCollectionTemplate.apply(this.app, project);
-        break;
-      case 'journal-article':
-        binderData = await JournalArticleTemplate.apply(this.app, project);
-        break;
-      case 'magazine-article':
-        binderData = await MagazineArticleTemplate.apply(this.app, project);
-        break;
-      default:
-        binderData = this.createBlankBinder(project);
-    }
+    const manifestBuilder = TEMPLATE_MANIFESTS[type];
+    const binderData: BinderData = manifestBuilder
+      ? await new TemplateScaffolder(this.files).apply(project, manifestBuilder(project))
+      : this.createBlankBinder(project);
 
     await this.saveProject(project);
     await this.saveBinder(binderData);

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -1,0 +1,119 @@
+import { normalizePath } from 'obsidian';
+import type { VaultFiles } from './VaultFiles';
+import { WritingProject } from '../models/Project';
+import { BinderData, BinderItem } from '../models/BinderItem';
+
+// A project template as data: the folders and documents to scaffold and the
+// binder tree they produce. Templates build one of these; TemplateScaffolder
+// is the only code that touches the vault.
+export interface ManifestNode {
+  id: string;
+  title: string;
+  type: BinderItem['type'];
+  // Path relative to the project's Chapters folder, without the .md
+  // extension. Structural nodes (group/part) omit it and carry no file.
+  fileName?: string;
+  // Full file content; required when fileName is present.
+  content?: string;
+  wordCountGoal?: number;
+  includeInExport?: boolean; // default true
+  children?: ManifestNode[];
+}
+
+export interface TemplateManifest {
+  // Extra folders relative to the Chapters folder (e.g. a year folder).
+  folders?: string[];
+  items: ManifestNode[];
+}
+
+export interface DocFields {
+  title: string;
+  // Frontmatter `type:` — may differ from the binder item type
+  // (e.g. 'abstract' in frontmatter, 'section' in the binder).
+  fmType: string;
+  order: number;
+  goal?: number;
+  date: string;
+  // Emits `include-in-export: false` for reference documents.
+  exportExcluded?: boolean;
+  tags?: string[];
+  // Extra frontmatter fields, emitted directly after the title.
+  extraFields?: Record<string, string>;
+  // Defaults to title.
+  heading?: string;
+  body: string;
+}
+
+// The one place the template document format lives.
+export function templateDoc(f: DocFields): string {
+  const extra = Object.entries(f.extraFields ?? {})
+    .map(([k, v]) => `\n${k}: "${v}"`)
+    .join('');
+  const goalLine = f.goal && f.goal > 0 ? `\nword-count-goal: ${f.goal}` : '';
+  const exportLine = f.exportExcluded ? '\ninclude-in-export: false' : '';
+  const tags = (f.tags ?? ['writing-studio']).join(', ');
+  return `---
+title: "${f.title}"${extra}
+type: ${f.fmType}
+order: ${f.order}
+status: draft${goalLine}${exportLine}
+word-count: 0
+created: ${f.date}
+modified: ${f.date}
+tags: [${tags}]
+---
+
+# ${f.heading ?? f.title}
+
+${f.body}
+`;
+}
+
+export function placeholderHint(text: string): string {
+  return `> [!note] Placeholder\n> *${text}*`;
+}
+
+export class TemplateScaffolder {
+  private files: VaultFiles;
+
+  constructor(files: VaultFiles) {
+    this.files = files;
+  }
+
+  async apply(project: WritingProject, manifest: TemplateManifest): Promise<BinderData> {
+    const chapters = normalizePath(`${project.folderPath}/Chapters`);
+    for (const folder of manifest.folders ?? []) {
+      await this.files.ensureFolder(normalizePath(`${chapters}/${folder}`));
+    }
+    const items = await this.buildItems(manifest.items, chapters);
+    return { version: '2.0', projectId: project.id, items };
+  }
+
+  private async buildItems(nodes: ManifestNode[], chapters: string): Promise<BinderItem[]> {
+    const items: BinderItem[] = [];
+    let order = 1;
+    for (const node of nodes) {
+      let filePath = '';
+      if (node.fileName) {
+        filePath = normalizePath(`${chapters}/${node.fileName}.md`);
+        // Never overwrite — a user file with the same name wins.
+        if (!this.files.exists(filePath)) {
+          await this.files.writeText(filePath, node.content ?? '');
+        }
+      }
+      const item: BinderItem = {
+        id: node.id,
+        title: node.title,
+        filePath,
+        type: node.type,
+        order: order++,
+        status: 'draft',
+        includeInExport: node.includeInExport ?? true,
+      };
+      if (node.wordCountGoal) item.wordCountGoal = node.wordCountGoal;
+      if (node.children) item.children = await this.buildItems(node.children, chapters);
+      items.push(item);
+    }
+    return items;
+  }
+}

--- a/templates/ArticleSeriesTemplate.ts
+++ b/templates/ArticleSeriesTemplate.ts
@@ -1,69 +1,22 @@
-import { App, normalizePath } from 'obsidian';
 import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
-import { BinderData, BinderItem } from '../models/BinderItem';
+import { TemplateManifest, templateDoc } from '../src/scaffold';
 
-export class ArticleSeriesTemplate {
-  static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = localDateString();
-    const chaptersPath = normalizePath(`${project.folderPath}/Chapters`);
-
-    const seriesMetaFile = normalizePath(`${chaptersPath}/Series Overview.md`);
-    const article1File = normalizePath(`${chaptersPath}/Article 1.md`);
-
-    await ArticleSeriesTemplate.createFile(app, seriesMetaFile, ArticleSeriesTemplate.seriesOverviewDoc(project.title, now));
-    await ArticleSeriesTemplate.createFile(app, article1File, ArticleSeriesTemplate.article1Doc(project.title, now));
-
-    const items: BinderItem[] = [
+export function articleSeriesManifest(project: WritingProject): TemplateManifest {
+  const date = localDateString();
+  return {
+    items: [
       {
         id: 'item-series-overview',
         title: 'Series Overview',
-        filePath: seriesMetaFile,
         type: 'note',
-        order: 1,
-        status: 'draft',
+        fileName: 'Series Overview',
         includeInExport: false,
-      },
-      {
-        id: 'item-article-1',
-        title: 'Article 1',
-        filePath: article1File,
-        type: 'article',
-        order: 2,
-        status: 'draft',
-        wordCountGoal: 1500,
-        includeInExport: true,
-      },
-    ];
-
-    return {
-      version: '2.0',
-      projectId: project.id,
-      items,
-    };
-  }
-
-  private static async createFile(app: App, path: string, content: string): Promise<void> {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content);
-    }
-  }
-
-  private static seriesOverviewDoc(title: string, date: string): string {
-    return `---
-title: "Series Overview"
-type: note
-order: 1
-status: draft
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio, series-meta]
----
-
-# ${title} — Series Overview
-
-## Series Description
+        content: templateDoc({
+          title: 'Series Overview', fmType: 'note', order: 1, date,
+          tags: ['writing-studio', 'series-meta'],
+          heading: `${project.title} — Series Overview`,
+          body: `## Series Description
 
 *Describe the series premise, target audience, and goals here.*
 
@@ -76,26 +29,20 @@ tags: [writing-studio, series-meta]
 ## WordPress Settings
 
 - **Site:** *(configure in Settings → WordPress)*
-- **Category:** *(set in Project Settings)*
-`;
-  }
-
-  private static article1Doc(_seriesTitle: string, date: string): string {
-    return `---
-title: "Article 1"
-type: article
-order: 1
-status: draft
-word-count-goal: 1500
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# Article 1
-
-*Write your first article here.*
-`;
-  }
+- **Category:** *(set in Project Settings)*`,
+        }),
+      },
+      {
+        id: 'item-article-1',
+        title: 'Article 1',
+        type: 'article',
+        fileName: 'Article 1',
+        wordCountGoal: 1500,
+        content: templateDoc({
+          title: 'Article 1', fmType: 'article', order: 1, goal: 1500, date,
+          body: '*Write your first article here.*',
+        }),
+      },
+    ],
+  };
 }

--- a/templates/BlogCollectionTemplate.ts
+++ b/templates/BlogCollectionTemplate.ts
@@ -1,78 +1,32 @@
-import { App, normalizePath } from 'obsidian';
 import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
-import { BinderData, BinderItem } from '../models/BinderItem';
+import { TemplateManifest, templateDoc } from '../src/scaffold';
 
-export class BlogCollectionTemplate {
-  static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = localDateString();
-    const chaptersPath = normalizePath(`${project.folderPath}/Chapters`);
-    const year = new Date().getFullYear();
-
-    await BlogCollectionTemplate.createFolder(app, normalizePath(`${chaptersPath}/${year}`));
-
-    const firstPostFile = normalizePath(`${chaptersPath}/${year}/${now}-first-post.md`);
-    await BlogCollectionTemplate.createFile(app, firstPostFile, BlogCollectionTemplate.firstPostDoc(now));
-
-    const items: BinderItem[] = [
+export function blogCollectionManifest(_project: WritingProject): TemplateManifest {
+  const date = localDateString();
+  const year = new Date().getFullYear();
+  return {
+    folders: [String(year)],
+    items: [
       {
         id: `item-year-${year}`,
         title: String(year),
-        filePath: '',
         type: 'group',
-        order: 1,
-        status: 'draft',
         includeInExport: false,
         children: [
           {
             id: 'item-first-post',
             title: 'First Post',
-            filePath: firstPostFile,
             type: 'article',
-            order: 1,
-            status: 'draft',
+            fileName: `${year}/${date}-first-post`,
             wordCountGoal: 800,
-            includeInExport: true,
+            content: templateDoc({
+              title: 'First Post', fmType: 'article', order: 1, goal: 800, date,
+              body: '*Write your first blog post here.*',
+            }),
           },
         ],
       },
-    ];
-
-    return {
-      version: '2.0',
-      projectId: project.id,
-      items,
-    };
-  }
-
-  private static async createFile(app: App, path: string, content: string): Promise<void> {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content);
-    }
-  }
-
-  private static async createFolder(app: App, path: string): Promise<void> {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.createFolder(path);
-    }
-  }
-
-  private static firstPostDoc(date: string): string {
-    return `---
-title: "First Post"
-type: article
-order: 1
-status: draft
-word-count-goal: 800
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# First Post
-
-*Write your first blog post here.*
-`;
-  }
+    ],
+  };
 }

--- a/templates/BookTemplate.ts
+++ b/templates/BookTemplate.ts
@@ -1,128 +1,49 @@
-import { App, normalizePath } from 'obsidian';
 import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
-import { BinderData, BinderItem } from '../models/BinderItem';
+import { TemplateManifest, templateDoc } from '../src/scaffold';
 
-export class BookTemplate {
-  static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = localDateString();
-    const chaptersPath = normalizePath(`${project.folderPath}/Chapters`);
-
-    const frontMatterFile = normalizePath(`${chaptersPath}/Front Matter.md`);
-    const chapter1File = normalizePath(`${chaptersPath}/Part 1 - Chapter 1.md`);
-    const backMatterFile = normalizePath(`${chaptersPath}/Back Matter.md`);
-
-    await BookTemplate.createFile(app, frontMatterFile, BookTemplate.frontMatterDoc(now));
-    await BookTemplate.createFile(app, chapter1File, BookTemplate.chapter1Doc(project.title, now));
-    await BookTemplate.createFile(app, backMatterFile, BookTemplate.backMatterDoc(now));
-
-    const items: BinderItem[] = [
+export function bookManifest(_project: WritingProject): TemplateManifest {
+  const date = localDateString();
+  return {
+    items: [
       {
         id: 'item-front-matter',
         title: 'Front Matter',
-        filePath: frontMatterFile,
         type: 'section',
-        order: 1,
-        status: 'draft',
-        includeInExport: true,
+        fileName: 'Front Matter',
+        content: templateDoc({
+          title: 'Front Matter', fmType: 'section', order: 1, date,
+          body: '*Title page, dedication, table of contents, and other front matter goes here.*',
+        }),
       },
       {
         id: 'item-part-1',
         title: 'Part 1',
-        filePath: '',
         type: 'part',
-        order: 2,
-        status: 'draft',
-        includeInExport: true,
         children: [
           {
             id: 'item-chapter-1',
             title: 'Chapter 1',
-            filePath: chapter1File,
             type: 'chapter',
-            order: 1,
-            status: 'draft',
+            fileName: 'Part 1 - Chapter 1',
             wordCountGoal: 3000,
-            includeInExport: true,
+            content: templateDoc({
+              title: 'Chapter 1', fmType: 'chapter', order: 1, goal: 3000, date,
+              body: '*Begin your story here.*',
+            }),
           },
         ],
       },
       {
         id: 'item-back-matter',
         title: 'Back Matter',
-        filePath: backMatterFile,
         type: 'section',
-        order: 3,
-        status: 'draft',
-        includeInExport: true,
+        fileName: 'Back Matter',
+        content: templateDoc({
+          title: 'Back Matter', fmType: 'section', order: 3, date,
+          body: '*Acknowledgments, bibliography, author bio, and other back matter goes here.*',
+        }),
       },
-    ];
-
-    return {
-      version: '2.0',
-      projectId: project.id,
-      items,
-    };
-  }
-
-  private static async createFile(app: App, path: string, content: string): Promise<void> {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content);
-    }
-  }
-
-  private static frontMatterDoc(date: string): string {
-    return `---
-title: "Front Matter"
-type: section
-order: 1
-status: draft
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# Front Matter
-
-*Title page, dedication, table of contents, and other front matter goes here.*
-`;
-  }
-
-  private static chapter1Doc(_projectTitle: string, date: string): string {
-    return `---
-title: "Chapter 1"
-type: chapter
-order: 1
-status: draft
-word-count-goal: 3000
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# Chapter 1
-
-*Begin your story here.*
-`;
-  }
-
-  private static backMatterDoc(date: string): string {
-    return `---
-title: "Back Matter"
-type: section
-order: 3
-status: draft
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# Back Matter
-
-*Acknowledgments, bibliography, author bio, and other back matter goes here.*
-`;
-  }
+    ],
+  };
 }

--- a/templates/JournalArticleTemplate.ts
+++ b/templates/JournalArticleTemplate.ts
@@ -1,105 +1,72 @@
-import { App, normalizePath } from 'obsidian';
 import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
-import { BinderData, BinderItem } from '../models/BinderItem';
+import { ManifestNode, TemplateManifest, templateDoc, placeholderHint } from '../src/scaffold';
 
-export class JournalArticleTemplate {
-  static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = localDateString();
-    const p = (name: string) => normalizePath(`${project.folderPath}/Chapters/${name}.md`);
+interface SectionSpec {
+  id: string;
+  title: string;
+  fileName?: string; // defaults to title
+  fmType: string;
+  goal?: number;
+  hint: string;
+}
 
-    const docs: Array<[string, string]> = [
-      [p('Title Page'),         JournalArticleTemplate.titlePageDoc(project.title, project.author, now)],
-      [p('Abstract'),           JournalArticleTemplate.standardDoc('Abstract',          'abstract',   2, 250,  now, 'Write a concise summary of the article in 150–250 words. Include research question, methodology, key findings, and conclusion.')],
-      [p('Keywords'),           JournalArticleTemplate.standardDoc('Keywords',           'keywords',   3, 0,    now, 'List 4–6 keywords separated by commas.')],
-      [p('Introduction'),       JournalArticleTemplate.standardDoc('Introduction',       'section',    4, 600,  now, 'Introduce the topic, state the research question or thesis, and outline the structure of the article.')],
-      [p('Literature Review'),  JournalArticleTemplate.standardDoc('Literature Review',  'section',    5, 1000, now, 'Survey the relevant scholarship. Identify gaps your article addresses.')],
-      [p('Methodology'),        JournalArticleTemplate.standardDoc('Methodology',        'section',    6, 600,  now, 'Describe your research method, sources, and analytical approach.')],
-      [p('Findings - Analysis'),JournalArticleTemplate.standardDoc('Findings / Analysis','section',    7, 1500, now, 'Present and analyze your findings. Use subheadings as needed.')],
-      [p('Discussion'),         JournalArticleTemplate.standardDoc('Discussion',         'section',    8, 800,  now, 'Interpret findings in light of the literature. Address implications and limitations.')],
-      [p('Conclusion'),         JournalArticleTemplate.standardDoc('Conclusion',         'section',    9, 400,  now, 'Summarize the argument, restate significance, and suggest future research directions.')],
-      [p('References'),         JournalArticleTemplate.standardDoc('References',         'references', 10, 0,   now, 'List all cited works here. Format according to target journal style (APA, MLA, Chicago, etc.).')],
-      [p('Appendices'),         JournalArticleTemplate.standardDoc('Appendices',         'appendix',   11, 0,   now, 'Include supplementary materials, data tables, or extended quotations here if needed.')],
-    ];
+const SECTIONS: SectionSpec[] = [
+  { id: 'ja-abstract', title: 'Abstract', fmType: 'abstract', goal: 250,
+    hint: 'Write a concise summary of the article in 150–250 words. Include research question, methodology, key findings, and conclusion.' },
+  { id: 'ja-keywords', title: 'Keywords', fmType: 'keywords',
+    hint: 'List 4–6 keywords separated by commas.' },
+  { id: 'ja-introduction', title: 'Introduction', fmType: 'section', goal: 600,
+    hint: 'Introduce the topic, state the research question or thesis, and outline the structure of the article.' },
+  { id: 'ja-literature-review', title: 'Literature Review', fmType: 'section', goal: 1000,
+    hint: 'Survey the relevant scholarship. Identify gaps your article addresses.' },
+  { id: 'ja-methodology', title: 'Methodology', fmType: 'section', goal: 600,
+    hint: 'Describe your research method, sources, and analytical approach.' },
+  { id: 'ja-findings', title: 'Findings / Analysis', fileName: 'Findings - Analysis', fmType: 'section', goal: 1500,
+    hint: 'Present and analyze your findings. Use subheadings as needed.' },
+  { id: 'ja-discussion', title: 'Discussion', fmType: 'section', goal: 800,
+    hint: 'Interpret findings in light of the literature. Address implications and limitations.' },
+  { id: 'ja-conclusion', title: 'Conclusion', fmType: 'section', goal: 400,
+    hint: 'Summarize the argument, restate significance, and suggest future research directions.' },
+  { id: 'ja-references', title: 'References', fmType: 'references',
+    hint: 'List all cited works here. Format according to target journal style (APA, MLA, Chicago, etc.).' },
+  { id: 'ja-appendices', title: 'Appendices', fmType: 'appendix',
+    hint: 'Include supplementary materials, data tables, or extended quotations here if needed.' },
+];
 
-    for (const [filePath, content] of docs) {
-      await JournalArticleTemplate.createFile(app, filePath, content);
-    }
+export function journalArticleManifest(project: WritingProject): TemplateManifest {
+  const date = localDateString();
 
-    const items: BinderItem[] = [
-      { id: 'ja-title-page',        title: 'Title Page',          filePath: p('Title Page'),          type: 'section', order: 1,  status: 'draft', wordCountGoal: 500,  includeInExport: true },
-      { id: 'ja-abstract',          title: 'Abstract',            filePath: p('Abstract'),            type: 'section', order: 2,  status: 'draft', wordCountGoal: 250,  includeInExport: true },
-      { id: 'ja-keywords',          title: 'Keywords',            filePath: p('Keywords'),            type: 'section', order: 3,  status: 'draft',                      includeInExport: true },
-      { id: 'ja-introduction',      title: 'Introduction',        filePath: p('Introduction'),        type: 'section', order: 4,  status: 'draft', wordCountGoal: 600,  includeInExport: true },
-      { id: 'ja-literature-review', title: 'Literature Review',   filePath: p('Literature Review'),   type: 'section', order: 5,  status: 'draft', wordCountGoal: 1000, includeInExport: true },
-      { id: 'ja-methodology',       title: 'Methodology',         filePath: p('Methodology'),         type: 'section', order: 6,  status: 'draft', wordCountGoal: 600,  includeInExport: true },
-      { id: 'ja-findings',          title: 'Findings / Analysis', filePath: p('Findings - Analysis'), type: 'section', order: 7,  status: 'draft', wordCountGoal: 1500, includeInExport: true },
-      { id: 'ja-discussion',        title: 'Discussion',          filePath: p('Discussion'),          type: 'section', order: 8,  status: 'draft', wordCountGoal: 800,  includeInExport: true },
-      { id: 'ja-conclusion',        title: 'Conclusion',          filePath: p('Conclusion'),          type: 'section', order: 9,  status: 'draft', wordCountGoal: 400,  includeInExport: true },
-      { id: 'ja-references',        title: 'References',          filePath: p('References'),          type: 'section', order: 10, status: 'draft',                      includeInExport: true },
-      { id: 'ja-appendices',        title: 'Appendices',          filePath: p('Appendices'),          type: 'section', order: 11, status: 'draft',                      includeInExport: true },
-    ];
+  const titlePage: ManifestNode = {
+    id: 'ja-title-page',
+    title: 'Title Page',
+    type: 'section',
+    fileName: 'Title Page',
+    wordCountGoal: 500,
+    content: templateDoc({
+      title: project.title, fmType: 'section', order: 1, goal: 500, date,
+      extraFields: {
+        author: project.author,
+        'institutional-affiliation': '',
+        'submission-date': date,
+        'journal-target': '',
+        'submission-deadline': '',
+      },
+      body: placeholderHint('Enter the article title, author name, institutional affiliation, submission date, and target journal name.'),
+    }),
+  };
 
-    return { version: '2.0', projectId: project.id, items };
-  }
+  const sections: ManifestNode[] = SECTIONS.map((s, i) => ({
+    id: s.id,
+    title: s.title,
+    type: 'section',
+    fileName: s.fileName ?? s.title,
+    wordCountGoal: s.goal,
+    content: templateDoc({
+      title: s.title, fmType: s.fmType, order: i + 2, goal: s.goal, date,
+      body: placeholderHint(s.hint),
+    }),
+  }));
 
-  private static async createFile(app: App, path: string, content: string): Promise<void> {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content);
-    }
-  }
-
-  private static hint(text: string): string {
-    return `> [!note] Placeholder\n> *${text}*`;
-  }
-
-  private static titlePageDoc(title: string, author: string, date: string): string {
-    return `---
-title: "${title}"
-author: "${author}"
-institutional-affiliation: ""
-submission-date: "${date}"
-journal-target: ""
-submission-deadline: ""
-type: section
-order: 1
-status: draft
-word-count-goal: 500
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# ${title}
-
-${JournalArticleTemplate.hint('Enter the article title, author name, institutional affiliation, submission date, and target journal name.')}
-`;
-  }
-
-  private static standardDoc(
-    title: string,
-    type: string,
-    order: number,
-    goal: number,
-    date: string,
-    hintText: string,
-  ): string {
-    const goalLine = goal > 0 ? `\nword-count-goal: ${goal}` : '';
-    return `---
-title: "${title}"
-type: ${type}
-order: ${order}
-status: draft${goalLine}
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# ${title}
-
-${JournalArticleTemplate.hint(hintText)}
-`;
-  }
+  return { items: [titlePage, ...sections] };
 }

--- a/templates/MagazineArticleTemplate.ts
+++ b/templates/MagazineArticleTemplate.ts
@@ -1,110 +1,59 @@
-import { App, normalizePath } from 'obsidian';
 import { localDateString } from '../src/dates';
 import { WritingProject } from '../models/Project';
-import { BinderData, BinderItem } from '../models/BinderItem';
+import { BinderItem } from '../models/BinderItem';
+import { ManifestNode, TemplateManifest, templateDoc, placeholderHint } from '../src/scaffold';
 
-export class MagazineArticleTemplate {
-  static async apply(app: App, project: WritingProject): Promise<BinderData> {
-    const now = localDateString();
-    const p = (name: string) => normalizePath(`${project.folderPath}/Chapters/${name}.md`);
+interface SectionSpec {
+  id: string;
+  title: string;
+  fileName: string;
+  type: BinderItem['type'];
+  fmType: string;
+  goal?: number;
+  exportExcluded?: boolean;
+  extraFields?: Record<string, string>;
+  hint: string;
+}
 
-    const docs: Array<[string, string]> = [
-      [p('Pitch - Query Notes'), MagazineArticleTemplate.notesDoc('Pitch / Query Notes', 'notes', 1, 300, now,
-        'Record your pitch angle, target publication, editor contact, and deadline here.',
-        { 'target-publication': '', 'editor-contact': '', 'deadline': '' })],
-      [p('Headline and Deck'),   MagazineArticleTemplate.standardDoc('Headline & Deck',   'headline', 2, 30,   now, 'Write your working headline and subheadline (deck) here. Headline: punchy, specific. Deck: expands the promise of the headline.')],
-      [p('Lede'),               MagazineArticleTemplate.standardDoc('Lede (Opening)',     'section',  3, 150,  now, 'Write your opening paragraph. Anecdote, scene, provocative statement, or surprising fact. Hook the reader immediately.')],
-      [p('Nut Graf'),           MagazineArticleTemplate.standardDoc('Nut Graf',           'section',  4, 100,  now, 'Tell the reader what this story is about and why it matters now. Usually 1–2 paragraphs following the lede.')],
-      [p('Body'),               MagazineArticleTemplate.standardDoc('Body',               'section',  5, 1500, now, 'Develop the story. Alternate between narrative, quotes, data, and analysis. Use subheadings to organize long sections.')],
-      [p('Quotes and Sources'), MagazineArticleTemplate.notesDoc('Quotes & Sources',      'notes',    6, 0,    now, 'Collect key quotes and source attributions here for reference while writing.')],
-      [p('Kicker'),             MagazineArticleTemplate.standardDoc('Kicker (Closing)',   'section',  7, 150,  now, 'Write your closing. Return to the opening anecdote, deliver the payoff, or leave the reader with a resonant final thought.')],
-      [p('Fact-Check Notes'),   MagazineArticleTemplate.notesDoc('Fact-Check Notes',      'notes',    8, 0,    now, 'List every factual claim that requires verification, with source links or contact info.')],
-      [p('Author Bio'),         MagazineArticleTemplate.standardDoc('Author Bio',         'bio',      9, 75,   now, 'Write a third-person author bio of 50–75 words for publication.')],
-    ];
+const SECTIONS: SectionSpec[] = [
+  { id: 'ma-pitch', title: 'Pitch / Query Notes', fileName: 'Pitch - Query Notes', type: 'note', fmType: 'notes', goal: 300, exportExcluded: true,
+    extraFields: { 'target-publication': '', 'editor-contact': '', 'deadline': '' },
+    hint: 'Record your pitch angle, target publication, editor contact, and deadline here.' },
+  { id: 'ma-headline', title: 'Headline & Deck', fileName: 'Headline and Deck', type: 'section', fmType: 'headline', goal: 30,
+    hint: 'Write your working headline and subheadline (deck) here. Headline: punchy, specific. Deck: expands the promise of the headline.' },
+  { id: 'ma-lede', title: 'Lede (Opening)', fileName: 'Lede', type: 'section', fmType: 'section', goal: 150,
+    hint: 'Write your opening paragraph. Anecdote, scene, provocative statement, or surprising fact. Hook the reader immediately.' },
+  { id: 'ma-nut-graf', title: 'Nut Graf', fileName: 'Nut Graf', type: 'section', fmType: 'section', goal: 100,
+    hint: 'Tell the reader what this story is about and why it matters now. Usually 1–2 paragraphs following the lede.' },
+  { id: 'ma-body', title: 'Body', fileName: 'Body', type: 'section', fmType: 'section', goal: 1500,
+    hint: 'Develop the story. Alternate between narrative, quotes, data, and analysis. Use subheadings to organize long sections.' },
+  { id: 'ma-quotes', title: 'Quotes & Sources', fileName: 'Quotes and Sources', type: 'note', fmType: 'notes', exportExcluded: true,
+    hint: 'Collect key quotes and source attributions here for reference while writing.' },
+  { id: 'ma-kicker', title: 'Kicker (Closing)', fileName: 'Kicker', type: 'section', fmType: 'section', goal: 150,
+    hint: 'Write your closing. Return to the opening anecdote, deliver the payoff, or leave the reader with a resonant final thought.' },
+  { id: 'ma-fact-check', title: 'Fact-Check Notes', fileName: 'Fact-Check Notes', type: 'note', fmType: 'notes', exportExcluded: true,
+    hint: 'List every factual claim that requires verification, with source links or contact info.' },
+  { id: 'ma-author-bio', title: 'Author Bio', fileName: 'Author Bio', type: 'section', fmType: 'bio', goal: 75,
+    hint: 'Write a third-person author bio of 50–75 words for publication.' },
+];
 
-    for (const [filePath, content] of docs) {
-      await MagazineArticleTemplate.createFile(app, filePath, content);
-    }
+export function magazineArticleManifest(_project: WritingProject): TemplateManifest {
+  const date = localDateString();
 
-    const items: BinderItem[] = [
-      { id: 'ma-pitch',       title: 'Pitch / Query Notes', filePath: p('Pitch - Query Notes'), type: 'note', order: 1, status: 'draft', wordCountGoal: 300,  includeInExport: false },
-      { id: 'ma-headline',    title: 'Headline & Deck',     filePath: p('Headline and Deck'),   type: 'section', order: 2, status: 'draft', wordCountGoal: 30, includeInExport: true },
-      { id: 'ma-lede',        title: 'Lede (Opening)',      filePath: p('Lede'),               type: 'section', order: 3, status: 'draft', wordCountGoal: 150,  includeInExport: true },
-      { id: 'ma-nut-graf',    title: 'Nut Graf',            filePath: p('Nut Graf'),           type: 'section', order: 4, status: 'draft', wordCountGoal: 100,  includeInExport: true },
-      { id: 'ma-body',        title: 'Body',                filePath: p('Body'),               type: 'section', order: 5, status: 'draft', wordCountGoal: 1500, includeInExport: true },
-      { id: 'ma-quotes',      title: 'Quotes & Sources',    filePath: p('Quotes and Sources'), type: 'note',    order: 6, status: 'draft',                      includeInExport: false },
-      { id: 'ma-kicker',      title: 'Kicker (Closing)',    filePath: p('Kicker'),             type: 'section', order: 7, status: 'draft', wordCountGoal: 150,  includeInExport: true },
-      { id: 'ma-fact-check',  title: 'Fact-Check Notes',   filePath: p('Fact-Check Notes'),   type: 'note',    order: 8, status: 'draft',                      includeInExport: false },
-      { id: 'ma-author-bio',  title: 'Author Bio',          filePath: p('Author Bio'),         type: 'section', order: 9, status: 'draft', wordCountGoal: 75,   includeInExport: true },
-    ];
+  const items: ManifestNode[] = SECTIONS.map((s, i) => ({
+    id: s.id,
+    title: s.title,
+    type: s.type,
+    fileName: s.fileName,
+    wordCountGoal: s.goal,
+    includeInExport: !s.exportExcluded,
+    content: templateDoc({
+      title: s.title, fmType: s.fmType, order: i + 1, goal: s.goal, date,
+      exportExcluded: s.exportExcluded,
+      extraFields: s.extraFields,
+      body: placeholderHint(s.hint),
+    }),
+  }));
 
-    return { version: '2.0', projectId: project.id, items };
-  }
-
-  private static async createFile(app: App, path: string, content: string): Promise<void> {
-    if (!app.vault.getAbstractFileByPath(path)) {
-      await app.vault.create(path, content);
-    }
-  }
-
-  private static hint(text: string): string {
-    return `> [!note] Placeholder\n> *${text}*`;
-  }
-
-  private static standardDoc(
-    title: string,
-    type: string,
-    order: number,
-    goal: number,
-    date: string,
-    hintText: string,
-  ): string {
-    const goalLine = goal > 0 ? `\nword-count-goal: ${goal}` : '';
-    return `---
-title: "${title}"
-type: ${type}
-order: ${order}
-status: draft${goalLine}
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]
----
-
-# ${title}
-
-${MagazineArticleTemplate.hint(hintText)}
-`;
-  }
-
-  private static notesDoc(
-    title: string,
-    type: string,
-    order: number,
-    goal: number,
-    date: string,
-    hintText: string,
-    extraFields: Record<string, string> = {},
-  ): string {
-    const goalLine = goal > 0 ? `\nword-count-goal: ${goal}` : '';
-    const extra = Object.entries(extraFields)
-      .map(([k, v]) => `\n${k}: "${v}"`)
-      .join('');
-    return `---
-title: "${title}"
-type: ${type}
-order: ${order}
-status: draft${goalLine}
-include-in-export: false
-word-count: 0
-created: ${date}
-modified: ${date}
-tags: [writing-studio]${extra}
----
-
-# ${title}
-
-${MagazineArticleTemplate.hint(hintText)}
-`;
-  }
+  return { items };
 }

--- a/templates/manifests.ts
+++ b/templates/manifests.ts
@@ -1,0 +1,17 @@
+import { ProjectType, WritingProject } from '../models/Project';
+import { TemplateManifest } from '../src/scaffold';
+import { bookManifest } from './BookTemplate';
+import { articleSeriesManifest } from './ArticleSeriesTemplate';
+import { blogCollectionManifest } from './BlogCollectionTemplate';
+import { journalArticleManifest } from './JournalArticleTemplate';
+import { magazineArticleManifest } from './MagazineArticleTemplate';
+
+// Every non-blank project type's scaffold, as data. Adding a project type
+// means adding a manifest builder here — no new file I/O code.
+export const TEMPLATE_MANIFESTS: Partial<Record<ProjectType, (project: WritingProject) => TemplateManifest>> = {
+  book: bookManifest,
+  series: articleSeriesManifest,
+  blog: blogCollectionManifest,
+  'journal-article': journalArticleManifest,
+  'magazine-article': magazineArticleManifest,
+};

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1,0 +1,126 @@
+import { TemplateScaffolder, templateDoc, ManifestNode } from '../src/scaffold';
+import { TEMPLATE_MANIFESTS } from '../templates/manifests';
+import { WritingProject } from '../models/Project';
+import { BinderItem } from '../models/BinderItem';
+import { InMemoryVaultFiles } from './inMemoryVaultFiles';
+
+function makeProject(): WritingProject {
+  return {
+    id: 'project-1',
+    title: 'My Book',
+    type: 'book',
+    author: 'Avery',
+    created: '2026-06-12',
+    modified: '2026-06-12',
+    description: '',
+    folderPath: 'Projects/My Book',
+    goals: {},
+  };
+}
+
+describe('TemplateScaffolder', () => {
+  it('scaffolds the book template: files, tree shape, sibling orders', async () => {
+    const files = new InMemoryVaultFiles();
+    const binder = await new TemplateScaffolder(files).apply(
+      makeProject(), TEMPLATE_MANIFESTS.book!(makeProject()));
+
+    expect(files.files.has('Projects/My Book/Chapters/Front Matter.md')).toBe(true);
+    expect(files.files.has('Projects/My Book/Chapters/Part 1 - Chapter 1.md')).toBe(true);
+    expect(files.files.has('Projects/My Book/Chapters/Back Matter.md')).toBe(true);
+
+    expect(binder.projectId).toBe('project-1');
+    expect(binder.items.map(i => i.order)).toEqual([1, 2, 3]);
+    const part = binder.items[1];
+    expect(part.type).toBe('part');
+    expect(part.filePath).toBe('');
+    expect(part.children).toHaveLength(1);
+    expect(part.children![0].wordCountGoal).toBe(3000);
+    expect(part.children![0].order).toBe(1);
+  });
+
+  it('never overwrites an existing file with the same name', async () => {
+    const files = new InMemoryVaultFiles();
+    files.files.set('Projects/My Book/Chapters/Front Matter.md', 'user content');
+
+    await new TemplateScaffolder(files).apply(
+      makeProject(), TEMPLATE_MANIFESTS.book!(makeProject()));
+
+    expect(files.files.get('Projects/My Book/Chapters/Front Matter.md')).toBe('user content');
+  });
+
+  it('creates manifest folders before files (blog year folder)', async () => {
+    const files = new InMemoryVaultFiles();
+    const year = new Date().getFullYear();
+
+    const binder = await new TemplateScaffolder(files).apply(
+      makeProject(), TEMPLATE_MANIFESTS.blog!(makeProject()));
+
+    expect(files.folders).toContain(`Projects/My Book/Chapters/${year}`);
+    const post = binder.items[0].children![0];
+    expect(post.filePath).toMatch(new RegExp(`^Projects/My Book/Chapters/${year}/.*-first-post\\.md$`));
+    expect(binder.items[0].includeInExport).toBe(false);
+  });
+});
+
+describe('template manifests', () => {
+  const allTypes = Object.keys(TEMPLATE_MANIFESTS) as Array<keyof typeof TEMPLATE_MANIFESTS>;
+
+  function walk(nodes: ManifestNode[], visit: (n: ManifestNode) => void): void {
+    for (const node of nodes) {
+      visit(node);
+      if (node.children) walk(node.children, visit);
+    }
+  }
+
+  it.each(allTypes)('%s: every file node has content and ids are unique', (type) => {
+    const manifest = TEMPLATE_MANIFESTS[type]!(makeProject());
+    const ids = new Set<string>();
+    walk(manifest.items, node => {
+      expect(ids.has(node.id)).toBe(false);
+      ids.add(node.id);
+      if (node.fileName) {
+        expect(node.content).toBeTruthy();
+        expect(node.content).toContain('# ');
+        expect(node.content).toMatch(/^---\n/);
+      } else {
+        expect(['group', 'part']).toContain(node.type);
+      }
+    });
+    expect(ids.size).toBeGreaterThan(0);
+  });
+
+  it('journal article keeps the divergent filename for Findings / Analysis', async () => {
+    const files = new InMemoryVaultFiles();
+    const binder = await new TemplateScaffolder(files).apply(
+      makeProject(), TEMPLATE_MANIFESTS['journal-article']!(makeProject()));
+
+    const flat: BinderItem[] = [];
+    const collect = (items: BinderItem[]) => { for (const i of items) { flat.push(i); if (i.children) collect(i.children); } };
+    collect(binder.items);
+    const findings = flat.find(i => i.id === 'ja-findings');
+    expect(findings?.title).toBe('Findings / Analysis');
+    expect(findings?.filePath).toBe('Projects/My Book/Chapters/Findings - Analysis.md');
+    expect(files.files.has('Projects/My Book/Chapters/Findings - Analysis.md')).toBe(true);
+  });
+
+  it('magazine article excludes notes documents from export in binder and frontmatter', async () => {
+    const files = new InMemoryVaultFiles();
+    const binder = await new TemplateScaffolder(files).apply(
+      makeProject(), TEMPLATE_MANIFESTS['magazine-article']!(makeProject()));
+
+    const pitch = binder.items.find(i => i.id === 'ma-pitch');
+    expect(pitch?.includeInExport).toBe(false);
+    expect(files.files.get('Projects/My Book/Chapters/Pitch - Query Notes.md')).toContain('include-in-export: false');
+  });
+});
+
+describe('templateDoc', () => {
+  it('emits goal and extra fields only when present', () => {
+    const withGoal = templateDoc({ title: 'A', fmType: 'section', order: 1, goal: 500, date: '2026-06-12', body: 'x' });
+    const without = templateDoc({ title: 'A', fmType: 'section', order: 1, date: '2026-06-12', body: 'x' });
+
+    expect(withGoal).toContain('word-count-goal: 500');
+    expect(without).not.toContain('word-count-goal');
+    expect(without).toContain('tags: [writing-studio]');
+  });
+});


### PR DESCRIPTION
Closes #141. Post-audit improvement 4 of 7 (sequence position 4; tracked as item 5 in the review) — accumulates under [Unreleased]; no release until all seven land.

## What changed
- **`src/scaffold.ts`** — `TemplateScaffolder.apply(project, manifest)` is the only code that scaffolds template files: ensures manifest folders, writes each file-backed node through the `VaultFiles` seam (never overwriting an existing file), assigns sibling-index orders, and returns the binder tree. `templateDoc()` centralizes the template document frontmatter format (goal/export-exclusion/tags/extra-field variants); `placeholderHint()` the callout format.
- **All five templates** (`book`, `series`, `blog`, `journal-article`, `magazine-article`) are now manifest-builder functions — pure data plus the shared builders. Their five copies of `createFile`/`createFolder` and the imperative walking code are deleted; no template imports `App` or touches the vault.
- **`templates/manifests.ts`** maps `ProjectType` → manifest builder; the switch in `ProjectManager.createProject` collapses to a lookup + scaffolder call. Adding a project type is now data entry.

## Fidelity notes
- Binder trees (ids, titles, types, goals, export flags, orders, the blog year group, the journal-article divergent filename `Findings - Analysis`) reproduce the previous output exactly.
- Document frontmatter is semantically identical; field order differs slightly in two documents (extra fields now always follow the title line) — frontmatter in scaffolded placeholders drives nothing downstream.

## Tests
143 passing (11 new): book tree shape/orders, never-overwrite guard, blog year-folder nesting, per-manifest invariants (unique ids, every file node has content), journal-article filename divergence, magazine-article export exclusion in both binder and frontmatter, templateDoc conditional fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)