### PR TITLE
Show binder root drop zone only during an active drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Writing Studio are documented here.
 
 ---
 
+## [Unreleased]
+
+UX improvement cycle from the 2026-06-12 product-experience review (issues #153–#171).
+
+### Fixed
+- The binder's "drop here to promote to root" zone now appears only while a drag is in progress, instead of sitting permanently under the document list. (#161)
+
+### Changed
+- Launcher mode buttons, binder document type icons, and the status bar mode pill now use Lucide icons instead of emoji, matching the icon language of the rest of the plugin. The status bar pill is hidden when no writing mode is active rather than reading "— mode". (#163)
+
+---
+
 ## [2.7.0]
 
 Post-audit improvement release: six structural and UX improvements from the 2026-06-12 fresh-eyes review (issues #138–#143, PRs #144–#148), the startup-gating fix (#150), and documentation corrections.

--- a/main.js
+++ b/main.js
@@ -11672,13 +11672,16 @@ var BinderView = class extends import_obsidian10.ItemView {
         this.showContextMenu(e, item);
       };
       row.ondragstart = (e) => {
-        var _a3;
+        var _a3, _b3;
         this.dragSource = item.id;
         row.addClass("ws-binder-dragging");
-        (_a3 = e.dataTransfer) == null ? void 0 : _a3.setData("text/plain", item.id);
+        (_a3 = this.listEl) == null ? void 0 : _a3.addClass("ws-binder-drag-active");
+        (_b3 = e.dataTransfer) == null ? void 0 : _b3.setData("text/plain", item.id);
       };
       row.ondragend = () => {
+        var _a3;
         row.classList.remove("ws-binder-dragging");
+        (_a3 = this.listEl) == null ? void 0 : _a3.removeClass("ws-binder-drag-active");
         this.dragSource = null;
         this.dropZone = null;
         const container2 = this.containerEl.children[1];

--- a/src/BinderView.ts
+++ b/src/BinderView.ts
@@ -383,10 +383,13 @@ export class BinderView extends ItemView {
       row.ondragstart = (e) => {
         this.dragSource = item.id;
         row.addClass('ws-binder-dragging');
+        // Reveals the root append zone — hidden except during a drag
+        this.listEl?.addClass('ws-binder-drag-active');
         e.dataTransfer?.setData('text/plain', item.id);
       };
       row.ondragend = () => {
         row.classList.remove('ws-binder-dragging');
+        this.listEl?.removeClass('ws-binder-drag-active');
         this.dragSource = null;
         this.dropZone = null;
         const container = this.containerEl.children[1] as HTMLElement;

--- a/styles.css
+++ b/styles.css
@@ -238,6 +238,8 @@ body.writing-studio-typography .markdown-reading-view .markdown-preview-section 
 }
 
 .ws-binder-root-append-zone {
+  /* Hidden until a binder drag is active — see ws-binder-drag-active */
+  display: none;
   margin: 6px 8px 4px;
   padding: 5px 12px;
   border: 1px dashed var(--background-modifier-border);
@@ -247,6 +249,10 @@ body.writing-studio-typography .markdown-reading-view .markdown-preview-section 
   text-align: center;
   cursor: default;
   transition: all 0.1s;
+}
+
+.ws-binder-drag-active .ws-binder-root-append-zone {
+  display: block;
 }
 
 .ws-binder-root-append-zone.ws-binder-root-append-active {


### PR DESCRIPTION
Closes #161. From the 2026-06-12 UX review, Batch B (visual finding V2, screenshot-confirmed).

- Zone hidden by default; `ws-binder-drag-active` on the list (added on row dragstart, removed on dragend) reveals it
- Drop-to-root behavior unchanged; styles via CSS classes only
- CHANGELOG `[Unreleased]` section seeded (includes the #163 entry missed in PR #172)
- lint 0/0, 156 tests pass, production build committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)