### PR TITLE
docs: SECURITY.md supported versions → 2.8.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Security fixes are applied to the **latest release only**. Older versions are no
 
 | Version | Supported |
 |---------|-----------|
-| 2.7.x (latest) | ✅ Yes |
-| < 2.7 | ❌ No |
+| 2.8.x (latest) | ✅ Yes |
+| < 2.8 | ❌ No |
 
 Always update to the latest release before reporting a security issue.
 


### PR DESCRIPTION
Post-release: bump the supported-versions table to 2.8.x (minor bump per CLAUDE.md post-release checklist item 5).