### PR TITLE
fix: store per-type document folder on new projects (#204 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Writing Studio are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- New writing projects now store their documents in a folder named for the project type instead of a folder always called `Chapters/`: book → Chapters, series → Articles, blog → Posts (with the year subfolder unchanged, e.g. `Posts/2026/`), journal article → Sections, magazine article → Sections, blank → Documents. The folder name is stored per project (`documentFolder` in `_project.json`), and everything that creates documents — template scaffolding and adding documents to the binder — respects it. **Existing projects are untouched:** a project without the stored field keeps using `Chapters/` exactly as before, and no files are moved. An optional migration for existing projects remains tracked in #204. (#204, Phase 1)
+
 ## [2.9.0] - 2026-06-16
 
 ### Changed

--- a/main.js
+++ b/main.js
@@ -52,6 +52,21 @@ function resolveDefaultDocumentType(projectType, globalDefault) {
   var _a2;
   return (_a2 = PROJECT_TYPE_DEFAULT_DOC_TYPE[projectType]) != null ? _a2 : globalDefault;
 }
+var PROJECT_TYPE_DOCUMENT_FOLDER = {
+  book: "Chapters",
+  series: "Articles",
+  blog: "Posts",
+  "journal-article": "Sections",
+  "magazine-article": "Sections",
+  blank: "Documents"
+};
+function defaultDocumentFolder(projectType) {
+  return PROJECT_TYPE_DOCUMENT_FOLDER[projectType];
+}
+function resolveDocumentFolder(project) {
+  var _a2;
+  return (_a2 = project.documentFolder) != null ? _a2 : "Chapters";
+}
 
 // modals/ProjectModal.ts
 var import_obsidian2 = require("obsidian");
@@ -1466,10 +1481,14 @@ var Formatter = class {
   format(value, format, lng, options = {}) {
     if (!format) return value;
     if (value == null) return value;
-    const formats = format.split(this.formatSeparator);
-    if (formats.length > 1 && formats[0].indexOf("(") > 1 && !formats[0].includes(")") && formats.find((f) => f.includes(")"))) {
-      const lastIndex = formats.findIndex((f) => f.includes(")"));
-      formats[0] = [formats[0], ...formats.splice(1, lastIndex)].join(this.formatSeparator);
+    const rawFormats = format.split(this.formatSeparator);
+    const formats = [];
+    for (let i2 = 0; i2 < rawFormats.length; i2++) {
+      let f = rawFormats[i2];
+      while (f.indexOf("(") > -1 && !f.includes(")") && i2 + 1 < rawFormats.length) {
+        f = `${f}${this.formatSeparator}${rawFormats[++i2]}`;
+      }
+      formats.push(f);
     }
     const result = formats.reduce((mem, f) => {
       var _a2;
@@ -16685,21 +16704,21 @@ var TemplateScaffolder = class {
   }
   async apply(project, manifest) {
     var _a2;
-    const chapters = (0, import_obsidian24.normalizePath)(`${project.folderPath}/Chapters`);
+    const container = (0, import_obsidian24.normalizePath)(`${project.folderPath}/${resolveDocumentFolder(project)}`);
     for (const folder of (_a2 = manifest.folders) != null ? _a2 : []) {
-      await this.files.ensureFolder((0, import_obsidian24.normalizePath)(`${chapters}/${folder}`));
+      await this.files.ensureFolder((0, import_obsidian24.normalizePath)(`${container}/${folder}`));
     }
-    const items = await this.buildItems(manifest.items, chapters);
+    const items = await this.buildItems(manifest.items, container);
     return { version: "2.0", projectId: project.id, items };
   }
-  async buildItems(nodes, chapters) {
+  async buildItems(nodes, container) {
     var _a2, _b2;
     const items = [];
     let order = 1;
     for (const node of nodes) {
       let filePath = "";
       if (node.fileName) {
-        filePath = (0, import_obsidian24.normalizePath)(`${chapters}/${node.fileName}.md`);
+        filePath = (0, import_obsidian24.normalizePath)(`${container}/${node.fileName}.md`);
         if (!this.files.exists(filePath)) {
           await this.files.writeText(filePath, (_a2 = node.content) != null ? _a2 : "");
         }
@@ -16714,7 +16733,7 @@ var TemplateScaffolder = class {
         includeInExport: (_b2 = node.includeInExport) != null ? _b2 : true
       };
       if (node.wordCountGoal) item.wordCountGoal = node.wordCountGoal;
-      if (node.children) item.children = await this.buildItems(node.children, chapters);
+      if (node.children) item.children = await this.buildItems(node.children, container);
       items.push(item);
     }
     return items;
@@ -17162,8 +17181,9 @@ var ProjectManager = class extends import_obsidian25.Events {
     if (this.files.exists(folderPath)) {
       throw new Error(t2("projectManager.errorFolderExists", { folder: folderName }));
     }
+    const documentFolder = defaultDocumentFolder(type);
     await this.files.ensureFolder(folderPath);
-    await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/Chapters`));
+    await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/${documentFolder}`));
     await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/Research`));
     await this.files.ensureFolder((0, import_obsidian25.normalizePath)(`${folderPath}/Exports`));
     const now = localDateString();
@@ -17176,6 +17196,7 @@ var ProjectManager = class extends import_obsidian25.Events {
       modified: now,
       description,
       folderPath,
+      documentFolder,
       goals: {}
     };
     const manifestBuilder = TEMPLATE_MANIFESTS[type];
@@ -17239,9 +17260,10 @@ var ProjectManager = class extends import_obsidian25.Events {
     const binder = await this.loadBinder(project);
     const now = localDateString();
     const baseName = title.replace(/[\\/:*?"<>|]/g, "-");
-    let filePath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/Chapters/${baseName}.md`);
+    const docFolder = resolveDocumentFolder(project);
+    let filePath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/${docFolder}/${baseName}.md`);
     for (let n = 2; this.files.exists(filePath); n++) {
-      filePath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/Chapters/${baseName} ${n}.md`);
+      filePath = (0, import_obsidian25.normalizePath)(`${project.folderPath}/${docFolder}/${baseName} ${n}.md`);
     }
     const item = {
       id: this.uniqueId("item"),

--- a/models/Project.ts
+++ b/models/Project.ts
@@ -25,6 +25,29 @@ export function resolveDefaultDocumentType(
   return PROJECT_TYPE_DEFAULT_DOC_TYPE[projectType] ?? globalDefault;
 }
 
+// Each project type declares the folder that holds its documents. Applied to
+// new projects only — existing projects predate the documentFolder field and
+// must keep resolving to 'Chapters' (see resolveDocumentFolder), because
+// their files physically live there.
+const PROJECT_TYPE_DOCUMENT_FOLDER: Record<ProjectType, string> = {
+  book: 'Chapters',
+  series: 'Articles',
+  blog: 'Posts',
+  'journal-article': 'Sections',
+  'magazine-article': 'Sections',
+  blank: 'Documents',
+};
+
+export function defaultDocumentFolder(projectType: ProjectType): string {
+  return PROJECT_TYPE_DOCUMENT_FOLDER[projectType];
+}
+
+// Absent field → 'Chapters'. Never fall back to the project type's default
+// here — that would repoint existing binders at folders that don't exist.
+export function resolveDocumentFolder(project: Pick<WritingProject, 'documentFolder'>): string {
+  return project.documentFolder ?? 'Chapters';
+}
+
 export interface ProjectGoals {
   totalWordCount?: number;
 }
@@ -38,6 +61,10 @@ export interface WritingProject {
   modified: string;
   description: string;
   folderPath: string;
+  // Name of the folder holding the project's documents. Absent on projects
+  // created before the field existed — resolveDocumentFolder falls back to
+  // 'Chapters' for those.
+  documentFolder?: string;
   goals: ProjectGoals;
   wordPressSite?: string;
   wordPressCategory?: string;

--- a/src/ProjectManager.ts
+++ b/src/ProjectManager.ts
@@ -3,7 +3,7 @@ import type WritingStudioPlugin from '../main';
 import type { VaultFiles } from './VaultFiles';
 import { t } from './i18n';
 import { localDateString } from './dates';
-import { WritingProject, ProjectType } from '../models/Project';
+import { WritingProject, ProjectType, defaultDocumentFolder, resolveDocumentFolder } from '../models/Project';
 import { BinderData, BinderItem } from '../models/BinderItem';
 import { SprintSession } from '../models/SprintSession';
 import { TemplateScaffolder } from './scaffold';
@@ -96,8 +96,9 @@ export class ProjectManager extends Events {
     }
 
     // Create folder structure
+    const documentFolder = defaultDocumentFolder(type);
     await this.files.ensureFolder(folderPath);
-    await this.files.ensureFolder(normalizePath(`${folderPath}/Chapters`));
+    await this.files.ensureFolder(normalizePath(`${folderPath}/${documentFolder}`));
     await this.files.ensureFolder(normalizePath(`${folderPath}/Research`));
     await this.files.ensureFolder(normalizePath(`${folderPath}/Exports`));
 
@@ -111,6 +112,7 @@ export class ProjectManager extends Events {
       modified: now,
       description,
       folderPath,
+      documentFolder,
       goals: {},
     };
 
@@ -198,9 +200,10 @@ export class ProjectManager extends Events {
     const binder = await this.loadBinder(project);
     const now = localDateString();
     const baseName = title.replace(/[\\/:*?"<>|]/g, '-');
-    let filePath = normalizePath(`${project.folderPath}/Chapters/${baseName}.md`);
+    const docFolder = resolveDocumentFolder(project);
+    let filePath = normalizePath(`${project.folderPath}/${docFolder}/${baseName}.md`);
     for (let n = 2; this.files.exists(filePath); n++) {
-      filePath = normalizePath(`${project.folderPath}/Chapters/${baseName} ${n}.md`);
+      filePath = normalizePath(`${project.folderPath}/${docFolder}/${baseName} ${n}.md`);
     }
 
     const item: BinderItem = {

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -1,6 +1,6 @@
 import { normalizePath } from 'obsidian';
 import type { VaultFiles } from './VaultFiles';
-import { WritingProject } from '../models/Project';
+import { WritingProject, resolveDocumentFolder } from '../models/Project';
 import { BinderData, BinderItem } from '../models/BinderItem';
 
 // A project template as data: the folders and documents to scaffold and the
@@ -10,7 +10,7 @@ export interface ManifestNode {
   id: string;
   title: string;
   type: BinderItem['type'];
-  // Path relative to the project's Chapters folder, without the .md
+  // Path relative to the project's document folder, without the .md
   // extension. Structural nodes (group/part) omit it and carry no file.
   fileName?: string;
   // Full file content; required when fileName is present.
@@ -21,7 +21,7 @@ export interface ManifestNode {
 }
 
 export interface TemplateManifest {
-  // Extra folders relative to the Chapters folder (e.g. a year folder).
+  // Extra folders relative to the document folder (e.g. a year folder).
   folders?: string[];
   items: ManifestNode[];
 }
@@ -81,21 +81,21 @@ export class TemplateScaffolder {
   }
 
   async apply(project: WritingProject, manifest: TemplateManifest): Promise<BinderData> {
-    const chapters = normalizePath(`${project.folderPath}/Chapters`);
+    const container = normalizePath(`${project.folderPath}/${resolveDocumentFolder(project)}`);
     for (const folder of manifest.folders ?? []) {
-      await this.files.ensureFolder(normalizePath(`${chapters}/${folder}`));
+      await this.files.ensureFolder(normalizePath(`${container}/${folder}`));
     }
-    const items = await this.buildItems(manifest.items, chapters);
+    const items = await this.buildItems(manifest.items, container);
     return { version: '2.0', projectId: project.id, items };
   }
 
-  private async buildItems(nodes: ManifestNode[], chapters: string): Promise<BinderItem[]> {
+  private async buildItems(nodes: ManifestNode[], container: string): Promise<BinderItem[]> {
     const items: BinderItem[] = [];
     let order = 1;
     for (const node of nodes) {
       let filePath = '';
       if (node.fileName) {
-        filePath = normalizePath(`${chapters}/${node.fileName}.md`);
+        filePath = normalizePath(`${container}/${node.fileName}.md`);
         // Never overwrite — a user file with the same name wins.
         if (!this.files.exists(filePath)) {
           await this.files.writeText(filePath, node.content ?? '');
@@ -111,7 +111,7 @@ export class TemplateScaffolder {
         includeInExport: node.includeInExport ?? true,
       };
       if (node.wordCountGoal) item.wordCountGoal = node.wordCountGoal;
-      if (node.children) item.children = await this.buildItems(node.children, chapters);
+      if (node.children) item.children = await this.buildItems(node.children, container);
       items.push(item);
     }
     return items;

--- a/tests/projectManager.test.ts
+++ b/tests/projectManager.test.ts
@@ -1,6 +1,6 @@
 import { ProjectManager } from '../src/ProjectManager';
 import { Notice } from 'obsidian';
-import { WritingProject, resolveDefaultDocumentType } from '../models/Project';
+import { WritingProject, resolveDefaultDocumentType, defaultDocumentFolder, resolveDocumentFolder } from '../models/Project';
 import { InMemoryVaultFiles } from './inMemoryVaultFiles';
 
 function makePlugin() {
@@ -46,6 +46,75 @@ describe('resolveDefaultDocumentType', () => {
   it('ignores the global default for typed projects', () => {
     // A user who set the global to "section" still gets article in a series project.
     expect(resolveDefaultDocumentType('series', 'section')).toBe('article');
+  });
+});
+
+describe('document folder resolution', () => {
+  it('maps each project type to its document folder for new projects', () => {
+    expect(defaultDocumentFolder('book')).toBe('Chapters');
+    expect(defaultDocumentFolder('series')).toBe('Articles');
+    expect(defaultDocumentFolder('blog')).toBe('Posts');
+    expect(defaultDocumentFolder('journal-article')).toBe('Sections');
+    expect(defaultDocumentFolder('magazine-article')).toBe('Sections');
+    expect(defaultDocumentFolder('blank')).toBe('Documents');
+  });
+
+  it('falls back to Chapters when the field is absent (pre-existing projects)', () => {
+    expect(resolveDocumentFolder({})).toBe('Chapters');
+    expect(resolveDocumentFolder(makeProject())).toBe('Chapters');
+  });
+
+  it('uses the stored documentFolder when present', () => {
+    expect(resolveDocumentFolder({ documentFolder: 'Posts' })).toBe('Posts');
+  });
+});
+
+describe('createProject sets the per-type document folder', () => {
+  it('creates the type-named folder and persists documentFolder', async () => {
+    const files = new InMemoryVaultFiles();
+    const pm = new ProjectManager(makePlugin(), files);
+
+    const project = await pm.createProject('My Series', 'series', '', '');
+
+    expect(project.documentFolder).toBe('Articles');
+    expect(files.folders).toContain('Projects/My Series/Articles');
+    const saved = JSON.parse(files.files.get('Projects/My Series/_project.json') ?? '{}') as WritingProject;
+    expect(saved.documentFolder).toBe('Articles');
+  });
+
+  it('blank projects use Documents', async () => {
+    const files = new InMemoryVaultFiles();
+    const pm = new ProjectManager(makePlugin(), files);
+
+    const project = await pm.createProject('Scratch', 'blank', '', '');
+
+    expect(project.documentFolder).toBe('Documents');
+    expect(files.folders).toContain('Projects/Scratch/Documents');
+  });
+});
+
+describe('addDocumentToBinder places files in the project document folder', () => {
+  it('writes to the stored folder when the field is set', async () => {
+    const files = new InMemoryVaultFiles();
+    const pm = new ProjectManager(makePlugin(), files);
+    const blog: WritingProject = { ...makeProject(), id: 'blog-1', type: 'blog', documentFolder: 'Posts' };
+    await pm.saveBinder({ version: '2.0', projectId: blog.id, items: [] });
+
+    const item = await pm.addDocumentToBinder(blog, 'New Post', 'article');
+
+    expect(item.filePath).toBe('Projects/My Book/Posts/New Post.md');
+    expect(files.files.has('Projects/My Book/Posts/New Post.md')).toBe(true);
+  });
+
+  it('writes to Chapters for legacy projects without the field', async () => {
+    const files = new InMemoryVaultFiles();
+    const pm = new ProjectManager(makePlugin(), files);
+    const legacy = makeProject();
+    await pm.saveBinder({ version: '2.0', projectId: legacy.id, items: [] });
+
+    const item = await pm.addDocumentToBinder(legacy, 'New Chapter', 'chapter');
+
+    expect(item.filePath).toBe('Projects/My Book/Chapters/New Chapter.md');
   });
 });
 

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -60,6 +60,28 @@ describe('TemplateScaffolder', () => {
     expect(post.filePath).toMatch(new RegExp(`^Projects/My Book/Chapters/${year}/.*-first-post\\.md$`));
     expect(binder.items[0].includeInExport).toBe(false);
   });
+
+  it('scaffolds into the project documentFolder when set', async () => {
+    const files = new InMemoryVaultFiles();
+    const project: WritingProject = { ...makeProject(), type: 'series', documentFolder: 'Articles' };
+
+    const binder = await new TemplateScaffolder(files).apply(
+      project, TEMPLATE_MANIFESTS.series!(project));
+
+    expect(files.files.has('Projects/My Book/Articles/Series Overview.md')).toBe(true);
+    expect(files.files.has('Projects/My Book/Articles/Article 1.md')).toBe(true);
+    const paths = binder.items.flatMap(i => [i, ...(i.children ?? [])]).map(i => i.filePath).filter(Boolean);
+    expect(paths.every(p => p.startsWith('Projects/My Book/Articles/'))).toBe(true);
+  });
+
+  it('scaffolds into Chapters when documentFolder is absent (legacy projects)', async () => {
+    const files = new InMemoryVaultFiles();
+
+    await new TemplateScaffolder(files).apply(
+      makeProject(), TEMPLATE_MANIFESTS.book!(makeProject()));
+
+    expect(files.files.has('Projects/My Book/Chapters/Front Matter.md')).toBe(true);
+  });
 });
 
 describe('template manifests', () => {


### PR DESCRIPTION
## Summary

Phase 1 of #204: new writing projects persist a `documentFolder` field in `_project.json`, set from the project type:

| Project type | Folder |
|---|---|
| book | `Chapters` |
| series | `Articles` |
| blog | `Posts` (year subfolder unchanged, e.g. `Posts/2026/`) |
| journal-article | `Sections` |
| magazine-article | `Sections` |
| blank | `Documents` |

Runtime resolution everywhere is `project.documentFolder ?? 'Chapters'` (new `resolveDocumentFolder` in `models/Project.ts`), so **existing projects without the field keep using `Chapters/` exactly as before — no files move, no binder paths change.**

## Changes

- `models/Project.ts` — `documentFolder?: string` on `WritingProject`; `defaultDocumentFolder(type)` map + `resolveDocumentFolder(project)` fallback helper
- `src/ProjectManager.ts` — `createProject` creates the type-named folder and stores the field; `addDocumentToBinder` resolves the container instead of hardcoding `Chapters/`
- `src/scaffold.ts` — `TemplateScaffolder.apply` resolves the container; template manifests are container-relative and needed no changes (verified, including the blog year folder)
- Tests: 9 new (mapping, fallback, `createProject`, `addDocumentToBinder`, scaffolder with/without the field) — 204 total, all passing
- CHANGELOG under `[Unreleased]`

The rebuilt `main.js` also picks up the i18next/@codemirror versions already on main''s lockfile (per the standing build-before-commit rule); the shipped 2.9.0 release assets are unaffected.

## Out of scope

Phase 2 — optional migration of existing projects — stays open in #204. No UI for choosing/renaming the folder.

Closes nothing (issue stays open for Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)