### PR TITLE
chore: configure prefer-setting-definitions off pending the real adoption

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,11 @@ export default [
       },
     },
     rules: {
-      "obsidianmd/ui/sentence-case": "off"
+      "obsidianmd/ui/sentence-case": "off",
+      // Advisory rule new in 0.4.1: adopting getSettingDefinitions() is a
+      // real refactor of the tabbed settings surface, tracked as its own
+      // issue — off until that ships, not suppressed inline.
+      "obsidianmd/settings-tab/prefer-setting-definitions": "off"
     }
   },
 ];


### PR DESCRIPTION
Unblocks #254 (eslint-plugin-obsidianmd 0.4.1): the new advisory rule `obsidianmd/settings-tab/prefer-setting-definitions` flags that our tabbed `WritingStudioSettingsTab` does not implement Obsidian 1.13's declarative `getSettingDefinitions()` API — meaning plugin settings are invisible to the settings **search**. Adopting the API is a real refactor of the whole settings surface, filed as its own issue for AC review; until it ships, the rule is configured off in `eslint.config.mjs` with rationale (the sentence-case precedent) — never suppressed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)