### PR TITLE
chore: verify date via Get-Date in /start-session

### DIFF
--- a/.claude/commands/start-session.md
+++ b/.claude/commands/start-session.md
@@ -1,14 +1,15 @@
 Start a new session. Do the following before we begin any work:
 
-1. Read CONTEXT.md
-2. Read all memory files linked in MEMORY.md
-3. Run: git fetch origin && git status && git log --oneline -10
-4. Run: npm run lint
-5. Check open GitHub issues: gh issue list --state open --limit 20
-6. Check open PRs: gh pr list --state open
-7. Read the latest end-session note (exclude Cowork updates):
+1. Run: Get-Date — use its output as the authoritative date and day of week for this session (step 8's Monday check and any date reasoning must come from this output, never from mental derivation)
+2. Read CONTEXT.md
+3. Read all memory files linked in MEMORY.md
+4. Run: git fetch origin && git status && git log --oneline -10
+5. Run: npm run lint
+6. Check open GitHub issues: gh issue list --state open --limit 20
+7. Check open PRs: gh pr list --state open
+8. Read the latest end-session note (exclude Cowork updates):
    Get-ChildItem "C:\Users\donpu\Vaults\Pucik Notes\Obsidian Writing Studio\*Session Update.md" | Where-Object { $_.Name -notmatch 'Cowork' } | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content
-8. If today is Monday, check: gh issue view 1185 --repo johansan/notebook-navigator
+9. If step 1's output says today is Monday, check: gh issue view 1185 --repo johansan/notebook-navigator
 
 Then give me a structured session brief:
 - Last session summary: what was worked on and what was completed


### PR DESCRIPTION
The /start-session checklist has a Monday conditional (step for the Notebook Navigator issue check) but no step that actually produces the day of week — so the weekday was being derived mentally, and on 2026-07-03 it was asserted wrong (Thursday instead of Friday) in a session brief.

This adds `Get-Date` as step 1 and makes the Monday conditional explicitly consume that step's output, the same verify-from-tool-output pattern as the existing `git fetch origin && git status` step.

Docs/skill-only change — no source, no build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)