### PR TITLE
fix: drawer panel renders below the tab bar, not above (#226)

### DIFF
--- a/main.js
+++ b/main.js
@@ -14163,8 +14163,20 @@ var FilesystemBinderView = class extends import_obsidian17.ItemView {
     drawerEl.empty();
     if (!this.activeProject || !model) return;
     const pref = this.drawerPref();
+    const tabs = drawerEl.createDiv("ws-fsb-drawer-tabs");
+    for (const zoneDef of DRAWER_ZONES) {
+      const zone = model.zones[zoneDef.zone];
+      const tab = tabs.createEl("button", { cls: "ws-fsb-drawer-tab" });
+      tab.toggleClass("is-active", pref.open && pref.tab === zoneDef.zone);
+      tab.createSpan({ cls: "ws-fsb-drawer-tab-label", text: t2(zoneDef.labelKey) });
+      tab.createSpan({ cls: "ws-fsb-count", text: String(zone.fileCount) });
+      (0, import_obsidian17.setTooltip)(tab, (_b2 = (_a2 = zone.folder) == null ? void 0 : _a2.name) != null ? _b2 : zoneDef.folderName);
+      tab.onclick = () => {
+        void this.selectDrawerTab(zoneDef.zone);
+      };
+    }
     if (pref.open) {
-      const zoneDef = (_a2 = DRAWER_ZONES.find((z) => z.zone === pref.tab)) != null ? _a2 : DRAWER_ZONES[0];
+      const zoneDef = (_c = DRAWER_ZONES.find((z) => z.zone === pref.tab)) != null ? _c : DRAWER_ZONES[0];
       const zone = model.zones[zoneDef.zone];
       const panel = drawerEl.createDiv("ws-fsb-drawer-panel");
       panel.setAttribute("role", "tree");
@@ -14173,18 +14185,6 @@ var FilesystemBinderView = class extends import_obsidian17.ItemView {
       } else {
         this.renderNodes(panel, zone.nodes, 0, false);
       }
-    }
-    const tabs = drawerEl.createDiv("ws-fsb-drawer-tabs");
-    for (const zoneDef of DRAWER_ZONES) {
-      const zone = model.zones[zoneDef.zone];
-      const tab = tabs.createEl("button", { cls: "ws-fsb-drawer-tab" });
-      tab.toggleClass("is-active", pref.open && pref.tab === zoneDef.zone);
-      tab.createSpan({ cls: "ws-fsb-drawer-tab-label", text: t2(zoneDef.labelKey) });
-      tab.createSpan({ cls: "ws-fsb-count", text: String(zone.fileCount) });
-      (0, import_obsidian17.setTooltip)(tab, (_c = (_b2 = zone.folder) == null ? void 0 : _b2.name) != null ? _c : zoneDef.folderName);
-      tab.onclick = () => {
-        void this.selectDrawerTab(zoneDef.zone);
-      };
     }
   }
   // Clicking the open tab closes the drawer; any other click opens it there

--- a/src/FilesystemBinderView.ts
+++ b/src/FilesystemBinderView.ts
@@ -384,18 +384,8 @@ export class FilesystemBinderView extends ItemView {
 
     const pref = this.drawerPref();
 
-    if (pref.open) {
-      const zoneDef = DRAWER_ZONES.find(z => z.zone === pref.tab) ?? DRAWER_ZONES[0];
-      const zone = model.zones[zoneDef.zone];
-      const panel = drawerEl.createDiv('ws-fsb-drawer-panel');
-      panel.setAttribute('role', 'tree');
-      if (zone.nodes.length === 0) {
-        panel.createDiv('ws-binder-empty').textContent = t(zoneDef.emptyKey);
-      } else {
-        this.renderNodes(panel, zone.nodes, 0, false);
-      }
-    }
-
+    // Prototype variant C order: the tab bar is the divider under the
+    // manuscript, and the selected zone opens downward BELOW the tabs
     const tabs = drawerEl.createDiv('ws-fsb-drawer-tabs');
     for (const zoneDef of DRAWER_ZONES) {
       const zone = model.zones[zoneDef.zone];
@@ -406,6 +396,18 @@ export class FilesystemBinderView extends ItemView {
       // On-disk truth: the tab label is UI text, the tooltip is the folder
       setTooltip(tab, zone.folder?.name ?? zoneDef.folderName);
       tab.onclick = () => { void this.selectDrawerTab(zoneDef.zone); };
+    }
+
+    if (pref.open) {
+      const zoneDef = DRAWER_ZONES.find(z => z.zone === pref.tab) ?? DRAWER_ZONES[0];
+      const zone = model.zones[zoneDef.zone];
+      const panel = drawerEl.createDiv('ws-fsb-drawer-panel');
+      panel.setAttribute('role', 'tree');
+      if (zone.nodes.length === 0) {
+        panel.createDiv('ws-binder-empty').textContent = t(zoneDef.emptyKey);
+      } else {
+        this.renderNodes(panel, zone.nodes, 0, false);
+      }
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -2144,19 +2144,21 @@ body .ws-launcher select {
   border-top: 1px solid var(--background-modifier-border);
 }
 
+/* Panel sits BELOW the tab bar (prototype variant C: the drawer opens
+   downward; the tab bar is the divider under the manuscript) */
 .ws-fsb-drawer-panel {
   max-height: 220px;
   overflow-y: auto;
   padding: 4px 0;
-  border-bottom: 1px solid var(--background-modifier-border);
 }
 
 .ws-fsb-drawer-tabs {
   display: flex;
 }
 
-/* Active tab = accent top border + normal text on a normal background —
-   readable under any theme accent (see light-theme fix above) */
+/* Active tab = accent bottom border (pointing at the panel below) + normal
+   text on a normal background — readable under any theme accent (see
+   light-theme fix above) */
 .ws-fsb-drawer-tab {
   flex: 1;
   display: flex;
@@ -2166,7 +2168,7 @@ body .ws-launcher select {
   padding: 6px 8px;
   background: none;
   border: none;
-  border-top: 2px solid transparent;
+  border-bottom: 2px solid transparent;
   border-radius: 0;
   font-size: 12px;
   color: var(--text-muted);
@@ -2178,7 +2180,7 @@ body .ws-launcher select {
 }
 
 .ws-fsb-drawer-tab.is-active {
-  border-top-color: var(--interactive-accent);
+  border-bottom-color: var(--interactive-accent);
   color: var(--text-normal);
   background: var(--background-secondary);
 }


### PR DESCRIPTION
## Summary

Fixes the #226 layout defect Don reported: with a zone selected, its files rendered above the Research/Exports tab bar instead of below it.

Verified against the variant-C prototype source (artifact 7951ff43): `renderVariantC` appends **manuscript tree → tab bar → drawer list** — the tab bar is the divider under the manuscript and the drawer opens downward. `renderDrawer` was building the panel before the tabs; it now builds tabs first with the panel below. The active-tab accent indicator moves from the top edge to the bottom edge so it points at the panel it opens, and the panel's stray bottom border is dropped.

No behavior change otherwise — persistence, counts, click routing untouched. 271 tests, lint 0/0, build clean.

Refs #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)