### PR TITLE
Word count goal modal edits the binder item when the file is bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Writing Studio are documented here.
 UX improvement cycle from the 2026-06-12 product-experience review (issues #153–#171).
 
 ### Fixed
+- "Set word count goal" now edits the binder item's goal when the document is in the active project's binder — previously it read and wrote only frontmatter, so for binder documents it showed the wrong current value and saving had no effect (the binder goal silently took precedence). Frontmatter is still used for files not in any binder. (#156)
 - The binder's "drop here to promote to root" zone now appears only while a drag is in progress, instead of sitting permanently under the document list. (#161)
 
 ### Changed

--- a/main.js
+++ b/main.js
@@ -16235,6 +16235,15 @@ tags: [writing-studio]
     }
     return void 0;
   }
+  // The goal modal needs the writable binder entry, not just the resolved
+  // number — null when the file is not in the active project's binder.
+  async findBinderEntryForFile(filePath) {
+    const project = this.getActiveProject();
+    if (!project) return null;
+    const binder = await this.loadBinder(project);
+    const item = this.findBinderItemByPath(binder.items, filePath);
+    return item ? { binder, item } : null;
+  }
   async getWordCountGoalForFile(file) {
     var _a2;
     const project = this.getActiveProject();
@@ -17739,26 +17748,41 @@ var WordCountGoalModal = class extends import_obsidian30.Modal {
   constructor(app, plugin, file) {
     super(app);
     this.goal = 0;
+    // Non-null when the file is in the active project's binder — the binder
+    // item is then the authoritative goal store (CONTEXT.md invariant 1) and
+    // frontmatter is neither read nor written.
+    this.binderEntry = null;
     this.plugin = plugin;
     this.file = file;
   }
   async onOpen() {
-    var _a2;
+    var _a2, _b2;
     const { contentEl } = this;
     contentEl.empty();
     contentEl.addClass("ws-goal-modal");
     contentEl.createEl("h2", { text: t2("wordCountGoal.title") });
-    const cache = this.app.metadataCache.getFileCache(this.file);
-    this.goal = Number((_a2 = cache == null ? void 0 : cache.frontmatter) == null ? void 0 : _a2["word-count-goal"]) || 0;
+    this.binderEntry = await this.plugin.projectManager.findBinderEntryForFile(this.file.path);
+    if (this.binderEntry) {
+      this.goal = (_a2 = this.binderEntry.item.wordCountGoal) != null ? _a2 : 0;
+    } else {
+      const cache = this.app.metadataCache.getFileCache(this.file);
+      this.goal = Number((_b2 = cache == null ? void 0 : cache.frontmatter) == null ? void 0 : _b2["word-count-goal"]) || 0;
+    }
     new import_obsidian30.Setting(contentEl).setName(t2("wordCountGoal.name")).setDesc(t2("wordCountGoal.desc")).addText((tx) => tx.setValue(String(this.goal || "")).setPlaceholder(t2("wordCountGoal.placeholder")).onChange((v) => {
       this.goal = parseInt(v) || 0;
     }));
     const btnRow = contentEl.createDiv("ws-modal-btn-row");
     const saveBtn = btnRow.createEl("button", { cls: "mod-cta", text: t2("wordCountGoal.save") });
     saveBtn.onclick = async () => {
-      await this.app.fileManager.processFrontMatter(this.file, (fm) => {
-        fm["word-count-goal"] = this.goal;
-      });
+      if (this.binderEntry) {
+        this.binderEntry.item.wordCountGoal = this.goal;
+        await this.plugin.projectManager.saveBinder(this.binderEntry.binder);
+      } else {
+        await this.app.fileManager.processFrontMatter(this.file, (fm) => {
+          fm["word-count-goal"] = this.goal;
+        });
+      }
+      void this.plugin.goalBanner.show();
       this.close();
     };
     const cancelBtn = btnRow.createEl("button", { text: t2("wordCountGoal.cancel") });

--- a/main.ts
+++ b/main.ts
@@ -42,6 +42,7 @@ import { WritingDashboardModal } from './modals/WritingDashboardModal';
 
 import { WordPressSite } from './models/WordPressSite';
 import { WritingModeType } from './models/WritingMode';
+import type { BinderData, BinderItem } from './models/BinderItem';
 
 // Minimal subset of the Notebook Navigator public API (v1.2–2.x) used by Writing Studio.
 // Full spec: https://github.com/johansan/notebook-navigator/blob/main/docs/api-reference.md
@@ -704,6 +705,10 @@ class WordCountGoalModal extends Modal {
   private plugin: WritingStudioPlugin;
   private file: TFile;
   private goal = 0;
+  // Non-null when the file is in the active project's binder — the binder
+  // item is then the authoritative goal store (CONTEXT.md invariant 1) and
+  // frontmatter is neither read nor written.
+  private binderEntry: { binder: BinderData; item: BinderItem } | null = null;
 
   constructor(app: App, plugin: WritingStudioPlugin, file: TFile) {
     super(app);
@@ -717,8 +722,13 @@ class WordCountGoalModal extends Modal {
     contentEl.addClass('ws-goal-modal');
     contentEl.createEl('h2', { text: t('wordCountGoal.title') });
 
-    const cache = this.app.metadataCache.getFileCache(this.file);
-    this.goal = Number(cache?.frontmatter?.['word-count-goal']) || 0;
+    this.binderEntry = await this.plugin.projectManager.findBinderEntryForFile(this.file.path);
+    if (this.binderEntry) {
+      this.goal = this.binderEntry.item.wordCountGoal ?? 0;
+    } else {
+      const cache = this.app.metadataCache.getFileCache(this.file);
+      this.goal = Number(cache?.frontmatter?.['word-count-goal']) || 0;
+    }
 
     new Setting(contentEl)
       .setName(t('wordCountGoal.name'))
@@ -732,9 +742,16 @@ class WordCountGoalModal extends Modal {
 
     const saveBtn = btnRow.createEl('button', { cls: 'mod-cta', text: t('wordCountGoal.save') });
     saveBtn.onclick = async () => {
-      await this.app.fileManager.processFrontMatter(this.file, (fm: Record<string, unknown>) => {
-        fm['word-count-goal'] = this.goal;
-      });
+      if (this.binderEntry) {
+        this.binderEntry.item.wordCountGoal = this.goal;
+        await this.plugin.projectManager.saveBinder(this.binderEntry.binder);
+      } else {
+        await this.app.fileManager.processFrontMatter(this.file, (fm: Record<string, unknown>) => {
+          fm['word-count-goal'] = this.goal;
+        });
+      }
+      // The banner re-resolves the goal — binder rows update via binder-changed
+      void this.plugin.goalBanner.show();
       this.close();
     };
 

--- a/src/ProjectManager.ts
+++ b/src/ProjectManager.ts
@@ -375,6 +375,16 @@ tags: [writing-studio]
     return undefined;
   }
 
+  // The goal modal needs the writable binder entry, not just the resolved
+  // number — null when the file is not in the active project's binder.
+  async findBinderEntryForFile(filePath: string): Promise<{ binder: BinderData; item: BinderItem } | null> {
+    const project = this.getActiveProject();
+    if (!project) return null;
+    const binder = await this.loadBinder(project);
+    const item = this.findBinderItemByPath(binder.items, filePath);
+    return item ? { binder, item } : null;
+  }
+
   async getWordCountGoalForFile(file: TFile): Promise<number | undefined> {
     const project = this.getActiveProject();
     if (project) {

--- a/tests/projectManager.test.ts
+++ b/tests/projectManager.test.ts
@@ -181,6 +181,52 @@ describe('ProjectManager change notification', () => {
   });
 });
 
+describe('ProjectManager.findBinderEntryForFile', () => {
+  it('returns the writable entry for a file in the active binder, including nested items', async () => {
+    const pm = new ProjectManager(makePlugin(), new InMemoryVaultFiles());
+    await pm.saveProject(makeProject());
+    await pm.setActiveProject('project-1');
+    await pm.saveBinder({
+      version: '2.0', projectId: 'project-1', items: [
+        { id: 'g1', title: 'Part 1', filePath: '', type: 'part', order: 1, status: 'draft', includeInExport: true, children: [
+          { id: 'c1', title: 'Ch 1', filePath: 'Projects/My Book/Chapters/Ch 1.md', type: 'chapter', order: 1, status: 'draft', includeInExport: true, wordCountGoal: 250 },
+        ] },
+      ],
+    });
+
+    const entry = await pm.findBinderEntryForFile('Projects/My Book/Chapters/Ch 1.md');
+
+    expect(entry).not.toBeNull();
+    expect(entry!.item.id).toBe('c1');
+    expect(entry!.item.wordCountGoal).toBe(250);
+  });
+
+  it('persists a goal written through the returned entry (the modal save path)', async () => {
+    const pm = new ProjectManager(makePlugin(), new InMemoryVaultFiles());
+    await pm.saveProject(makeProject());
+    await pm.setActiveProject('project-1');
+    const item = await pm.addDocumentToBinder(makeProject(), 'Chapter One', 'chapter');
+
+    const entry = await pm.findBinderEntryForFile(item.filePath);
+    entry!.item.wordCountGoal = 500;
+    await pm.saveBinder(entry!.binder);
+
+    const reloaded = await pm.findBinderEntryForFile(item.filePath);
+    expect(reloaded!.item.wordCountGoal).toBe(500);
+  });
+
+  it('returns null for files outside the binder and when no project is active', async () => {
+    const pm = new ProjectManager(makePlugin(), new InMemoryVaultFiles());
+    await pm.saveProject(makeProject());
+
+    // No active project yet
+    expect(await pm.findBinderEntryForFile('anything.md')).toBeNull();
+
+    await pm.setActiveProject('project-1');
+    expect(await pm.findBinderEntryForFile('not-in-binder.md')).toBeNull();
+  });
+});
+
 describe('ProjectManager.addDocumentToBinder filename de-duplication', () => {
   it('suffixes the filename when the target file already exists', async () => {
     const files = new InMemoryVaultFiles();


### PR DESCRIPTION
Closes #156. From the 2026-06-12 UX review, Batch A item 4 — a bug against CONTEXT.md invariant 1 (BinderItem.wordCountGoal is authoritative).

- New `ProjectManager.findBinderEntryForFile(filePath)` returns the writable `{ binder, item }` entry for the active project
- Modal reads the binder goal when bound, writes it back via `saveBinder` (binder-changed fires, rows update); frontmatter path unchanged for unbound files
- Goal banner re-resolves after save on both paths
- 3 new tests (nested lookup, persisted write-through, null paths) — 159 total
- lint 0/0, build committed, CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)