### PR TITLE
fix: launcher project card shows the project name once (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ UX improvement cycle from the 2026-06-12 product-experience review (issues #153�
 - The create-project modal now collects the author (prefilled from the author name setting) and an optional total word count goal. The goal was previously displayed in the launcher, status bar, and writing dashboard but could not be set anywhere in the UI. The unused `dailyWordCount` and `deadline` project goal fields were removed from the data model. (#153)
 
 ### Fixed
+- The launcher project card shows the project name once — with multiple projects, the switcher is now an icon-only menu next to the name instead of a dropdown that echoed the same title. Single-project vaults are unchanged. (#164)
 - "Set word count goal" now edits the binder item's goal when the document is in the active project's binder — previously it read and wrote only frontmatter, so for binder documents it showed the wrong current value and saving had no effect (the binder goal silently took precedence). Frontmatter is still used for files not in any binder. (#156)
 - The binder's "drop here to promote to root" zone now appears only while a drag is in progress, instead of sitting permanently under the document list. (#161)
 

--- a/main.js
+++ b/main.js
@@ -2577,7 +2577,8 @@ var en_default = {
       streakDays: "{{streak}}d"
     },
     sessionWordsTyped: "Session: +{{n}} words typed",
-    dailyGoal: "Daily goal: {{written}} / {{goal}} words"
+    dailyGoal: "Daily goal: {{written}} / {{goal}} words",
+    switchProject: "Switch project"
   },
   log: {
     displayText: "Writing log",
@@ -3249,7 +3250,8 @@ var zh_default = {
     },
     sessionWordsTyped: "\u672C\u6B21\uFF1A+{{n}} \u5B57",
     dailyGoal: "\u6BCF\u65E5\u76EE\u6807\uFF1A{{written}} / {{goal}} \u5B57",
-    sprintInProgress: "\u51B2\u523A\u8FDB\u884C\u4E2D"
+    sprintInProgress: "\u51B2\u523A\u8FDB\u884C\u4E2D",
+    switchProject: "\u5207\u6362\u9879\u76EE"
   },
   log: {
     displayText: "\u5199\u4F5C\u65E5\u5FD7",
@@ -3921,7 +3923,8 @@ var hi_default = {
     },
     sessionWordsTyped: "\u0938\u0924\u094D\u0930: +{{n}} \u0936\u092C\u094D\u0926 \u0932\u093F\u0916\u0947",
     dailyGoal: "\u0926\u0948\u0928\u093F\u0915 \u0932\u0915\u094D\u0937\u094D\u092F: {{written}} / {{goal}} \u0936\u092C\u094D\u0926",
-    sprintInProgress: "\u0938\u094D\u092A\u094D\u0930\u093F\u0902\u091F \u091C\u093E\u0930\u0940 \u0939\u0948"
+    sprintInProgress: "\u0938\u094D\u092A\u094D\u0930\u093F\u0902\u091F \u091C\u093E\u0930\u0940 \u0939\u0948",
+    switchProject: "\u092A\u094D\u0930\u094B\u091C\u0947\u0915\u094D\u091F \u092C\u0926\u0932\u0947\u0902"
   },
   log: {
     displayText: "\u0932\u0947\u0916\u0928 \u0932\u0949\u0917",
@@ -4593,7 +4596,8 @@ var es_default = {
     },
     sessionWordsTyped: "Sesi\xF3n: +{{n}} palabras escritas",
     dailyGoal: "Meta diaria: {{written}} / {{goal}} palabras",
-    sprintInProgress: "Sprint en curso"
+    sprintInProgress: "Sprint en curso",
+    switchProject: "Cambiar de proyecto"
   },
   log: {
     displayText: "Registro de escritura",
@@ -5265,7 +5269,8 @@ var ar_default = {
     },
     sessionWordsTyped: "\u0627\u0644\u062C\u0644\u0633\u0629: +{{n}} \u0643\u0644\u0645\u0629 \u0645\u0643\u062A\u0648\u0628\u0629",
     dailyGoal: "\u0627\u0644\u0647\u062F\u0641 \u0627\u0644\u064A\u0648\u0645\u064A: {{written}} / {{goal}} \u0643\u0644\u0645\u0629",
-    sprintInProgress: "\u0627\u0644\u0633\u0628\u0627\u0642 \u062C\u0627\u0631\u064D"
+    sprintInProgress: "\u0627\u0644\u0633\u0628\u0627\u0642 \u062C\u0627\u0631\u064D",
+    switchProject: "\u062A\u0628\u062F\u064A\u0644 \u0627\u0644\u0645\u0634\u0631\u0648\u0639"
   },
   log: {
     displayText: "\u0633\u062C\u0644 \u0627\u0644\u0643\u062A\u0627\u0628\u0629",
@@ -5948,7 +5953,8 @@ var fr_default = {
     },
     sessionWordsTyped: "Session : +{{n}} mots \xE9crits",
     dailyGoal: "Objectif quotidien : {{written}} / {{goal}} mots",
-    sprintInProgress: "Sprint en cours"
+    sprintInProgress: "Sprint en cours",
+    switchProject: "Changer de projet"
   },
   log: {
     displayText: "Journal d'\xE9criture",
@@ -6620,7 +6626,8 @@ var bn_default = {
     },
     sessionWordsTyped: "\u09B8\u09C7\u09B6\u09A8: +{{n}} \u09B6\u09AC\u09CD\u09A6 \u099F\u09BE\u0987\u09AA \u0995\u09B0\u09BE \u09B9\u09AF\u09BC\u09C7\u099B\u09C7",
     dailyGoal: "\u09A6\u09C8\u09A8\u09BF\u0995 \u09B2\u0995\u09CD\u09B7\u09CD\u09AF: {{written}} / {{goal}} \u09B6\u09AC\u09CD\u09A6",
-    sprintInProgress: "\u09B8\u09CD\u09AA\u09CD\u09B0\u09BF\u09A8\u09CD\u099F \u099A\u09B2\u099B\u09C7"
+    sprintInProgress: "\u09B8\u09CD\u09AA\u09CD\u09B0\u09BF\u09A8\u09CD\u099F \u099A\u09B2\u099B\u09C7",
+    switchProject: "\u09AA\u09CD\u09B0\u0995\u09B2\u09CD\u09AA \u09AA\u09B0\u09BF\u09AC\u09B0\u09CD\u09A4\u09A8 \u0995\u09B0\u09C1\u09A8"
   },
   log: {
     displayText: "\u09B2\u09C7\u0996\u09BE\u09B0 \u09B2\u0997",
@@ -7292,7 +7299,8 @@ var pt_BR_default = {
     },
     sessionWordsTyped: "Sess\xE3o: +{{n}} palavras digitadas",
     dailyGoal: "Meta di\xE1ria: {{written}} / {{goal}} palavras",
-    sprintInProgress: "Sprint em andamento"
+    sprintInProgress: "Sprint em andamento",
+    switchProject: "Trocar de projeto"
   },
   log: {
     displayText: "Di\xE1rio de escrita",
@@ -7964,7 +7972,8 @@ var ru_default = {
     },
     sessionWordsTyped: "\u0421\u0435\u0430\u043D\u0441: +{{n}} \u043D\u0430\u043F\u0438\u0441\u0430\u043D\u043D\u044B\u0445 \u0441\u043B\u043E\u0432",
     dailyGoal: "\u0414\u043D\u0435\u0432\u043D\u0430\u044F \u0446\u0435\u043B\u044C: {{written}} / {{goal}} \u0441\u043B\u043E\u0432",
-    sprintInProgress: "\u0421\u043F\u0440\u0438\u043D\u0442 \u0438\u0434\u0451\u0442"
+    sprintInProgress: "\u0421\u043F\u0440\u0438\u043D\u0442 \u0438\u0434\u0451\u0442",
+    switchProject: "\u0421\u043C\u0435\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0435\u043A\u0442"
   },
   log: {
     displayText: "\u0416\u0443\u0440\u043D\u0430\u043B \u043F\u0438\u0441\u044C\u043C\u0430",
@@ -8642,7 +8651,8 @@ var ja_default = {
     },
     sessionWordsTyped: "\u30BB\u30C3\u30B7\u30E7\u30F3\uFF1A+{{n}} \u8A9E",
     dailyGoal: "1\u65E5\u306E\u76EE\u6A19\uFF1A{{written}} / {{goal}} \u8A9E",
-    sprintInProgress: "\u30B9\u30D7\u30EA\u30F3\u30C8\u5B9F\u884C\u4E2D"
+    sprintInProgress: "\u30B9\u30D7\u30EA\u30F3\u30C8\u5B9F\u884C\u4E2D",
+    switchProject: "\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8\u3092\u5207\u308A\u66FF\u3048"
   },
   log: {
     displayText: "\u57F7\u7B46\u30ED\u30B0",
@@ -9314,7 +9324,8 @@ var de_default = {
     },
     sessionWordsTyped: "Sitzung: +{{n}} W\xF6rter getippt",
     dailyGoal: "Tagesziel: {{written}} / {{goal}} W\xF6rter",
-    sprintInProgress: "Sprint l\xE4uft"
+    sprintInProgress: "Sprint l\xE4uft",
+    switchProject: "Projekt wechseln"
   },
   log: {
     displayText: "Schreibprotokoll",
@@ -9986,7 +9997,8 @@ var ko_default = {
     },
     sessionWordsTyped: "\uC138\uC158: +{{n}} \uB2E8\uC5B4 \uC785\uB825",
     dailyGoal: "\uC77C\uC77C \uBAA9\uD45C: {{written}} / {{goal}} \uB2E8\uC5B4",
-    sprintInProgress: "\uC2A4\uD504\uB9B0\uD2B8 \uC9C4\uD589 \uC911"
+    sprintInProgress: "\uC2A4\uD504\uB9B0\uD2B8 \uC9C4\uD589 \uC911",
+    switchProject: "\uD504\uB85C\uC81D\uD2B8 \uC804\uD658"
   },
   log: {
     displayText: "\uAE00\uC4F0\uAE30 \uB85C\uADF8",
@@ -13454,14 +13466,19 @@ var LauncherView = class extends import_obsidian18.ItemView {
     nameRow.createEl("strong", { text: project.title, cls: "ws-launcher-project-name" });
     const projects = this.plugin.projectManager.getProjects();
     if (projects.length > 1) {
-      const sel = nameRow.createEl("select", { cls: "ws-launcher-project-mini-sel" });
-      for (const p of projects) {
-        const opt = sel.createEl("option", { text: p.title, value: p.id });
-        if (p.id === project.id) opt.selected = true;
-      }
-      sel.onchange = async () => {
-        await this.plugin.projectManager.setActiveProject(sel.value);
-        await this.refresh();
+      const switchBtn = nameRow.createEl("button", { cls: "ws-launcher-icon-btn" });
+      (0, import_obsidian18.setIcon)(switchBtn, "chevrons-up-down");
+      (0, import_obsidian18.setTooltip)(switchBtn, t2("launcher.switchProject"));
+      switchBtn.onclick = (e) => {
+        const menu = new import_obsidian18.Menu();
+        for (const p of projects) {
+          menu.addItem((i) => {
+            i.setTitle(p.title).setChecked(p.id === project.id).onClick(async () => {
+              await this.plugin.projectManager.setActiveProject(p.id);
+            });
+          });
+        }
+        menu.showAtMouseEvent(e);
       };
     }
     try {

--- a/src/LauncherView.ts
+++ b/src/LauncherView.ts
@@ -1,4 +1,4 @@
-import { App, ItemView, WorkspaceLeaf, setIcon } from 'obsidian';
+import { App, ItemView, Menu, WorkspaceLeaf, setIcon, setTooltip } from 'obsidian';
 import type WritingStudioPlugin from '../main';
 import { WritingModeType } from '../models/WritingMode';
 import { ProjectModal } from '../modals/ProjectModal';
@@ -172,20 +172,28 @@ export class LauncherView extends ItemView {
       return;
     }
 
-    // Project name + switcher
+    // Project name + switcher — the name renders once; with multiple
+    // projects an icon-only menu handles switching (a select here echoed
+    // the title a second time)
     const nameRow = card.createDiv('ws-launcher-project-name-row');
     nameRow.createEl('strong', { text: project.title, cls: 'ws-launcher-project-name' });
 
     const projects = this.plugin.projectManager.getProjects();
     if (projects.length > 1) {
-      const sel = nameRow.createEl('select', { cls: 'ws-launcher-project-mini-sel' });
-      for (const p of projects) {
-        const opt = sel.createEl('option', { text: p.title, value: p.id });
-        if (p.id === project.id) opt.selected = true;
-      }
-      sel.onchange = async () => {
-        await this.plugin.projectManager.setActiveProject(sel.value);
-        await this.refresh();
+      const switchBtn = nameRow.createEl('button', { cls: 'ws-launcher-icon-btn' });
+      setIcon(switchBtn, 'chevrons-up-down');
+      setTooltip(switchBtn, t('launcher.switchProject'));
+      switchBtn.onclick = (e) => {
+        const menu = new Menu();
+        for (const p of projects) {
+          menu.addItem(i => {
+            i.setTitle(p.title).setChecked(p.id === project.id).onClick(async () => {
+              // The active-project-changed event re-renders this panel
+              await this.plugin.projectManager.setActiveProject(p.id);
+            });
+          });
+        }
+        menu.showAtMouseEvent(e);
       };
     }
 

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "الجلسة: +{{n}} كلمة مكتوبة",
     "dailyGoal": "الهدف اليومي: {{written}} / {{goal}} كلمة",
-    "sprintInProgress": "السباق جارٍ"
+    "sprintInProgress": "السباق جارٍ",
+    "switchProject": "تبديل المشروع"
   },
   "log": {
     "displayText": "سجل الكتابة",

--- a/src/i18n/bn.json
+++ b/src/i18n/bn.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "সেশন: +{{n}} শব্দ টাইপ করা হয়েছে",
     "dailyGoal": "দৈনিক লক্ষ্য: {{written}} / {{goal}} শব্দ",
-    "sprintInProgress": "স্প্রিন্ট চলছে"
+    "sprintInProgress": "স্প্রিন্ট চলছে",
+    "switchProject": "প্রকল্প পরিবর্তন করুন"
   },
   "log": {
     "displayText": "লেখার লগ",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "Sitzung: +{{n}} Wörter getippt",
     "dailyGoal": "Tagesziel: {{written}} / {{goal}} Wörter",
-    "sprintInProgress": "Sprint läuft"
+    "sprintInProgress": "Sprint läuft",
+    "switchProject": "Projekt wechseln"
   },
   "log": {
     "displayText": "Schreibprotokoll",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -267,7 +267,8 @@
       "streakDays": "{{streak}}d"
     },
     "sessionWordsTyped": "Session: +{{n}} words typed",
-    "dailyGoal": "Daily goal: {{written}} / {{goal}} words"
+    "dailyGoal": "Daily goal: {{written}} / {{goal}} words",
+    "switchProject": "Switch project"
   },
   "log": {
     "displayText": "Writing log",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "Sesión: +{{n}} palabras escritas",
     "dailyGoal": "Meta diaria: {{written}} / {{goal}} palabras",
-    "sprintInProgress": "Sprint en curso"
+    "sprintInProgress": "Sprint en curso",
+    "switchProject": "Cambiar de proyecto"
   },
   "log": {
     "displayText": "Registro de escritura",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "Session : +{{n}} mots écrits",
     "dailyGoal": "Objectif quotidien : {{written}} / {{goal}} mots",
-    "sprintInProgress": "Sprint en cours"
+    "sprintInProgress": "Sprint en cours",
+    "switchProject": "Changer de projet"
   },
   "log": {
     "displayText": "Journal d'écriture",

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "सत्र: +{{n}} शब्द लिखे",
     "dailyGoal": "दैनिक लक्ष्य: {{written}} / {{goal}} शब्द",
-    "sprintInProgress": "स्प्रिंट जारी है"
+    "sprintInProgress": "स्प्रिंट जारी है",
+    "switchProject": "प्रोजेक्ट बदलें"
   },
   "log": {
     "displayText": "लेखन लॉग",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "セッション：+{{n}} 語",
     "dailyGoal": "1日の目標：{{written}} / {{goal}} 語",
-    "sprintInProgress": "スプリント実行中"
+    "sprintInProgress": "スプリント実行中",
+    "switchProject": "プロジェクトを切り替え"
   },
   "log": {
     "displayText": "執筆ログ",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "세션: +{{n}} 단어 입력",
     "dailyGoal": "일일 목표: {{written}} / {{goal}} 단어",
-    "sprintInProgress": "스프린트 진행 중"
+    "sprintInProgress": "스프린트 진행 중",
+    "switchProject": "프로젝트 전환"
   },
   "log": {
     "displayText": "글쓰기 로그",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "Sessão: +{{n}} palavras digitadas",
     "dailyGoal": "Meta diária: {{written}} / {{goal}} palavras",
-    "sprintInProgress": "Sprint em andamento"
+    "sprintInProgress": "Sprint em andamento",
+    "switchProject": "Trocar de projeto"
   },
   "log": {
     "displayText": "Diário de escrita",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "Сеанс: +{{n}} написанных слов",
     "dailyGoal": "Дневная цель: {{written}} / {{goal}} слов",
-    "sprintInProgress": "Спринт идёт"
+    "sprintInProgress": "Спринт идёт",
+    "switchProject": "Сменить проект"
   },
   "log": {
     "displayText": "Журнал письма",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -267,7 +267,8 @@
     },
     "sessionWordsTyped": "本次：+{{n}} 字",
     "dailyGoal": "每日目标：{{written}} / {{goal}} 字",
-    "sprintInProgress": "冲刺进行中"
+    "sprintInProgress": "冲刺进行中",
+    "switchProject": "切换项目"
   },
   "log": {
     "displayText": "写作日志",

--- a/styles.css
+++ b/styles.css
@@ -989,8 +989,7 @@ body.writing-studio-typography .markdown-reading-view .markdown-preview-section 
   margin-bottom: 8px;
 }
 
-.ws-launcher-project-sel,
-.ws-launcher-project-mini-sel {
+.ws-launcher-project-sel {
   font-size: 12px;
   padding: 3px 6px;
   background: var(--background-secondary);
@@ -1011,12 +1010,6 @@ body.writing-studio-typography .markdown-reading-view .markdown-preview-section 
 .ws-launcher-project-name {
   font-size: 14px;
   color: var(--text-normal);
-}
-
-.ws-launcher-project-mini-sel {
-  font-size: 11px;
-  padding: 2px 4px;
-  opacity: 0.7;
 }
 
 .ws-launcher-wc-row {


### PR DESCRIPTION
## Summary

Implements #164 — Batch C visual finding V3 from the 2026-06-12 UX review.

With multiple projects, the launcher project card rendered the bold project name and, directly beside it, a switcher dropdown displaying the same title. The switcher is now an icon-only menu (chevrons-up-down) next to the name: it lists all projects with the active one checked, and selecting one switches via `setActiveProject` — the active-project-changed event re-renders the panel. Single-project vaults are unchanged (no switcher, as before). The dead mini-select CSS was removed; one new tooltip string in all 12 locales.

## Acceptance criteria

- [x] Active project name appears exactly once in the project card, with switching still one click away
- [x] Single-project vaults look unchanged (no dropdown today — keep it that way)
- [x] lint, tests, build pass

## Tests

179 passing — UI-only change, no new unit tests.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)