### PR TITLE
docs: ADR 0001 filesystem-owned binder + glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,9 @@ magazine-article → `section`. The project type's declared default wins; the gl
 The ordered, hierarchical list of documents that belong to a writing project.
 Stored as `_binder.json` in the project folder. Rendered in the left sidebar as `BinderView`.
 Prefer: *binder*. Avoid: *outline*, *table of contents*, *file list*.
+> **Redesign accepted (ADR 0001, not yet implemented):** the binder becomes a live rendering
+> of the project folder tree — `_binder.json` leaves runtime, and the vocabulary in
+> "Binder redesign terms" below applies. Until that ships, this entry describes the code.
 
 **Binder item** (`BinderItem`)
 One entry in the binder. Has a `type` (chapter, section, article, note, group, part),
@@ -113,6 +116,39 @@ A left-sidebar view showing daily writing-activity records.
 
 **Folder sidebar** (`FolderSidebarView`, view type `writing-studio-folder-sidebar`)
 A right-sidebar view scoped to a single vault folder. Opened via file-menu or command.
+
+### Binder redesign terms (accepted — see docs/adr/0001; not yet implemented)
+
+Use these exact terms in redesign issues, PRs, and code. They describe the accepted
+filesystem-owned binder, not the shipped `_binder.json` model.
+
+**Manuscript zone**
+The upper binder zone: the project folder tree minus Research and Exports. Its depth-first
+binder order is the compile order — the zone boundary is the compile boundary.
+Prefer: *manuscript zone*. Avoid: *outline area*, *main list*.
+
+**Resources zone** / **drawer**
+The lower binder zone: Research and Exports pinned as drawer tabs with document counts.
+Research is two-way for `.md` files; Exports is output-only (written by the export engine).
+Non-markdown files are visible and openable but never promotable into the manuscript.
+
+**`binder-order`**
+Integer frontmatter key holding a document's position among its siblings. Written lazily on
+reorder (gaps of 10, midpoint insertion). Folders carry order as a numeric name prefix
+(`020 Part One`) instead, stripped in binder display. Anything without a value natural-sorts
+at the end of its group. Prefer: *order* / *binder-order*. Avoid: *rank*, *index*, *sort key*.
+
+**`binder-status`**, **`binder-type`**, **`binder-compile`**
+Frontmatter homes for per-document metadata: lifecycle status (values unchanged), optional
+document type (icon/menu only), and `binder-compile: false` to exclude a document from
+compile (rendered dimmed). `word-count-goal` (existing key) becomes the sole goal authority.
+The separate binder title is removed — the filename is the title.
+
+**Carry-over**
+The per-project, opt-in migration from a legacy `_binder.json`: Preview (dry run listing
+every operation) → one atomic rename per item plus idempotent frontmatter writes, all targets
+computed deterministically from the immutable legacy file. `_binder.json` is never deleted.
+Prefer: *carry-over*. Avoid: *migration* in UI copy (fine in code/issues), *import*, *conversion*.
 
 ### Writing environment modes
 

--- a/docs/adr/0001-filesystem-owned-binder.md
+++ b/docs/adr/0001-filesystem-owned-binder.md
@@ -1,0 +1,127 @@
+# ADR 0001 — Filesystem-owned binder
+
+- **Status:** Accepted (2026-07-03) — not yet implemented
+- **Deciders:** Don Pucik, with design interviews by Claude Code and independent review by Claude Cowork
+- **Supersedes:** the `_binder.json` runtime model (in effect through 2.11.0)
+
+## Context
+
+Through 2.11.0 the binder keeps its own ordered, hierarchical copy of project membership in
+`_binder.json`, keyed by file path. Every synchronization bug in the plugin's history traces to
+that copy drifting from disk reality. The breaking case: Windows Explorer renames reach plugins
+as CREATE+DELETE pairs with no rename event (console-proven 2026-07-02), so event-based path
+repair can never cover external changes (#219).
+
+Two hard gates were set for any redesign: **(1)** existing projects must migrate with zero risk
+to users' vaults; **(2)** manuscript order must survive changes made outside the plugin. The
+full design was resolved in an eight-area interview (2026-07-03); both gates closed.
+
+## Decision
+
+**The binder is a live rendering of the project folder tree.** The filesystem owns membership
+and hierarchy; order and per-document metadata travel inside what they describe; the plugin
+holds no hidden structural state. `_binder.json` is not consulted at runtime.
+
+### Structure
+
+- Binder drag, promote, and demote physically move files and folders via
+  `fileManager.renameFile()` (links auto-heal). Dragging a folder carries its children because
+  that is what a filesystem move is.
+- Containers are pure folders with no text of their own. A part's introduction is an ordinary
+  document ordered first inside it. Documents cannot contain documents; demote is only valid
+  relative to a folder. The group/part distinction is dropped — there are only folders.
+- Externally added, moved, renamed, or deleted files are automatically correct in the binder.
+  The folder-scan command and Add-to-project modal become unnecessary and are removed.
+
+### Order
+
+- **Documents:** integer `binder-order` frontmatter key, written via `processFrontMatter`.
+  Document filenames are never touched for ordering; the plugin never mints filenames
+  containing position numbers (scaffolds use position-neutral names).
+- **Folders:** numeric name prefix (`020 Part One`), stripped in binder display; on-disk name
+  shown on hover.
+- One number line per sibling group (a document's `binder-order: 15` sorts before a folder
+  prefixed `020`). Ties: natural display-name comparison, then documents before folders.
+- Base order is natural sort (numeric-aware). Values are written lazily — only on reorder —
+  in gaps of 10, midpoint insertion, renumbering a sibling group only when its gaps exhaust.
+- Unordered items (including externally dropped files) place at end-of-group, after ordered
+  siblings; folders never reordered remain pure natural sort.
+- Guarantees: order survives external renames/moves including Windows CREATE+DELETE pairs
+  (it travels in the file/name); external copies sort adjacent to their original (duplicate
+  values are benign ties); no central order file exists whose loss or sync conflict can
+  scramble a project. The one soft edge: an external folder rename that deliberately strips
+  the prefix falls back visibly to natural sort; contents are unharmed.
+
+Rejected alternatives: document filename prefixes (visible numbers in tab headers and inline
+titles — vetoed); a stable-ID-per-document plus ID-keyed order overlay (a central mutable
+state file recreates the `_binder.json` failure class: sync-conflict scramble, no folder
+coverage, ID collisions on copy); any path-keyed sidecar (the original failure mode).
+
+### Per-document metadata
+
+Frontmatter, edited from the context menu: `binder-status` (draft / in-progress / complete /
+published), `word-count-goal` (existing key — now the sole authority; the former
+binder-item-first dual-source invariant is dissolved), optional `binder-type` (icon and menu
+only; export never reads type). The separate binder title is removed: the filename is the
+title, and renaming in the binder renames the file.
+
+### Zones
+
+Two zones in the binder: the manuscript tree above; **Research** and **Exports** pinned below
+as drawer tabs. Research keeps its name (Scrivener convention; zero migration) and is two-way
+for `.md` files. Exports is output-only — files land there via the export engine. Non-markdown
+files are visible and openable but never promotable into the manuscript. The right-side view
+is always called the *folder sidebar*, never "research".
+
+### Export
+
+Compile = the manuscript zone, depth-first, in binder order; the zone boundary is the compile
+boundary. Existing `addTitlePage` and `includeTitlesAsHeadings` options carry over (title =
+basename). New default-off option "Include folder names as headings" (today's compile skips
+structural items, so default-off keeps existing output identical). Per-document exclusion via
+`binder-compile: false` (context menu; rendered dimmed). Right-click a folder → subtree export.
+
+### Migration (gate 1 mechanism)
+
+Upgrading migrates zero bytes; the binder renders disk truth immediately, `_binder.json`
+dormant. Per project with a differing legacy binder: a one-time non-blocking notice —
+**Preview / Carry over / Not now** — where Preview is a dry run listing every planned
+operation. The pass:
+
+1. Create real folders for legacy groups/parts.
+2. **One atomic `renameFile` per item, original → final** (move + rename-to-title + prefix in
+   a single operation; no intermediate location exists).
+3. Idempotent frontmatter writes (`binder-order`, `binder-status`, `word-count-goal`,
+   `binder-type`).
+
+The plan — including collision suffixes, resolved by legacy binder order — is a pure function
+of the immutable `_binder.json`, so every run computes identical targets. Re-run
+classification: file at original path = pending; at final path = done; at neither = surfaced
+as an anomaly, never guessed. Resumability therefore needs no journal or checkpoint state.
+`_binder.json` is never deleted (rollback/re-seed source; downgrade is best-effort). No
+rollback engine: safety = opt-in + full preview + content-preserving operation classes. No
+migration code path can alter document prose.
+
+### UI
+
+Prototype variant C ("compact outliner", Don's selection 2026-07-03): dense single-line rows;
+status as a colored left-edge stripe; folder count badges under a single `#` toggle (default
+on); no order gutter; no per-row type icons; no in-row goal progress (tooltip, targets
+dashboard, and the inline goal banner carry it); hover tooltip shows the on-disk name and
+frontmatter via `setTooltip`. Control strip, project row, search, and the #143 keyboard
+navigation carry over unchanged; toolbar = New document / New folder / Targets dashboard.
+Drag affordances: between-line indicator, folder highlight, hover-to-expand. Drawer open
+state persists per project (view preference, not manuscript state).
+
+## Consequences
+
+- Dies with this ADR: `_binder.json` at runtime; the scan button, scan command, and
+  Add-to-project modal; group/part item types; separate binder titles; the path-keyed drift
+  bug class — **#219 closes as dissolved**.
+- Position numbers users place inside their own filenames ("Chapter 2") can go stale after a
+  reorder; the designated mitigation is compile-time chapter numbering (deferred, own issue).
+- Deferred, non-blocking: compile-time chapter numbering; keyboard promote/demote
+  (Ctrl+arrows); folder-note support if ever wanted.
+- Sequencing: 2.11.0 shipped before any of this lands (done 2026-07-03). Build proceeds as
+  tracer-bullet issues — read-only tree render, then gestures, then migration, then export —
+  each under the acceptance-criteria protocol.


### PR DESCRIPTION
Durable record of the binder rethink design accepted 2026-07-03 (interview complete, both gates closed). Adds docs/adr/0001-filesystem-owned-binder.md and a scoped "Binder redesign terms" glossary section in CONTEXT.md. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)