### PR TITLE
refactor: single-source the path/validation vocabulary and small consistency leftovers (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Writing Studio are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+- Internal code consolidation, no behavior change: one shared home for path helpers, the illegal-filename-character rule, and the typed-name validation core; `binder-compile` gains a parser like the other frontmatter keys; the document status list is single-sourced. (#276)
+
+---
+
 ## [3.0.0] - 2026-07-06
 
 ### Changed

--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ var import_obsidian35 = require("obsidian");
 var import_obsidian14 = require("obsidian");
 
 // models/BinderItem.ts
+var DOCUMENT_STATUSES = ["draft", "in-progress", "complete", "published"];
 var STATUS_COLORS = {
   draft: "#888888",
   "in-progress": "#f59e0b",
@@ -129,7 +130,10 @@ function parseBinderType(value) {
   return typeof value === "string" && BINDER_TYPES.includes(value) ? value : null;
 }
 function parseBinderStatus(value) {
-  return typeof value === "string" && value in STATUS_COLORS ? value : null;
+  return typeof value === "string" && DOCUMENT_STATUSES.includes(value) ? value : null;
+}
+function parseBinderCompile(value) {
+  return value !== false;
 }
 function menuActionsFor(entry, zone) {
   if (zone === "exports") return ["delete"];
@@ -157,9 +161,8 @@ function renameTargetName(entry, typed) {
   return typed.toLowerCase().endsWith(suffix.toLowerCase()) ? typed : typed + suffix;
 }
 function validateItemName(typed, targetName, siblingNames) {
-  if (typed.trim() === "") return { ok: false, reason: "empty" };
-  if (/[\\/:*?"<>|]/.test(typed)) return { ok: false, reason: "invalid-chars" };
-  if (/[. ]$/.test(typed)) return { ok: false, reason: "trailing" };
+  const text = rejectNameText(typed);
+  if (text !== null) return { ok: false, reason: text };
   const lower = targetName.toLowerCase();
   if (siblingNames.some((n) => n.toLowerCase() === lower)) return { ok: false, reason: "exists" };
   return { ok: true };
@@ -184,18 +187,43 @@ function parentPath(path) {
   const i2 = path.lastIndexOf("/");
   return i2 === -1 ? "" : path.slice(0, i2);
 }
+function joinPath(parent, name) {
+  return parent ? `${parent}/${name}` : name;
+}
 function pathAtOrUnder(path, prefix) {
   return path === prefix || path.startsWith(prefix + "/");
+}
+function pathStrictlyUnder(path, prefix) {
+  return path.startsWith(prefix + "/");
 }
 function rewritePathPrefix(path, oldPrefix, newPrefix) {
   if (path === oldPrefix) return newPrefix;
   if (path.startsWith(oldPrefix + "/")) return newPrefix + path.slice(oldPrefix.length);
   return path;
 }
+var ILLEGAL_NAME_CHARS = /[\\/:*?"<>|]/;
+var ILLEGAL_NAME_CHARS_ALL = /[\\/:*?"<>|]/g;
+function hasIllegalNameChars(name) {
+  return ILLEGAL_NAME_CHARS.test(name);
+}
+function replaceIllegalNameChars(name, replacement) {
+  return name.replace(ILLEGAL_NAME_CHARS_ALL, replacement);
+}
+function hasTrailingDotOrSpace(name) {
+  return /[. ]$/.test(name);
+}
+function stripTrailingDotsAndSpaces(name) {
+  return name.replace(/[. ]+$/, "");
+}
+function rejectNameText(name) {
+  if (name.trim() === "") return "empty";
+  if (hasIllegalNameChars(name)) return "invalid-chars";
+  if (hasTrailingDotOrSpace(name)) return "trailing";
+  return null;
+}
 function validateDocumentFolderName(name, currentName, targetExists) {
-  if (name.trim() === "") return { ok: false, reason: "empty" };
-  if (/[\\/:*?"<>|]/.test(name)) return { ok: false, reason: "invalid-chars" };
-  if (/[. ]$/.test(name)) return { ok: false, reason: "trailing" };
+  const text = rejectNameText(name);
+  if (text !== null) return { ok: false, reason: text };
   if (isReservedFolderName(name)) {
     return { ok: false, reason: "reserved" };
   }
@@ -245,7 +273,7 @@ function buildManuscriptTree(app, rootPath, opts = {}) {
           kind: "doc",
           path: s.file.path,
           title: s.file.name.slice(0, s.file.name.length - s.file.extension.length - 1),
-          compileExcluded: (fm == null ? void 0 : fm["binder-compile"]) === false
+          compileExcluded: !parseBinderCompile(fm == null ? void 0 : fm["binder-compile"])
         });
       }
     }
@@ -304,17 +332,10 @@ function evaluateDrop(source, destParentPath, destZone) {
   if (source.isFolder && destZone !== source.zone) {
     return { kind: "notice", messageKey: "binder.fs.folderZoneBlocked" };
   }
-  if (source.isFolder && (destParentPath === source.path || destParentPath.startsWith(source.path + "/"))) {
+  if (source.isFolder && pathAtOrUnder(destParentPath, source.path)) {
     return { kind: "refuse" };
   }
   return { kind: "accept" };
-}
-function parentOf(path) {
-  const i2 = path.lastIndexOf("/");
-  return i2 < 0 ? "" : path.slice(0, i2);
-}
-function joinPath(parent, name) {
-  return parent ? `${parent}/${name}` : name;
 }
 function planMove(source, destParentPath, destSiblings, insertAt, writeOrder) {
   var _a2;
@@ -339,7 +360,7 @@ function planMove(source, destParentPath, destSiblings, insertAt, writeOrder) {
     if (entry.isFolder) {
       const newName = folderNameWithPrefix(entry.name, w.order);
       if (newName === entry.name) continue;
-      ops.push({ kind: "rename", path: entry.path, newPath: joinPath(parentOf(entry.path), newName) });
+      ops.push({ kind: "rename", path: entry.path, newPath: joinPath(parentPath(entry.path), newName) });
     } else {
       ops.push({ kind: "set-order", path: entry.path, order: w.order });
     }
@@ -11599,7 +11620,7 @@ function resolveExportTitle(choice, ctx) {
   }
 }
 function sanitizeTitleForFilename(title) {
-  return title.replace(/[\\/:*?"<>|]/g, "-");
+  return replaceIllegalNameChars(title, "-");
 }
 
 // modals/ExportModal.ts
@@ -13161,7 +13182,7 @@ var FilesystemBinderView = class extends import_obsidian14.ItemView {
       displayName: entryDisplayName(entry),
       status,
       docType: parseBinderType(fm == null ? void 0 : fm["binder-type"]),
-      compileExcluded: (fm == null ? void 0 : fm["binder-compile"]) === false,
+      compileExcluded: !parseBinderCompile(fm == null ? void 0 : fm["binder-compile"]),
       fmLines,
       children: [],
       mdCount: 0
@@ -17579,7 +17600,7 @@ var ProjectManager = class extends import_obsidian24.Events {
   async createProject(title, type, author, description) {
     const rootFolder = this.plugin.settings.defaultProjectFolder || "Writing Projects";
     const id = this.uniqueId("project");
-    const folderName = title.replace(/[\\/:*?"<>|]/g, "-");
+    const folderName = replaceIllegalNameChars(title, "-");
     const folderPath = (0, import_obsidian24.normalizePath)(`${rootFolder}/${folderName}`);
     if (this.files.exists(folderPath)) {
       throw new Error(t2("projectManager.errorFolderExists", { folder: folderName }));
@@ -18749,7 +18770,9 @@ function parseLegacyBinder(content2) {
   }
 }
 function sanitizeTitle(title) {
-  return title.replace(/[\\/:*?"<>|]/g, "").replace(/\s+/g, " ").trim().replace(/[. ]+$/, "");
+  return stripTrailingDotsAndSpaces(
+    replaceIllegalNameChars(title, "").replace(/\s+/g, " ").trim()
+  );
 }
 function docCurrentPath(op) {
   if (op.state === "missing") return null;
@@ -18782,7 +18805,12 @@ function planCarryOver(items, projectFolderPath, disk) {
   assignLeftoverOrders(plan, disk);
   return plan;
 }
-var parentOf2 = (path) => path.split("/").slice(0, -1).join("/");
+var compareAdoptionCandidates = (a, b) => {
+  const aMarked = parseFolderPrefix(a).order !== null;
+  const bMarked = parseFolderPrefix(b).order !== null;
+  if (aMarked !== bMarked) return aMarked ? -1 : 1;
+  return naturalCompare(a, b);
+};
 function planContentFolders(plan, projectFolderPath, disk) {
   const claimed = /* @__PURE__ */ new Set();
   for (const op of plan.folderOps) {
@@ -18792,36 +18820,30 @@ function planContentFolders(plan, projectFolderPath, disk) {
   const blocked = /* @__PURE__ */ new Set();
   for (const op of plan.docOps) {
     if ((op.state === "pending" || op.state === "leftover") && op.originalPath !== "") {
-      blocked.add(parentOf2(op.originalPath));
+      blocked.add(parentPath(op.originalPath));
     }
   }
   const earliest = /* @__PURE__ */ new Map();
   for (const op of plan.docOps) {
     if (op.state !== "done") continue;
     if (op.originalPath === "") continue;
-    const recordedParent = parentOf2(op.originalPath);
+    const recordedParent = parentPath(op.originalPath);
     if (blocked.has(recordedParent)) continue;
-    if (!(recordedParent.length > projectFolderPath.length && recordedParent.startsWith(projectFolderPath + "/"))) continue;
-    if (parentOf2(op.finalPath) !== parentOf2(recordedParent)) continue;
+    if (!pathStrictlyUnder(recordedParent, projectFolderPath)) continue;
+    if (parentPath(op.finalPath) !== parentPath(recordedParent)) continue;
     const current = earliest.get(recordedParent);
     if (current === void 0 || op.order < current) earliest.set(recordedParent, op.order);
   }
   for (const [recordedParent, position] of [...earliest.entries()].sort()) {
-    const parent = parentOf2(recordedParent);
-    const plainName = recordedParent.split("/").pop();
+    const parent = parentPath(recordedParent);
+    const plainName = baseName(recordedParent);
     const candidates = disk.subfolderNames(parent).filter((n) => !claimed.has(`${parent}/${n}`) && parseFolderPrefix(n).displayName.toLowerCase() === plainName.toLowerCase());
     if (candidates.length === 0) continue;
-    candidates.sort((a, b) => {
-      const aMarked = parseFolderPrefix(a).order !== null;
-      const bMarked = parseFolderPrefix(b).order !== null;
-      if (aMarked !== bMarked) return aMarked ? -1 : 1;
-      return naturalCompare(a, b);
-    });
+    candidates.sort(compareAdoptionCandidates);
     const name = candidates[0];
     claimed.add(`${parent}/${name}`);
     if (parseFolderPrefix(name).order !== null) {
       plan.folderOps.push({
-        kind: "folder",
         legacyTitle: plainName,
         displayName: parseFolderPrefix(name).displayName,
         currentPath: null,
@@ -18833,7 +18855,6 @@ function planContentFolders(plan, projectFolderPath, disk) {
     }
     const attached = folderNameWithPrefix(name, position - 5);
     plan.folderOps.push({
-      kind: "folder",
       legacyTitle: plainName,
       displayName: name,
       currentPath: `${parent}/${name}`,
@@ -18867,16 +18888,12 @@ function planFolder(item, position, parentPath2, existingFolders, consumedAdopte
   const candidates = existingFolders.filter((n) => !consumedAdoptees.has(n) && parseFolderPrefix(n).displayName.toLowerCase() === displayName.toLowerCase());
   candidates.sort((a, b) => {
     if (a === minted !== (b === minted)) return a === minted ? -1 : 1;
-    const aMarked = parseFolderPrefix(a).order !== null;
-    const bMarked = parseFolderPrefix(b).order !== null;
-    if (aMarked !== bMarked) return aMarked ? -1 : 1;
-    return naturalCompare(a, b);
+    return compareAdoptionCandidates(a, b);
   });
   const adopted = candidates.length > 0 ? candidates[0] : null;
   if (adopted !== null) consumedAdoptees.add(adopted);
   if (adopted === null) {
     return {
-      kind: "folder",
       legacyTitle: item.title,
       displayName,
       currentPath: null,
@@ -18887,7 +18904,6 @@ function planFolder(item, position, parentPath2, existingFolders, consumedAdopte
   }
   if (parseFolderPrefix(adopted).order !== null) {
     return {
-      kind: "folder",
       legacyTitle: item.title,
       displayName,
       currentPath: null,
@@ -18898,7 +18914,6 @@ function planFolder(item, position, parentPath2, existingFolders, consumedAdopte
   }
   const attached = folderNameWithPrefix(adopted, position);
   return {
-    kind: "folder",
     legacyTitle: item.title,
     displayName,
     currentPath: `${parentPath2}/${adopted}`,
@@ -18908,9 +18923,9 @@ function planFolder(item, position, parentPath2, existingFolders, consumedAdopte
   };
 }
 function planDoc(item, position, parentPath2, disk, claimedBasenames) {
-  var _a2, _b2;
+  var _a2;
   const originalPath = (item.filePath || "").replace(/\\/g, "/");
-  const basename = (_a2 = originalPath.split("/").pop()) != null ? _a2 : "";
+  const basename = baseName(originalPath);
   const finalPath = `${parentPath2}/${basename}`;
   const atOriginal = originalPath !== "" && disk.fileExists(originalPath);
   const atFinal = basename !== "" && disk.fileExists(finalPath);
@@ -18928,10 +18943,9 @@ function planDoc(item, position, parentPath2, disk, claimedBasenames) {
     else state = "done";
   }
   const currentPath = state === "missing" ? null : state === "done" ? finalPath : originalPath;
-  const fm = currentPath !== null ? (_b2 = disk.frontmatter(currentPath)) != null ? _b2 : {} : {};
+  const fm = currentPath !== null ? (_a2 = disk.frontmatter(currentPath)) != null ? _a2 : {} : {};
   const kept = (k) => fm[k] !== void 0 && fm[k] !== null;
   return {
-    kind: "doc",
     originalPath,
     finalPath,
     state,
@@ -18964,7 +18978,7 @@ function assignLeftoverOrders(plan, disk) {
   const positions = /* @__PURE__ */ new Map();
   for (const op of plan.docOps) {
     if (op.state !== "leftover") continue;
-    const parent = op.originalPath.split("/").slice(0, -1).join("/");
+    const parent = parentPath(op.originalPath);
     const next = ((_a2 = positions.get(parent)) != null ? _a2 : 0) + 10;
     positions.set(parent, next);
     op.order = next;
@@ -18982,11 +18996,10 @@ function planRestore(items, projectFolderPath, disk) {
     if (op.action !== "none") continue;
     const parsed = parseFolderPrefix(op.targetName);
     if (parsed.order === null) continue;
-    const parent = parentOf2(op.targetPath);
+    const parent = parentPath(op.targetPath);
     const toPath = `${parent}/${parsed.displayName}`;
     const occupied = disk.folderExists(toPath) || disk.fileExists(toPath);
     folderOps.push({
-      kind: "restore-folder",
       fromPath: op.targetPath,
       toPath,
       state: occupied ? "skipped" : "pending",
@@ -19024,7 +19037,6 @@ function planRestore(items, projectFolderPath, disk) {
       skipReason = "not-found";
     }
     docOps.push({
-      kind: "restore-doc",
       fromPath: op.finalPath,
       toPath,
       ensureFolders: ancestorsWithin(toPath, projectFolderPath),
@@ -19041,20 +19053,16 @@ function ancestorsWithin(filePath, projectFolderPath) {
   let path = "";
   for (const part of parts) {
     path = path === "" ? part : `${path}/${part}`;
-    if (path.length > projectFolderPath.length && path.startsWith(projectFolderPath + "/")) {
+    if (pathStrictlyUnder(path, projectFolderPath)) {
       out.push(path);
     }
   }
   return out;
 }
-var basenameOf = (path) => {
-  var _a2;
-  return (_a2 = path.split("/").pop()) != null ? _a2 : path;
-};
 async function runMigrationPass(compute, io) {
   const result = { changed: 0, failures: [], leftovers: 0, missing: 0 };
   const failedRoots = [];
-  const underFailedRoot = (path) => failedRoots.some((root) => path === root || path.startsWith(root + "/"));
+  const underFailedRoot = (path) => failedRoots.some((root) => pathAtOrUnder(path, root));
   const attemptedFolders = /* @__PURE__ */ new Set();
   const runFolderOps = async () => {
     for (; ; ) {
@@ -19080,7 +19088,7 @@ async function runMigrationPass(compute, io) {
   const afterFolders = compute();
   for (const op of afterFolders.plan.docOps) {
     if (op.state !== "pending") continue;
-    const targetParent = op.finalPath.split("/").slice(0, -1).join("/");
+    const targetParent = parentPath(op.finalPath);
     if (!afterFolders.disk.folderExists(targetParent)) continue;
     try {
       await io.rename(op.originalPath, op.finalPath);
@@ -19088,7 +19096,7 @@ async function runMigrationPass(compute, io) {
     } catch (e) {
       result.failures.push({
         signature: `move|${op.originalPath}`,
-        name: basenameOf(op.originalPath),
+        name: baseName(op.originalPath),
         reason: e instanceof Error ? e.message : String(e),
         kind: "move"
       });
@@ -19105,7 +19113,7 @@ async function runMigrationPass(compute, io) {
       result.leftovers += 1;
       result.failures.push({
         signature: `leftover|${op.originalPath}`,
-        name: basenameOf(op.originalPath),
+        name: baseName(op.originalPath),
         reason: "name-taken",
         kind: "leftover"
       });
@@ -19126,7 +19134,7 @@ async function runMigrationPass(compute, io) {
     } catch (e) {
       result.failures.push({
         signature: `frontmatter|${path}`,
-        name: basenameOf(path),
+        name: baseName(path),
         reason: e instanceof Error ? e.message : String(e),
         kind: "frontmatter"
       });
@@ -19155,7 +19163,7 @@ async function runRestorePass(compute, io) {
     } catch (e) {
       result.failures.push({
         signature: `restore|${op.fromPath}`,
-        name: basenameOf(op.fromPath),
+        name: baseName(op.fromPath),
         reason: e instanceof Error ? e.message : String(e),
         kind: "move"
       });
@@ -19173,7 +19181,7 @@ async function runRestorePass(compute, io) {
     } catch (e) {
       result.failures.push({
         signature: `restore|${op.fromPath}`,
-        name: basenameOf(op.fromPath),
+        name: baseName(op.fromPath),
         reason: e instanceof Error ? e.message : String(e),
         kind: "folder"
       });

--- a/models/BinderItem.ts
+++ b/models/BinderItem.ts
@@ -1,5 +1,9 @@
 export type BinderItemType = 'chapter' | 'section' | 'article' | 'note' | 'group' | 'part';
-export type DocumentStatus = 'draft' | 'in-progress' | 'complete' | 'published';
+
+// The lifecycle states in order — the single source for what counts as a
+// valid `binder-status` value; the color table below is keyed off it.
+export const DOCUMENT_STATUSES = ['draft', 'in-progress', 'complete', 'published'] as const;
+export type DocumentStatus = (typeof DOCUMENT_STATUSES)[number];
 
 export interface BinderItem {
   id: string;
@@ -25,11 +29,4 @@ export const STATUS_COLORS: Record<DocumentStatus, string> = {
   'in-progress': '#f59e0b',
   complete: '#10b981',
   published: '#3b82f6',
-};
-
-export const STATUS_LABELS: Record<DocumentStatus, string> = {
-  draft: 'Draft',
-  'in-progress': 'In Progress',
-  complete: 'Complete',
-  published: 'Published',
 };

--- a/src/FilesystemBinderView.ts
+++ b/src/FilesystemBinderView.ts
@@ -5,7 +5,7 @@ import { STATUS_COLORS, DocumentStatus } from '../models/BinderItem';
 import { inManuscriptZone } from './manuscriptTree';
 import { SiblingEntry, sortSiblings, entryDisplayName, isHiddenName, parseBinderOrder } from './binderOrder';
 import { BinderZone, DropRegion, DragSource, MoveEntry, MoveOp, dropRegion, canStartDrag, evaluateDrop, planMove } from './binderMove';
-import { BinderDocType, BINDER_TYPES, ItemNameRejection, menuActionsFor, parseBinderStatus, parseBinderType, renamePrefill, renameTargetName, validateItemName } from './binderMenu';
+import { BinderDocType, BINDER_TYPES, ItemNameRejection, menuActionsFor, parseBinderCompile, parseBinderStatus, parseBinderType, renamePrefill, renameTargetName, validateItemName } from './binderMenu';
 import { ProjectModal } from '../modals/ProjectModal';
 import { TargetsDashboardModal } from '../modals/TargetsDashboardModal';
 import { TitlePromptModal } from '../modals/TitlePromptModal';
@@ -369,7 +369,7 @@ export class FilesystemBinderView extends ItemView {
       displayName: entryDisplayName(entry),
       status,
       docType: parseBinderType(fm?.['binder-type']),
-      compileExcluded: fm?.['binder-compile'] === false,
+      compileExcluded: !parseBinderCompile(fm?.['binder-compile']),
       fmLines,
       children: [],
       mdCount: 0,

--- a/src/ProjectManager.ts
+++ b/src/ProjectManager.ts
@@ -11,6 +11,7 @@ import {
   baseName,
   parentPath,
   pathAtOrUnder,
+  replaceIllegalNameChars,
   rewritePathPrefix,
 } from './folderRename';
 
@@ -84,7 +85,7 @@ export class ProjectManager extends Events {
   ): Promise<WritingProject> {
     const rootFolder = this.plugin.settings.defaultProjectFolder || 'Writing Projects';
     const id = this.uniqueId('project');
-    const folderName = title.replace(/[\\/:*?"<>|]/g, '-');
+    const folderName = replaceIllegalNameChars(title, '-');
     const folderPath = normalizePath(`${rootFolder}/${folderName}`);
 
     // Refuse rather than scaffold into an existing folder — writing into one

--- a/src/binderMenu.ts
+++ b/src/binderMenu.ts
@@ -3,8 +3,9 @@
 // what on-disk name a typed value produces, and how names validate.
 
 import { SiblingEntry, parseFolderPrefix, folderNameWithPrefix, entryDisplayName } from './binderOrder';
-import { BinderZone } from './binderMove';
-import { DocumentStatus, STATUS_COLORS } from '../models/BinderItem';
+import type { BinderZone } from './binderMove';
+import { DocumentStatus, DOCUMENT_STATUSES } from '../models/BinderItem';
+import { NameTextRejection, rejectNameText } from './folderRename';
 
 export type MenuAction =
   | 'rename' | 'status' | 'goal' | 'type' | 'compile'
@@ -22,9 +23,15 @@ export function parseBinderType(value: unknown): BinderDocType | null {
 }
 
 export function parseBinderStatus(value: unknown): DocumentStatus | null {
-  return typeof value === 'string' && value in STATUS_COLORS
+  return typeof value === 'string' && (DOCUMENT_STATUSES as readonly string[]).includes(value)
     ? (value as DocumentStatus)
     : null;
+}
+
+// `binder-compile: false` is the only exclusion form; any other value —
+// absent, true, junk — compiles (#229: re-include deletes the key).
+export function parseBinderCompile(value: unknown): boolean {
+  return value !== false;
 }
 
 // Rulings on #229: Exports rows are delete-only (the zone is output-only);
@@ -71,7 +78,7 @@ export function renameTargetName(entry: SiblingEntry, typed: string): string {
   return typed.toLowerCase().endsWith(suffix.toLowerCase()) ? typed : typed + suffix;
 }
 
-export type ItemNameRejection = 'empty' | 'invalid-chars' | 'trailing' | 'exists';
+export type ItemNameRejection = NameTextRejection | 'exists';
 
 export interface ItemNameVerdict {
   ok: boolean;
@@ -89,9 +96,8 @@ export function validateItemName(
   targetName: string,
   siblingNames: string[],
 ): ItemNameVerdict {
-  if (typed.trim() === '') return { ok: false, reason: 'empty' };
-  if (/[\\/:*?"<>|]/.test(typed)) return { ok: false, reason: 'invalid-chars' };
-  if (/[. ]$/.test(typed)) return { ok: false, reason: 'trailing' };
+  const text = rejectNameText(typed);
+  if (text !== null) return { ok: false, reason: text };
   const lower = targetName.toLowerCase();
   if (siblingNames.some(n => n.toLowerCase() === lower)) return { ok: false, reason: 'exists' };
   return { ok: true };

--- a/src/binderMove.ts
+++ b/src/binderMove.ts
@@ -9,6 +9,7 @@
 // subtree, and only markdown documents cross between manuscript and Research.
 
 import { SiblingEntry, canCarryOrder, planReorder, folderNameWithPrefix } from './binderOrder';
+import { joinPath, parentPath, pathAtOrUnder } from './folderRename';
 
 export type BinderZone = 'manuscript' | 'research' | 'exports';
 export type DropRegion = 'before' | 'after' | 'into';
@@ -53,7 +54,7 @@ export function evaluateDrop(source: DragSource, destParentPath: string, destZon
   if (source.isFolder && destZone !== source.zone) {
     return { kind: 'notice', messageKey: 'binder.fs.folderZoneBlocked' };
   }
-  if (source.isFolder && (destParentPath === source.path || destParentPath.startsWith(source.path + '/'))) {
+  if (source.isFolder && pathAtOrUnder(destParentPath, source.path)) {
     return { kind: 'refuse' };
   }
   return { kind: 'accept' };
@@ -67,15 +68,6 @@ export interface MoveEntry extends SiblingEntry {
 export type MoveOp =
   | { kind: 'rename'; path: string; newPath: string }
   | { kind: 'set-order'; path: string; order: number };
-
-function parentOf(path: string): string {
-  const i = path.lastIndexOf('/');
-  return i < 0 ? '' : path.slice(0, i);
-}
-
-function joinPath(parent: string, name: string): string {
-  return parent ? `${parent}/${name}` : name;
-}
 
 // Turns a drop into the minimal operation list. destSiblings is the
 // destination group in binder order, excluding the source; insertAt is the
@@ -120,7 +112,7 @@ export function planMove(
     if (entry.isFolder) {
       const newName = folderNameWithPrefix(entry.name, w.order);
       if (newName === entry.name) continue;
-      ops.push({ kind: 'rename', path: entry.path, newPath: joinPath(parentOf(entry.path), newName) });
+      ops.push({ kind: 'rename', path: entry.path, newPath: joinPath(parentPath(entry.path), newName) });
     } else {
       ops.push({ kind: 'set-order', path: entry.path, order: w.order });
     }

--- a/src/carryOver.ts
+++ b/src/carryOver.ts
@@ -22,6 +22,10 @@
 import { BinderData, BinderItem } from '../models/BinderItem';
 import { parseFolderPrefix, folderNameWithPrefix, naturalCompare } from './binderOrder';
 import { parseBinderStatus, parseBinderType } from './binderMenu';
+import {
+  baseName, parentPath, pathAtOrUnder, pathStrictlyUnder,
+  replaceIllegalNameChars, stripTrailingDotsAndSpaces,
+} from './folderRename';
 
 // The one window onto the vault the engine is allowed: existence checks and
 // frontmatter reads. No handle that could write is ever passed in.
@@ -50,11 +54,8 @@ export function parseLegacyBinder(content: string): BinderData | null {
 // component: illegal characters deleted, whitespace runs collapsed, trailing
 // dots and spaces stripped. Documents never pass through here.
 export function sanitizeTitle(title: string): string {
-  return title
-    .replace(/[\\/:*?"<>|]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/[. ]+$/, '');
+  return stripTrailingDotsAndSpaces(
+    replaceIllegalNameChars(title, '').replace(/\s+/g, ' ').trim());
 }
 
 export interface CarryOverFmEntry {
@@ -69,7 +70,6 @@ export interface CarryOverFmEntry {
 export type FolderAction = 'none' | 'create' | 'attach-marker';
 
 export interface CarryOverFolderOp {
-  kind: 'folder';
   legacyTitle: string;
   displayName: string;
   /** On-disk path today (attach-marker only). */
@@ -85,7 +85,6 @@ export interface CarryOverFolderOp {
 export type DocState = 'done' | 'pending' | 'leftover' | 'missing';
 
 export interface CarryOverDocOp {
-  kind: 'doc';
   originalPath: string;
   finalPath: string;
   state: DocState;
@@ -104,7 +103,7 @@ export interface CarryOverPlan {
 
 // Where a document's frontmatter belongs right now: a pending document is
 // still at its original path; done lives at final; a leftover stays put.
-export function docCurrentPath(op: CarryOverDocOp): string | null {
+function docCurrentPath(op: CarryOverDocOp): string | null {
   if (op.state === 'missing') return null;
   return op.state === 'done' ? op.finalPath : op.originalPath;
 }
@@ -147,7 +146,14 @@ export function planCarryOver(
   return plan;
 }
 
-const parentOf = (path: string): string => path.split('/').slice(0, -1).join('/');
+// Marker-carrying names adopt first, then natural order — the tiebreak
+// shared by structural adoption and content-folder matching (#276).
+const compareAdoptionCandidates = (a: string, b: string): number => {
+  const aMarked = parseFolderPrefix(a).order !== null;
+  const bMarked = parseFolderPrefix(b).order !== null;
+  if (aMarked !== bMarked) return aMarked ? -1 : 1;
+  return naturalCompare(a, b);
+};
 
 // #263: a physical folder the legacy binder recorded documents inside is
 // invisible to the legacy file as an item — the classic binder was a flat
@@ -178,7 +184,7 @@ function planContentFolders(
   const blocked = new Set<string>();
   for (const op of plan.docOps) {
     if ((op.state === 'pending' || op.state === 'leftover') && op.originalPath !== '') {
-      blocked.add(parentOf(op.originalPath));
+      blocked.add(parentPath(op.originalPath));
     }
   }
 
@@ -189,35 +195,29 @@ function planContentFolders(
   for (const op of plan.docOps) {
     if (op.state !== 'done') continue;
     if (op.originalPath === '') continue;
-    const recordedParent = parentOf(op.originalPath);
+    const recordedParent = parentPath(op.originalPath);
     if (blocked.has(recordedParent)) continue;
-    if (!(recordedParent.length > projectFolderPath.length
-        && recordedParent.startsWith(projectFolderPath + '/'))) continue;
+    if (!pathStrictlyUnder(recordedParent, projectFolderPath)) continue;
     // Same sibling group: the document's order lands where the folder sits
-    if (parentOf(op.finalPath) !== parentOf(recordedParent)) continue;
+    if (parentPath(op.finalPath) !== parentPath(recordedParent)) continue;
     const current = earliest.get(recordedParent);
     if (current === undefined || op.order < current) earliest.set(recordedParent, op.order);
   }
 
   for (const [recordedParent, position] of [...earliest.entries()].sort()) {
-    const parent = parentOf(recordedParent);
-    const plainName = recordedParent.split('/').pop() as string;
+    const parent = parentPath(recordedParent);
+    const plainName = baseName(recordedParent);
     const candidates = disk.subfolderNames(parent).filter(n =>
       !claimed.has(`${parent}/${n}`) &&
       parseFolderPrefix(n).displayName.toLowerCase() === plainName.toLowerCase());
     if (candidates.length === 0) continue; // folder gone or renamed — never guess
-    candidates.sort((a, b) => {
-      const aMarked = parseFolderPrefix(a).order !== null;
-      const bMarked = parseFolderPrefix(b).order !== null;
-      if (aMarked !== bMarked) return aMarked ? -1 : 1;
-      return naturalCompare(a, b);
-    });
+    candidates.sort(compareAdoptionCandidates);
     const name = candidates[0];
     claimed.add(`${parent}/${name}`);
 
     if (parseFolderPrefix(name).order !== null) {
       plan.folderOps.push({
-        kind: 'folder', legacyTitle: plainName,
+        legacyTitle: plainName,
         displayName: parseFolderPrefix(name).displayName,
         currentPath: null, targetName: name,
         targetPath: `${parent}/${name}`, action: 'none',
@@ -226,7 +226,7 @@ function planContentFolders(
     }
     const attached = folderNameWithPrefix(name, position - 5);
     plan.folderOps.push({
-      kind: 'folder', legacyTitle: plainName, displayName: name,
+      legacyTitle: plainName, displayName: name,
       currentPath: `${parent}/${name}`, targetName: attached,
       targetPath: `${parent}/${attached}`, action: 'attach-marker',
     });
@@ -281,24 +281,21 @@ function planFolder(
     parseFolderPrefix(n).displayName.toLowerCase() === displayName.toLowerCase());
   candidates.sort((a, b) => {
     if ((a === minted) !== (b === minted)) return a === minted ? -1 : 1;
-    const aMarked = parseFolderPrefix(a).order !== null;
-    const bMarked = parseFolderPrefix(b).order !== null;
-    if (aMarked !== bMarked) return aMarked ? -1 : 1;
-    return naturalCompare(a, b);
+    return compareAdoptionCandidates(a, b);
   });
   const adopted = candidates.length > 0 ? candidates[0] : null;
   if (adopted !== null) consumedAdoptees.add(adopted);
 
   if (adopted === null) {
     return {
-      kind: 'folder', legacyTitle: item.title, displayName,
+      legacyTitle: item.title, displayName,
       currentPath: null, targetName: minted,
       targetPath: `${parentPath}/${minted}`, action: 'create',
     };
   }
   if (parseFolderPrefix(adopted).order !== null) {
     return {
-      kind: 'folder', legacyTitle: item.title, displayName,
+      legacyTitle: item.title, displayName,
       currentPath: null, targetName: adopted,
       targetPath: `${parentPath}/${adopted}`, action: 'none',
     };
@@ -307,7 +304,7 @@ function planFolder(
   // The attached name reuses the folder's own typed text, not the title.
   const attached = folderNameWithPrefix(adopted, position);
   return {
-    kind: 'folder', legacyTitle: item.title, displayName,
+    legacyTitle: item.title, displayName,
     currentPath: `${parentPath}/${adopted}`, targetName: attached,
     targetPath: `${parentPath}/${attached}`, action: 'attach-marker',
   };
@@ -321,7 +318,7 @@ function planDoc(
   claimedBasenames: Set<string>,
 ): CarryOverDocOp {
   const originalPath = (item.filePath || '').replace(/\\/g, '/');
-  const basename = originalPath.split('/').pop() ?? '';
+  const basename = baseName(originalPath);
   const finalPath = `${parentPath}/${basename}`;
 
   const atOriginal = originalPath !== '' && disk.fileExists(originalPath);
@@ -350,7 +347,6 @@ function planDoc(
   const kept = (k: string): boolean => fm[k] !== undefined && fm[k] !== null;
 
   return {
-    kind: 'doc',
     originalPath,
     finalPath,
     state,
@@ -388,7 +384,7 @@ function assignLeftoverOrders(plan: CarryOverPlan, disk: DiskState): void {
   const positions = new Map<string, number>();
   for (const op of plan.docOps) {
     if (op.state !== 'leftover') continue;
-    const parent = op.originalPath.split('/').slice(0, -1).join('/');
+    const parent = parentPath(op.originalPath);
     const next = (positions.get(parent) ?? 0) + 10;
     positions.set(parent, next);
     op.order = next;
@@ -403,7 +399,6 @@ function assignLeftoverOrders(plan: CarryOverPlan, disk: DiskState): void {
 // deleted — a folder migration created stays behind (empty) because it is
 // statelessly indistinguishable from a pre-existing adopted folder.
 export interface RestoreDocOp {
-  kind: 'restore-doc';
   /** Where migration put it (or would have). */
   fromPath: string;
   /** The legacy home it returns to. */
@@ -415,7 +410,6 @@ export interface RestoreDocOp {
 }
 
 export interface RestoreFolderOp {
-  kind: 'restore-folder';
   /** Marker-carrying path today. */
   fromPath: string;
   /** Same folder with the marker stripped. */
@@ -455,11 +449,10 @@ export function planRestore(
     if (op.action !== 'none') continue;
     const parsed = parseFolderPrefix(op.targetName);
     if (parsed.order === null) continue; // adopted plain folder — no marker to strip
-    const parent = parentOf(op.targetPath);
+    const parent = parentPath(op.targetPath);
     const toPath = `${parent}/${parsed.displayName}`;
     const occupied = disk.folderExists(toPath) || disk.fileExists(toPath);
     folderOps.push({
-      kind: 'restore-folder',
       fromPath: op.targetPath,
       toPath,
       state: occupied ? 'skipped' : 'pending',
@@ -503,7 +496,6 @@ export function planRestore(
       skipReason = 'not-found';
     }
     docOps.push({
-      kind: 'restore-doc',
       fromPath: op.finalPath,
       toPath,
       ensureFolders: ancestorsWithin(toPath, projectFolderPath),
@@ -524,7 +516,7 @@ function ancestorsWithin(filePath: string, projectFolderPath: string): string[] 
   let path = '';
   for (const part of parts) {
     path = path === '' ? part : `${path}/${part}`;
-    if (path.length > projectFolderPath.length && path.startsWith(projectFolderPath + '/')) {
+    if (pathStrictlyUnder(path, projectFolderPath)) {
       out.push(path);
     }
   }
@@ -558,8 +550,6 @@ export interface PassResult {
   missing: number;
 }
 
-const basenameOf = (path: string): string => path.split('/').pop() ?? path;
-
 // The migration pass (R3): folders → recompute → moves → recompute →
 // frontmatter. Recomputing between phases means no operation ever acts on a
 // path a previous phase changed. Per-item try/catch; a failed folder skips
@@ -571,7 +561,7 @@ export async function runMigrationPass(
   const result: PassResult = { changed: 0, failures: [], leftovers: 0, missing: 0 };
   const failedRoots: string[] = [];
   const underFailedRoot = (path: string): boolean =>
-    failedRoots.some(root => path === root || path.startsWith(root + '/'));
+    failedRoots.some(root => pathAtOrUnder(path, root));
   // Every folder op attempted this run, success or failure — a re-plan sees
   // successes as 'none', and failures must not retry within the run (the
   // graduated notice ledger counts runs, not attempts).
@@ -613,7 +603,7 @@ export async function runMigrationPass(
   const afterFolders = compute();
   for (const op of afterFolders.plan.docOps) {
     if (op.state !== 'pending') continue;
-    const targetParent = op.finalPath.split('/').slice(0, -1).join('/');
+    const targetParent = parentPath(op.finalPath);
     // Dependency skip: the parent's own failure already carries the notice
     if (!afterFolders.disk.folderExists(targetParent)) continue;
     try {
@@ -622,7 +612,7 @@ export async function runMigrationPass(
     } catch (e) {
       result.failures.push({
         signature: `move|${op.originalPath}`,
-        name: basenameOf(op.originalPath),
+        name: baseName(op.originalPath),
         reason: e instanceof Error ? e.message : String(e),
         kind: 'move',
       });
@@ -642,7 +632,7 @@ export async function runMigrationPass(
       result.leftovers += 1;
       result.failures.push({
         signature: `leftover|${op.originalPath}`,
-        name: basenameOf(op.originalPath),
+        name: baseName(op.originalPath),
         reason: 'name-taken',
         kind: 'leftover',
       });
@@ -665,7 +655,7 @@ export async function runMigrationPass(
     } catch (e) {
       result.failures.push({
         signature: `frontmatter|${path}`,
-        name: basenameOf(path),
+        name: baseName(path),
         reason: e instanceof Error ? e.message : String(e),
         kind: 'frontmatter',
       });
@@ -714,7 +704,7 @@ export async function runRestorePass(
     } catch (e) {
       result.failures.push({
         signature: `restore|${op.fromPath}`,
-        name: basenameOf(op.fromPath),
+        name: baseName(op.fromPath),
         reason: e instanceof Error ? e.message : String(e),
         kind: 'move',
       });
@@ -741,7 +731,7 @@ export async function runRestorePass(
     } catch (e) {
       result.failures.push({
         signature: `restore|${op.fromPath}`,
-        name: basenameOf(op.fromPath),
+        name: baseName(op.fromPath),
         reason: e instanceof Error ? e.message : String(e),
         kind: 'folder',
       });

--- a/src/exportTitle.ts
+++ b/src/exportTitle.ts
@@ -2,6 +2,8 @@
 // and the choice resolves to a single string that names the export everywhere —
 // filename, title page, and file metadata. Pure module, no Obsidian imports.
 
+import { replaceIllegalNameChars } from './folderRename';
+
 export type ExportTitleChoice = 'folder' | 'project-folder' | 'project' | 'custom';
 
 export interface ExportTitleContext {
@@ -40,5 +42,5 @@ export function resolveExportTitle(choice: ExportTitleChoice, ctx: ExportTitleCo
 // The title as it appears in the export's filename — reserved path characters
 // become hyphens; the title is otherwise kept verbatim.
 export function sanitizeTitleForFilename(title: string): string {
-  return title.replace(/[\\/:*?"<>|]/g, '-');
+  return replaceIllegalNameChars(title, '-');
 }

--- a/src/folderRename.ts
+++ b/src/folderRename.ts
@@ -33,10 +33,19 @@ export function parentPath(path: string): string {
   return i === -1 ? '' : path.slice(0, i);
 }
 
+export function joinPath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name;
+}
+
 // Segment-boundary prefix test: 'A/Chapters' covers 'A/Chapters/Ch 1.md' and
 // itself, but never 'A/Chapters-old/x.md'.
 export function pathAtOrUnder(path: string, prefix: string): boolean {
   return path === prefix || path.startsWith(prefix + '/');
+}
+
+// Same boundary, but the prefix itself does not count.
+export function pathStrictlyUnder(path: string, prefix: string): boolean {
+  return path.startsWith(prefix + '/');
 }
 
 export function rewritePathPrefix(path: string, oldPrefix: string, newPrefix: string): string {
@@ -45,7 +54,42 @@ export function rewritePathPrefix(path: string, oldPrefix: string, newPrefix: st
   return path;
 }
 
-export type FolderNameRejection = 'empty' | 'invalid-chars' | 'trailing' | 'reserved' | 'exists';
+// The Windows-illegal filename character class — single home (#276). A test
+// regex and a global replace regex kept separate so .test() never carries
+// lastIndex state.
+const ILLEGAL_NAME_CHARS = /[\\/:*?"<>|]/;
+const ILLEGAL_NAME_CHARS_ALL = /[\\/:*?"<>|]/g;
+
+export function hasIllegalNameChars(name: string): boolean {
+  return ILLEGAL_NAME_CHARS.test(name);
+}
+
+export function replaceIllegalNameChars(name: string, replacement: string): string {
+  return name.replace(ILLEGAL_NAME_CHARS_ALL, replacement);
+}
+
+// Windows also rejects names ending in a dot or space.
+export function hasTrailingDotOrSpace(name: string): boolean {
+  return /[. ]$/.test(name);
+}
+
+export function stripTrailingDotsAndSpaces(name: string): string {
+  return name.replace(/[. ]+$/, '');
+}
+
+export type NameTextRejection = 'empty' | 'invalid-chars' | 'trailing';
+
+// The text checks every typed name passes before any context rule (reserved
+// names, sibling collisions) applies — the shared core of validateItemName
+// and validateDocumentFolderName (#276).
+export function rejectNameText(name: string): NameTextRejection | null {
+  if (name.trim() === '') return 'empty';
+  if (hasIllegalNameChars(name)) return 'invalid-chars';
+  if (hasTrailingDotOrSpace(name)) return 'trailing';
+  return null;
+}
+
+export type FolderNameRejection = NameTextRejection | 'reserved' | 'exists';
 
 export interface FolderNameVerdict {
   ok: boolean;
@@ -62,9 +106,8 @@ export function validateDocumentFolderName(
   currentName: string,
   targetExists: boolean,
 ): FolderNameVerdict {
-  if (name.trim() === '') return { ok: false, reason: 'empty' };
-  if (/[\\/:*?"<>|]/.test(name)) return { ok: false, reason: 'invalid-chars' };
-  if (/[. ]$/.test(name)) return { ok: false, reason: 'trailing' };
+  const text = rejectNameText(name);
+  if (text !== null) return { ok: false, reason: text };
   if (isReservedFolderName(name)) {
     return { ok: false, reason: 'reserved' };
   }

--- a/src/manuscriptTree.ts
+++ b/src/manuscriptTree.ts
@@ -1,6 +1,7 @@
 import { App, TFile, TFolder } from 'obsidian';
 import { isReservedFolderName } from './folderRename';
 import { isHiddenName, parseBinderOrder, parseFolderPrefix, sortSiblings } from './binderOrder';
+import { parseBinderCompile } from './binderMenu';
 
 // The manuscript zone as data, for consumers outside the view: the same tree
 // FilesystemBinderView renders — depth-first, in binder order, hidden names
@@ -86,7 +87,7 @@ export function buildManuscriptTree(
           kind: 'doc',
           path: s.file.path,
           title: s.file.name.slice(0, s.file.name.length - s.file.extension.length - 1),
-          compileExcluded: fm?.['binder-compile'] === false,
+          compileExcluded: !parseBinderCompile(fm?.['binder-compile']),
         });
       }
     }


### PR DESCRIPTION
Closes #276. All eight items, mechanical, no behavior change — 393 tests pass **unmodified**, lint clean, production build.

**Path/validation consolidation**
1. `baseName`/`parentPath` imported from folderRename everywhere (carryOver''s local `parentOf`, `basenameOf`, and three inline splits; binderMove''s local `parentOf`); one exported `joinPath`.
2. Segment-boundary tests reuse `pathAtOrUnder` (carryOver''s `underFailedRoot`, binderMove''s own-subtree refusal); new `pathStrictlyUnder` sibling replaces the two strictly-under inlines.
3. The Windows-illegal-character class and trailing-dot/space rule live once in folderRename (`hasIllegalNameChars`/`replaceIllegalNameChars`, `hasTrailingDotOrSpace`/`stripTrailingDotsAndSpaces`), consumed by carryOver, binderMenu, exportTitle — **and a fifth site the issue missed: ProjectManager''s project-folder-name sanitizer**, same class, same replacement, included as the same consolidation.
4. Shared validation core `rejectNameText` (empty → invalid-chars → trailing); `validateItemName` and `validateDocumentFolderName` wrap it. Public signatures and rejection unions unchanged.

**Consistency leftovers**
5. `parseBinderCompile` added beside the other parsers; both `=== false` inlines (FilesystemBinderView, manuscriptTree) consume it.
6. `DOCUMENT_STATUSES` array exported from the model; `DocumentStatus` derives from it and `parseBinderStatus` keys off it (was keyed off the UI color table); dead `STATUS_LABELS` deleted (zero importers).
7. carryOver plan-op `kind` literal discriminants deleted (nothing read them — verified across src and tests); `docCurrentPath` un-exported (internal use only, no test imports it).
8. Marker-aware adoption tiebreak extracted as `compareAdoptionCandidates`, shared by `planContentFolders` and `planFolder` (the latter keeps its exact-minted-name first clause).

Note on imports: binderMenu''s `BinderZone` import is now `import type`, so the new binderMove → folderRename → binderMenu edge stays erased at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)