### PR TITLE
fix: the edit-project modal never shows or strips a folder order marker (#233 audit)

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,36 +40,6 @@ var STATUS_COLORS = {
   published: "#3b82f6"
 };
 
-// src/folderRename.ts
-var RESERVED_PROJECT_FOLDERS = ["Research", "Exports"];
-function baseName(path) {
-  const i2 = path.lastIndexOf("/");
-  return i2 === -1 ? path : path.slice(i2 + 1);
-}
-function parentPath(path) {
-  const i2 = path.lastIndexOf("/");
-  return i2 === -1 ? "" : path.slice(0, i2);
-}
-function pathAtOrUnder(path, prefix) {
-  return path === prefix || path.startsWith(prefix + "/");
-}
-function rewritePathPrefix(path, oldPrefix, newPrefix) {
-  if (path === oldPrefix) return newPrefix;
-  if (path.startsWith(oldPrefix + "/")) return newPrefix + path.slice(oldPrefix.length);
-  return path;
-}
-function validateDocumentFolderName(name, currentName, targetExists) {
-  if (name.trim() === "") return { ok: false, reason: "empty" };
-  if (/[\\/:*?"<>|]/.test(name)) return { ok: false, reason: "invalid-chars" };
-  if (/[. ]$/.test(name)) return { ok: false, reason: "trailing" };
-  if (RESERVED_PROJECT_FOLDERS.some((r) => r.toLowerCase() === name.toLowerCase())) {
-    return { ok: false, reason: "reserved" };
-  }
-  const caseOnly = name !== currentName && name.toLowerCase() === currentName.toLowerCase();
-  if (targetExists && !caseOnly) return { ok: false, reason: "exists" };
-  return { ok: true };
-}
-
 // src/binderOrder.ts
 function parseFolderPrefix(name) {
   const m = /^(-?\d+)~ (\S.*)$/.exec(name);
@@ -150,6 +120,84 @@ function planReorder(sequence, movedIndex) {
   return writes;
 }
 
+// src/binderMenu.ts
+var BINDER_TYPES = ["chapter", "section", "article", "note"];
+function parseBinderType(value) {
+  return typeof value === "string" && BINDER_TYPES.includes(value) ? value : null;
+}
+function parseBinderStatus(value) {
+  return typeof value === "string" && value in STATUS_COLORS ? value : null;
+}
+function menuActionsFor(entry, zone) {
+  if (zone === "exports") return ["delete"];
+  if (!entry.isFolder && entry.extension !== "md") return ["rename", "delete"];
+  if (entry.isFolder && zone === "manuscript") {
+    return ["rename", "export", "newDoc", "newFolder", "delete"];
+  }
+  if (zone === "research" || entry.isFolder) {
+    return ["rename", "newDoc", "newFolder", "delete"];
+  }
+  return ["rename", "status", "goal", "type", "compile", "newDoc", "newFolder", "delete"];
+}
+function renamePrefill(entry) {
+  if (entry.isFolder || entry.extension === "md") return entryDisplayName(entry);
+  return entry.extension ? entry.name.slice(0, entry.name.length - entry.extension.length - 1) : entry.name;
+}
+function renameTargetName(entry, typed) {
+  if (entry.isFolder) {
+    if (parseFolderPrefix(typed).order !== null) return typed;
+    const order = parseFolderPrefix(entry.name).order;
+    return order !== null ? folderNameWithPrefix(typed, order) : typed;
+  }
+  if (!entry.extension) return typed;
+  const suffix = "." + entry.extension;
+  return typed.toLowerCase().endsWith(suffix.toLowerCase()) ? typed : typed + suffix;
+}
+function validateItemName(typed, targetName, siblingNames) {
+  if (typed.trim() === "") return { ok: false, reason: "empty" };
+  if (/[\\/:*?"<>|]/.test(typed)) return { ok: false, reason: "invalid-chars" };
+  if (/[. ]$/.test(typed)) return { ok: false, reason: "trailing" };
+  const lower = targetName.toLowerCase();
+  if (siblingNames.some((n) => n.toLowerCase() === lower)) return { ok: false, reason: "exists" };
+  return { ok: true };
+}
+
+// src/folderRename.ts
+var RESERVED_PROJECT_FOLDERS = ["Research", "Exports"];
+function documentFolderDisplayName(onDiskName) {
+  return parseFolderPrefix(onDiskName).displayName;
+}
+function documentFolderRenameTarget(onDiskName, typed) {
+  return renameTargetName({ name: onDiskName, isFolder: true, binderOrder: null }, typed);
+}
+function baseName(path) {
+  const i2 = path.lastIndexOf("/");
+  return i2 === -1 ? path : path.slice(i2 + 1);
+}
+function parentPath(path) {
+  const i2 = path.lastIndexOf("/");
+  return i2 === -1 ? "" : path.slice(0, i2);
+}
+function pathAtOrUnder(path, prefix) {
+  return path === prefix || path.startsWith(prefix + "/");
+}
+function rewritePathPrefix(path, oldPrefix, newPrefix) {
+  if (path === oldPrefix) return newPrefix;
+  if (path.startsWith(oldPrefix + "/")) return newPrefix + path.slice(oldPrefix.length);
+  return path;
+}
+function validateDocumentFolderName(name, currentName, targetExists) {
+  if (name.trim() === "") return { ok: false, reason: "empty" };
+  if (/[\\/:*?"<>|]/.test(name)) return { ok: false, reason: "invalid-chars" };
+  if (/[. ]$/.test(name)) return { ok: false, reason: "trailing" };
+  if (RESERVED_PROJECT_FOLDERS.some((r) => r.toLowerCase() === name.toLowerCase())) {
+    return { ok: false, reason: "reserved" };
+  }
+  const caseOnly = name !== currentName && name.toLowerCase() === currentName.toLowerCase();
+  if (targetExists && !caseOnly) return { ok: false, reason: "exists" };
+  return { ok: true };
+}
+
 // src/binderMove.ts
 function dropRegion(targetIsFolder, offsetY, height) {
   if (!targetIsFolder) return offsetY < height / 2 ? "before" : "after";
@@ -208,48 +256,6 @@ function planMove(source, destParentPath, destSiblings, insertAt, writeOrder) {
     }
   }
   return ops;
-}
-
-// src/binderMenu.ts
-var BINDER_TYPES = ["chapter", "section", "article", "note"];
-function parseBinderType(value) {
-  return typeof value === "string" && BINDER_TYPES.includes(value) ? value : null;
-}
-function parseBinderStatus(value) {
-  return typeof value === "string" && value in STATUS_COLORS ? value : null;
-}
-function menuActionsFor(entry, zone) {
-  if (zone === "exports") return ["delete"];
-  if (!entry.isFolder && entry.extension !== "md") return ["rename", "delete"];
-  if (entry.isFolder && zone === "manuscript") {
-    return ["rename", "export", "newDoc", "newFolder", "delete"];
-  }
-  if (zone === "research" || entry.isFolder) {
-    return ["rename", "newDoc", "newFolder", "delete"];
-  }
-  return ["rename", "status", "goal", "type", "compile", "newDoc", "newFolder", "delete"];
-}
-function renamePrefill(entry) {
-  if (entry.isFolder || entry.extension === "md") return entryDisplayName(entry);
-  return entry.extension ? entry.name.slice(0, entry.name.length - entry.extension.length - 1) : entry.name;
-}
-function renameTargetName(entry, typed) {
-  if (entry.isFolder) {
-    if (parseFolderPrefix(typed).order !== null) return typed;
-    const order = parseFolderPrefix(entry.name).order;
-    return order !== null ? folderNameWithPrefix(typed, order) : typed;
-  }
-  if (!entry.extension) return typed;
-  const suffix = "." + entry.extension;
-  return typed.toLowerCase().endsWith(suffix.toLowerCase()) ? typed : typed + suffix;
-}
-function validateItemName(typed, targetName, siblingNames) {
-  if (typed.trim() === "") return { ok: false, reason: "empty" };
-  if (/[\\/:*?"<>|]/.test(typed)) return { ok: false, reason: "invalid-chars" };
-  if (/[. ]$/.test(typed)) return { ok: false, reason: "trailing" };
-  const lower = targetName.toLowerCase();
-  if (siblingNames.some((n) => n.toLowerCase() === lower)) return { ok: false, reason: "exists" };
-  return { ok: true };
 }
 
 // modals/ProjectModal.ts
@@ -11081,7 +11087,7 @@ var ProjectModal = class extends import_obsidian2.Modal {
       this.author = this.edit.author;
       this.description = this.edit.description;
       this.goalRaw = String(((_a2 = this.edit.goals) == null ? void 0 : _a2.totalWordCount) || "");
-      this.documentFolder = resolveDocumentFolder(this.edit);
+      this.documentFolder = documentFolderDisplayName(resolveDocumentFolder(this.edit));
     } else {
       this.author = this.plugin.settings.authorName;
     }
@@ -11165,7 +11171,7 @@ var ProjectModal = class extends import_obsidian2.Modal {
   async saveEdit(project, submitBtn) {
     var _a2;
     const currentFolder = resolveDocumentFolder(project);
-    if (this.documentFolder !== currentFolder) {
+    if (this.documentFolder !== documentFolderDisplayName(currentFolder)) {
       const renamed = await this.renameDocumentFolder(project, currentFolder);
       if (!renamed) {
         submitBtn.disabled = false;
@@ -11195,16 +11201,17 @@ var ProjectModal = class extends import_obsidian2.Modal {
   // vault rename fails — a failed rename never passes silently.
   async renameDocumentFolder(project, currentFolder) {
     var _a2;
-    const target = (0, import_obsidian2.normalizePath)(`${project.folderPath}/${this.documentFolder}`);
+    const targetName = documentFolderRenameTarget(currentFolder, this.documentFolder);
+    const target = (0, import_obsidian2.normalizePath)(`${project.folderPath}/${targetName}`);
     const targetExists = this.app.vault.getAbstractFileByPath(target) !== null;
-    const verdict = validateDocumentFolderName(this.documentFolder, currentFolder, targetExists);
+    const verdict = validateDocumentFolderName(this.documentFolder, documentFolderDisplayName(currentFolder), targetExists);
     if (!verdict.ok) {
       new import_obsidian2.Notice(t2(FOLDER_REJECTION_KEYS[(_a2 = verdict.reason) != null ? _a2 : "empty"], { name: this.documentFolder }));
       return false;
     }
     const source = this.app.vault.getFolderByPath((0, import_obsidian2.normalizePath)(`${project.folderPath}/${currentFolder}`));
     if (!source) {
-      new import_obsidian2.Notice(t2("projectModal.folderMissing", { name: currentFolder }));
+      new import_obsidian2.Notice(t2("projectModal.folderMissing", { name: documentFolderDisplayName(currentFolder) }));
       return false;
     }
     try {

--- a/modals/ProjectModal.ts
+++ b/modals/ProjectModal.ts
@@ -1,7 +1,10 @@
 import { App, Modal, Setting, Notice, normalizePath } from 'obsidian';
 import type WritingStudioPlugin from '../main';
 import { ProjectType, WritingProject, resolveDocumentFolder } from '../models/Project';
-import { validateDocumentFolderName, FolderNameRejection } from '../src/folderRename';
+import {
+  validateDocumentFolderName, FolderNameRejection,
+  documentFolderDisplayName, documentFolderRenameTarget,
+} from '../src/folderRename';
 import { t } from '../src/i18n';
 
 const FOLDER_REJECTION_KEYS: Record<FolderNameRejection, string> = {
@@ -45,7 +48,8 @@ export class ProjectModal extends Modal {
       this.author = this.edit.author;
       this.description = this.edit.description;
       this.goalRaw = String(this.edit.goals?.totalWordCount || '');
-      this.documentFolder = resolveDocumentFolder(this.edit);
+      // Display name only — a folder order marker never shows here
+      this.documentFolder = documentFolderDisplayName(resolveDocumentFolder(this.edit));
     } else {
       // Author was previously taken silently from settings — surfacing it
       // means the manuscript title page never gets a blank author unnoticed
@@ -169,7 +173,7 @@ export class ProjectModal extends Modal {
   // project record and binder, exactly as for a manual rename.
   private async saveEdit(project: WritingProject, submitBtn: HTMLButtonElement): Promise<void> {
     const currentFolder = resolveDocumentFolder(project);
-    if (this.documentFolder !== currentFolder) {
+    if (this.documentFolder !== documentFolderDisplayName(currentFolder)) {
       const renamed = await this.renameDocumentFolder(project, currentFolder);
       if (!renamed) {
         submitBtn.disabled = false;
@@ -199,16 +203,20 @@ export class ProjectModal extends Modal {
   // False (with a notice shown) when validation rejects the name or the
   // vault rename fails — a failed rename never passes silently.
   private async renameDocumentFolder(project: WritingProject, currentFolder: string): Promise<boolean> {
-    const target = normalizePath(`${project.folderPath}/${this.documentFolder}`);
+    // The typed value is a display name; the on-disk target re-attaches the
+    // folder's existing order marker, so a rename here can never cost the
+    // folder its order (#233 audit ruling)
+    const targetName = documentFolderRenameTarget(currentFolder, this.documentFolder);
+    const target = normalizePath(`${project.folderPath}/${targetName}`);
     const targetExists = this.app.vault.getAbstractFileByPath(target) !== null;
-    const verdict = validateDocumentFolderName(this.documentFolder, currentFolder, targetExists);
+    const verdict = validateDocumentFolderName(this.documentFolder, documentFolderDisplayName(currentFolder), targetExists);
     if (!verdict.ok) {
       new Notice(t(FOLDER_REJECTION_KEYS[verdict.reason ?? 'empty'], { name: this.documentFolder }));
       return false;
     }
     const source = this.app.vault.getFolderByPath(normalizePath(`${project.folderPath}/${currentFolder}`));
     if (!source) {
-      new Notice(t('projectModal.folderMissing', { name: currentFolder }));
+      new Notice(t('projectModal.folderMissing', { name: documentFolderDisplayName(currentFolder) }));
       return false;
     }
     try {

--- a/src/folderRename.ts
+++ b/src/folderRename.ts
@@ -1,7 +1,23 @@
+import { parseFolderPrefix } from './binderOrder';
+import { renameTargetName } from './binderMenu';
+
 // Folders every project reserves for non-document content. createProject
 // scaffolds these next to the document folder; template manifests create
 // nothing else at that level, so this list is complete.
 export const RESERVED_PROJECT_FOLDERS = ['Research', 'Exports'];
+
+// The edit-project modal's Document folder field works in display names:
+// the order marker migration or a reorder attached to the folder is never
+// shown, and a typed name re-attaches the existing marker — the same engine
+// as a binder rename — so an edit there can never cost the folder its order
+// (#233 audit ruling).
+export function documentFolderDisplayName(onDiskName: string): string {
+  return parseFolderPrefix(onDiskName).displayName;
+}
+
+export function documentFolderRenameTarget(onDiskName: string, typed: string): string {
+  return renameTargetName({ name: onDiskName, isFolder: true, binderOrder: null }, typed);
+}
 
 export function baseName(path: string): string {
   const i = path.lastIndexOf('/');

--- a/tests/folderRename.test.ts
+++ b/tests/folderRename.test.ts
@@ -3,6 +3,8 @@ import { WritingProject, resolveDocumentFolder } from '../models/Project';
 import {
   validateDocumentFolderName,
   RESERVED_PROJECT_FOLDERS,
+  documentFolderDisplayName,
+  documentFolderRenameTarget,
 } from '../src/folderRename';
 import { InMemoryVaultFiles } from './inMemoryVaultFiles';
 
@@ -36,6 +38,26 @@ async function setup(project: WritingProject, folders: string[] = []) {
   await pm.saveProject(project);
   return { pm, files };
 }
+
+// The edit-project modal works in display names (#233 audit ruling): the
+// order marker never shows, and a rename re-attaches it — editing the field
+// can never cost the folder its order.
+describe('document folder display name and rename target', () => {
+  it('strips the order marker for display; a plain name is unchanged', () => {
+    expect(documentFolderDisplayName('005~ Chapters')).toBe('Chapters');
+    expect(documentFolderDisplayName('Chapters')).toBe('Chapters');
+  });
+
+  it('a rename re-attaches the existing marker', () => {
+    expect(documentFolderRenameTarget('005~ Chapters', 'Scenes')).toBe('005~ Scenes');
+    expect(documentFolderRenameTarget('005~ Chapters', 'Chapters')).toBe('005~ Chapters');
+  });
+
+  it('a plain folder stays plain; typed marker syntax is kept byte-for-byte (#239 residual)', () => {
+    expect(documentFolderRenameTarget('Chapters', 'Scenes')).toBe('Scenes');
+    expect(documentFolderRenameTarget('005~ Chapters', '007~ Bond')).toBe('007~ Bond');
+  });
+});
 
 describe('validateDocumentFolderName', () => {
   it('rejects an empty name', () => {


### PR DESCRIPTION
Audit sweep finding — Don''s ruling: **fix before the tag.** The order marker is never shown in the edit-project modal, and editing the folder name there cannot strip the marker or cost the folder its order.

Before: the Document folder field prefilled the on-disk name, so a migrated document folder showed `005~ Chapters`, and the natural user correction (retyping `Chapters`) stripped the marker — the folder lost its order and sank to the binder''s bottom, re-creating the #263 surprise through our own UI.

Now the field works in display names end to end:
- **Prefill** strips the marker (`005~ Chapters` shows as `Chapters`).
- **Unchanged detection** compares display names, so opening and saving the modal is a no-op.
- **Rename** re-attaches the existing marker via the same engine as a binder rename (`binderMenu.renameTargetName`): typing `Scenes` over `005~ Chapters` produces `005~ Scenes`. Typed marker syntax is kept byte-for-byte (#239 residual, same as the binder).
- **Validation and notices** compare and name display forms.

New pure helpers `documentFolderDisplayName` / `documentFolderRenameTarget` in `src/folderRename.ts`; modal stays thin glue. Three regression tests. Tests 387 → **390**, lint clean, production build, `main.js` in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)