### PR TITLE
Strengthen /release-check: CONTEXT.md check + repo-wide stale-version scan

### DIFF
--- a/.claude/commands/release-check.md
+++ b/.claude/commands/release-check.md
@@ -2,7 +2,7 @@ Run the release preflight checklist for version $ARGUMENTS.
 
 If no version argument is provided, ask Don for the target version before proceeding.
 
-Check each item below and report PASS or FAIL. Do not tag until all nine pass.
+Check each item below and report PASS or FAIL. Do not tag until all twelve pass.
 
 1. **CHANGELOG heading** — Read CHANGELOG.md and confirm it contains a `## [$ARGUMENTS]` heading (exact match including brackets, e.g. `## [2.4.5]`).
 2. **Tag prefix** — Confirm `$ARGUMENTS` begins with a digit, not the letter v (correct: `2.4.5`, wrong: `v2.4.5`).
@@ -14,6 +14,18 @@ Check each item below and report PASS or FAIL. Do not tag until all nine pass.
 8. **README.md version badge** — Read README.md and confirm it contains `**Version $ARGUMENTS**`.
 9. **Branch name** — Run `git branch --show-current` and confirm the current branch is `release/$ARGUMENTS`.
 10. **No eslint-disable for no-deprecated** — Run `grep -rn "eslint-disable.*no-deprecated" src/ modals/ main.ts` — must return no matches.
+11. **CONTEXT.md current version** — Read CONTEXT.md and confirm the "current version" line equals `$ARGUMENTS` exactly (e.g. ``current version: `2.4.5` ``).
+12. **No stale previous-version markers** — Determine PREV, the previous version, as the **second** key in versions.json (the entry directly below the new top entry, e.g. if the top is `2.9.0` then PREV is `2.8.0`). Then scan the repo for PREV:
+
+    ```
+    rg -n --fixed-strings "<PREV>" -g '!node_modules' -g '!.git' -g '!CHANGELOG.md' -g '!versions.json' -g '!package-lock.json' -g '!main.js' -g '!styles.css' -g '!*.sarif'
+    ```
+
+    Expected: **no matches**. Any match is a stale current-version marker (a file that still advertises the previous version) and **FAILS the release** — bump it to `$ARGUMENTS`. This catches version markers in files not explicitly named by the other checks (docs, source comments, ADRs, etc.).
+
+    Allowlist rationale — the excluded paths legitimately contain a non-marker occurrence of PREV: `CHANGELOG.md` and `versions.json` retain historical version numbers by design; `package-lock.json`, `main.js`, and `styles.css` are generated/lock artifacts that may pin third-party version strings coincidentally equal to PREV (the plugin's own version in these is already covered by check #6 and the production rebuild). If a future authored file gains a legitimate, non-marker reference to PREV, add it to this allowlist with a comment explaining why — do not silence the check by other means.
+
+    Note: this scan keys on the exact previous version string (e.g. `2.8.0`). The `x`-form supported-versions table in SECURITY.md (e.g. `2.8.x`) is covered by the SECURITY.md note below, not by this scan.
 
 **SECURITY.md note:** If this is a minor or major version bump (e.g. 2.4.x → 2.5.0 or 3.0.0), remind Don to update the supported versions table in SECURITY.md before tagging.
 
@@ -31,6 +43,8 @@ Report results as a table:
 | README.md version badge | PASS/FAIL | actual line if mismatched |
 | Branch name | PASS/FAIL | actual branch name if wrong |
 | No eslint-disable no-deprecated | PASS/FAIL | list any matching lines if found |
+| CONTEXT.md current version | PASS/FAIL | actual value if mismatched |
+| No stale previous-version markers | PASS/FAIL | list file:line of any match (PREV) |
 
-If all ten pass: state "Release preflight passed — safe to tag $ARGUMENTS."
+If all twelve pass: state "Release preflight passed — safe to tag $ARGUMENTS."
 If any fail: state "Release preflight FAILED — do not tag until all items pass." List exactly what needs fixing.

--- a/.claude/commands/release-check.md
+++ b/.claude/commands/release-check.md
@@ -18,10 +18,12 @@ Check each item below and report PASS or FAIL. Do not tag until all twelve pass.
 12. **No stale previous-version markers** — Determine PREV, the previous version, as the **second** key in versions.json (the entry directly below the new top entry, e.g. if the top is `2.9.0` then PREV is `2.8.0`). Then scan the repo for PREV:
 
     ```
-    rg -n --fixed-strings "<PREV>" -g '!node_modules' -g '!.git' -g '!CHANGELOG.md' -g '!versions.json' -g '!package-lock.json' -g '!main.js' -g '!styles.css' -g '!*.sarif'
+    git grep -n -F "<PREV>" -- ':!CHANGELOG.md' ':!versions.json' ':!package-lock.json' ':!main.js' ':!styles.css' ':!*.sarif'
     ```
 
-    Expected: **no matches**. Any match is a stale current-version marker (a file that still advertises the previous version) and **FAILS the release** — bump it to `$ARGUMENTS`. This catches version markers in files not explicitly named by the other checks (docs, source comments, ADRs, etc.).
+    (`git grep` searches only tracked files, so `node_modules`/`.git` need no exclusion. If `rg` is on PATH it works too, but add `-g '!node_modules' -g '!.git'`.)
+
+    Expected: **no matches** (`git grep` exits non-zero when nothing is found — that is the PASS case). Any match is a stale current-version marker (a file that still advertises the previous version) and **FAILS the release** — bump it to `$ARGUMENTS`. This catches version markers in files not explicitly named by the other checks (docs, source comments, ADRs, etc.).
 
     Allowlist rationale — the excluded paths legitimately contain a non-marker occurrence of PREV: `CHANGELOG.md` and `versions.json` retain historical version numbers by design; `package-lock.json`, `main.js`, and `styles.css` are generated/lock artifacts that may pin third-party version strings coincidentally equal to PREV (the plugin's own version in these is already covered by check #6 and the production rebuild). If a future authored file gains a legitimate, non-marker reference to PREV, add it to this allowlist with a comment explaining why — do not silence the check by other means.
 


### PR DESCRIPTION
## Strengthen `/release-check` so version markers can't be missed

Two new preflight checks, motivated by `CONTEXT.md` shipping a stale "current version: 2.8.0" during 2.9.0 prep — it isn't one of the named version files, so nothing caught it.

### Added
- **Check 11 — CONTEXT.md current version** verified against the tag, same as manifest/README.
- **Check 12 — repo-wide stale-version scan.** Derives PREV (the previous version) from the second key in `versions.json`, then `git grep`s the repo for it. Any match outside the allowlist **fails the release**, so a stale current-version marker can't survive even in files the checklist doesn't name (docs, source comments, ADRs, …).

### Allowlist
`CHANGELOG.md` and `versions.json` (historical references, as specified) plus generated/lock artifacts `package-lock.json`, `main.js`, `styles.css`, `*.sarif` — these can contain third-party/self versions equal to PREV that are already covered by the package.json check and the rebuild. Adding a path requires a comment explaining why.

### Validated against `release/2.9.0`
- With exclusions: **no matches** (PASS).
- Without exclusions: exactly the 3 allowlisted hits (CHANGELOG `## [2.8.0]`, `versions.json` history, `package-lock` `module-replacements ^2.8.0`) — confirming the allowlist is exactly the set of legitimate references and nothing else harbors `2.8.0`.

Uses `git grep` (tracked files only; always on PATH) rather than `rg`. The total check count is now twelve; the prior "nine/ten" wording is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
