### PR TITLE
docs: upgrade note — project folder contents now compile (audit item 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Folders are the structure. The book template creates a part folder for you, and 
 
 **Upgrading from an earlier version:**
 
-The first time you open an existing project, Writing Studio arranges its folders to match what your old binder showed — creating folders and moving documents, deleting nothing, and never changing your writing. A one-time notice explains this, and the command **Restore previous binder layout** puts your folders back the way they were if you preferred your earlier arrangement.
+The first time you open an existing project, Writing Studio arranges its folders to match what your old binder showed — creating folders and moving documents, deleting nothing, and never changing your writing. A one-time notice explains this, and the command **Restore previous binder layout** puts your folders back the way they were if you preferred your earlier arrangement. Everything in your project folder is now part of the compiled manuscript. Check the compile preview before your first export, and use Exclude from compile on anything you want left out.
 
 ---
 


### PR DESCRIPTION
Audit gate item 1 (agenda on #233) — ruling applied.

**Finding:** at the migration boundary, (A) a document whose classic-binder compile exclusion could not be carried (stale recorded path — the #219 class) starts compiling, and (B) files never added to the classic binder now compile because the manuscript zone is the compile boundary. The classic export skipped stale paths, so both are silent behavior flips for upgrading users.

**Ruling (Don, in session):** both cases accepted, no behavior change. Options 3 (carry exclusions by basename) and 4 (surfacing notice) declined. Modal copy stays final. The README upgrade paragraph gains one sentence (Don''s exact wording) pointing users at the compile preview and Exclude from compile.

README-only change; no source, no build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)