### PR TITLE
test: execute real planMove plans through the view's executor (#268)

### DIFF
--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -111,3 +111,35 @@ export class Modal {
   onOpen(): void {}
   onClose(): void {}
 }
+
+export class FuzzySuggestModal extends Modal {}
+
+export class TAbstractFile {}
+
+// Minimal view base so view modules load and construct; the app rides in on
+// the leaf, as in the real API. Rendering is never driven in tests.
+export class ItemView extends Component {
+  leaf: unknown;
+  app: unknown;
+  constructor(leaf: unknown) {
+    super();
+    this.leaf = leaf;
+    this.app = (leaf as { app?: unknown } | undefined)?.app;
+  }
+  registerEvent(_ref?: unknown): void {}
+  registerDomEvent(): void {}
+}
+
+export class Menu {
+  addItem(): this {
+    return this;
+  }
+  addSeparator(): this {
+    return this;
+  }
+  showAtMouseEvent(): void {}
+}
+
+export function setIcon(): void {}
+
+export function setTooltip(): void {}

--- a/tests/binderMoveExec.test.ts
+++ b/tests/binderMoveExec.test.ts
@@ -1,0 +1,161 @@
+// Move-plan execution through the view's real executor (#268). planMove is
+// unit-tested as a pure planner; these tests feed its actual output through
+// FilesystemBinderView.executeMove against an in-memory vault, locking the
+// two #228 guarantees that had no execution-level coverage: every rename
+// goes through fileManager.renameFile (one atomic op per move — links heal,
+// a folder carries its subtree), and a failure stops the plan without
+// leaving the failed operation half-applied.
+
+import { Notice, WorkspaceLeaf } from 'obsidian';
+import type WritingStudioPlugin from '../main';
+import { FilesystemBinderView } from '../src/FilesystemBinderView';
+import { planMove, MoveEntry, MoveOp } from '../src/binderMove';
+import { FakeVaultApp } from './fakeVaultApp';
+
+const basename = (path: string) => path.slice(path.lastIndexOf('/') + 1);
+
+const doc = (path: string, binderOrder: number | null = null): MoveEntry => ({
+  path,
+  name: basename(path),
+  isFolder: false,
+  extension: 'md',
+  binderOrder,
+});
+
+const folder = (path: string, binderOrder: number | null = null): MoveEntry => ({
+  path,
+  name: basename(path),
+  isFolder: true,
+  binderOrder,
+});
+
+function makeView(fake: FakeVaultApp): FilesystemBinderView {
+  const leaf = { app: fake.app() } as unknown as WorkspaceLeaf;
+  return new FilesystemBinderView(leaf, {} as unknown as WritingStudioPlugin);
+}
+
+async function execute(view: FilesystemBinderView, ops: MoveOp[]): Promise<void> {
+  await view['executeMove'](ops);
+}
+
+beforeEach(() => {
+  Notice.messages = [];
+});
+
+describe('executeMove runs a real planMove plan against the vault', () => {
+  it('moves a document in one rename and writes its order at the post-move path', async () => {
+    const fake = new FakeVaultApp();
+    fake.file('P/010~ Part/A.md', { 'binder-order': 10 });
+    fake.file('P/C.md');
+    const view = makeView(fake);
+
+    const ops = planMove(doc('P/C.md'), 'P/010~ Part', [doc('P/010~ Part/A.md', 10)], 'end', true);
+    await execute(view, ops);
+
+    expect(fake.byPath.has('P/C.md')).toBe(false);
+    expect(fake.frontmatterAt('P/010~ Part/C.md')).toEqual({ 'binder-order': 20 });
+    expect(fake.renameLog).toEqual(['P/C.md -> P/010~ Part/C.md']);
+    expect(Notice.messages).toEqual([]);
+  });
+
+  it('moves a folder with its new marker as ONE rename that carries the subtree', async () => {
+    const fake = new FakeVaultApp();
+    fake.file('P/005~ Part/Ch 1.md');
+    fake.file('P/Book/A.md', { 'binder-order': 10 });
+    const view = makeView(fake);
+
+    const ops = planMove(folder('P/005~ Part', 5), 'P/Book', [doc('P/Book/A.md', 10)], 'end', true);
+    await execute(view, ops);
+
+    // One atomic fileManager.renameFile — move and prefix folded, links heal,
+    // no intermediate location ever existed for the document inside.
+    expect(fake.renameLog).toEqual(['P/005~ Part -> P/Book/020~ Part']);
+    expect(fake.byPath.has('P/Book/020~ Part/Ch 1.md')).toBe(true);
+    expect(fake.byPath.has('P/005~ Part')).toBe(false);
+    expect(Notice.messages).toEqual([]);
+  });
+
+  it('executes a materialization plan across documents and folders', async () => {
+    const fake = new FakeVaultApp();
+    fake.file('P/Book/A.md');
+    fake.file('P/Book/Part/Ch 1.md');
+    fake.file('P/D.md');
+    const view = makeView(fake);
+
+    // Unordered destination group: the drop materializes the whole group.
+    const ops = planMove(doc('P/D.md'), 'P/Book', [doc('P/Book/A.md'), folder('P/Book/Part')], 'end', true);
+    await execute(view, ops);
+
+    expect(fake.frontmatterAt('P/Book/D.md')).toEqual({ 'binder-order': 30 });
+    expect(fake.frontmatterAt('P/Book/A.md')).toEqual({ 'binder-order': 10 });
+    expect(fake.byPath.has('P/Book/020~ Part')).toBe(true);
+    expect(fake.byPath.has('P/Book/020~ Part/Ch 1.md')).toBe(true);
+    expect(fake.renameLog).toEqual([
+      'P/D.md -> P/Book/D.md',
+      'P/Book/Part -> P/Book/020~ Part',
+    ]);
+    expect(Notice.messages).toEqual([]);
+  });
+});
+
+describe('executeMove failure semantics', () => {
+  it('a rename that throws stops the plan — nothing after it runs, the source stays put', async () => {
+    const fake = new FakeVaultApp();
+    fake.file('P/Book/A.md');
+    fake.file('P/Book/Part/Ch 1.md');
+    fake.file('P/D.md');
+    fake.file('P/Book/D.md'); // occupies the first op's destination
+    const view = makeView(fake);
+
+    const ops = planMove(doc('P/D.md'), 'P/Book', [doc('P/Book/A.md'), folder('P/Book/Part')], 'end', true);
+    await execute(view, ops);
+
+    // The failed rename applied nothing: the source is exactly where it was.
+    expect(fake.byPath.has('P/D.md')).toBe(true);
+    expect(fake.frontmatterAt('P/D.md')).toEqual({});
+    // Everything after the failure never ran.
+    expect(fake.frontmatterAt('P/Book/A.md')).toEqual({});
+    expect(fake.byPath.has('P/Book/Part')).toBe(true);
+    expect(fake.byPath.has('P/Book/020~ Part')).toBe(false);
+    // One notice names the failure.
+    expect(Notice.messages).toHaveLength(1);
+    expect(Notice.messages[0]).toContain('EEXIST');
+  });
+
+  it('a late failure keeps the earlier atomic operations — nothing is half-moved', async () => {
+    const fake = new FakeVaultApp();
+    fake.file('P/Book/A.md');
+    fake.file('P/Book/Part/Ch 1.md');
+    fake.file('P/D.md');
+    fake.folder('P/Book/020~ Part'); // occupies the last op's destination
+    const view = makeView(fake);
+
+    const ops = planMove(doc('P/D.md'), 'P/Book', [doc('P/Book/A.md'), folder('P/Book/Part')], 'end', true);
+    await execute(view, ops);
+
+    // Ops before the failure landed whole.
+    expect(fake.frontmatterAt('P/Book/D.md')).toEqual({ 'binder-order': 30 });
+    expect(fake.frontmatterAt('P/Book/A.md')).toEqual({ 'binder-order': 10 });
+    // The failed folder rename applied nothing: subtree intact at the source.
+    expect(fake.byPath.has('P/Book/Part/Ch 1.md')).toBe(true);
+    expect(fake.byPath.has('P/Book/020~ Part/Ch 1.md')).toBe(false);
+    expect(Notice.messages).toHaveLength(1);
+  });
+
+  it('a file missing at execution time is skipped and the rest of the plan continues', async () => {
+    const fake = new FakeVaultApp();
+    fake.file('P/Book/A.md');
+    fake.file('P/Book/Part/Ch 1.md');
+    fake.file('P/D.md');
+    const view = makeView(fake);
+
+    const ops = planMove(doc('P/D.md'), 'P/Book', [doc('P/Book/A.md'), folder('P/Book/Part')], 'end', true);
+    // A.md vanishes between plan and execution (external delete).
+    fake.byPath.delete('P/Book/A.md');
+    await execute(view, ops);
+
+    expect(fake.frontmatterAt('P/Book/D.md')).toEqual({ 'binder-order': 30 });
+    expect(fake.byPath.has('P/Book/020~ Part')).toBe(true);
+    expect(Notice.messages).toEqual([]);
+  });
+});

--- a/tests/fakeVaultApp.ts
+++ b/tests/fakeVaultApp.ts
@@ -1,0 +1,104 @@
+// In-memory Obsidian app facade with real vault-tree semantics, for tests
+// that drive view-level code (the binder's move executor, model building):
+// a live TFile/TFolder object tree, fileManager.renameFile that carries a
+// folder's subtree and throws on collisions like the real vault, frontmatter
+// that rides the file object across renames, and vault/metadataCache events.
+
+import { App, Events, TFile, TFolder } from 'obsidian';
+
+export class FakeVaultApp {
+  byPath = new Map<string, TFile | TFolder>();
+  fm = new Map<TFile, Record<string, unknown>>();
+  /** Every fileManager.renameFile call, as `from -> to`. */
+  renameLog: string[] = [];
+  vaultEvents = new Events();
+  metaEvents = new Events();
+
+  private root = new TFolder('');
+
+  private parentFolder(path: string): TFolder {
+    const i = path.lastIndexOf('/');
+    if (i === -1) return this.root;
+    const parent = this.byPath.get(path.slice(0, i));
+    if (!(parent instanceof TFolder)) throw new Error(`ENOENT: parent missing for ${path}`);
+    return parent;
+  }
+
+  folder(path: string): TFolder {
+    const existing = this.byPath.get(path);
+    if (existing instanceof TFolder) return existing;
+    if (existing) throw new Error(`EEXIST: file at ${path}`);
+    const i = path.lastIndexOf('/');
+    if (i !== -1) this.folder(path.slice(0, i));
+    const created = new TFolder(path);
+    this.byPath.set(path, created);
+    this.parentFolder(path).children.push(created);
+    return created;
+  }
+
+  file(path: string, fm: Record<string, unknown> = {}): TFile {
+    if (this.byPath.has(path)) throw new Error(`EEXIST: ${path}`);
+    const i = path.lastIndexOf('/');
+    if (i !== -1) this.folder(path.slice(0, i));
+    const name = i === -1 ? path : path.slice(i + 1);
+    const dot = name.lastIndexOf('.');
+    const created = new TFile(path, dot === -1 ? '' : name.slice(dot + 1));
+    this.byPath.set(path, created);
+    this.parentFolder(path).children.push(created);
+    this.fm.set(created, fm);
+    return created;
+  }
+
+  frontmatterAt(path: string): Record<string, unknown> | undefined {
+    const f = this.byPath.get(path);
+    return f instanceof TFile ? this.fm.get(f) : undefined;
+  }
+
+  private repath(entry: TFile | TFolder, newPath: string): void {
+    this.byPath.delete(entry.path);
+    if (entry instanceof TFolder) {
+      for (const child of entry.children) {
+        this.repath(child, `${newPath}/${child.name}`);
+      }
+    }
+    entry.path = newPath;
+    entry.name = newPath.slice(newPath.lastIndexOf('/') + 1);
+    this.byPath.set(newPath, entry);
+  }
+
+  app(): App {
+    const facade = {
+      vault: {
+        getAbstractFileByPath: (path: string) => this.byPath.get(path) ?? null,
+        on: (name: string, cb: (...data: unknown[]) => unknown) => this.vaultEvents.on(name, cb),
+      },
+      metadataCache: {
+        getFileCache: (file: TFile) => {
+          const fm = this.fm.get(file);
+          return fm === undefined ? null : { frontmatter: fm };
+        },
+        on: (name: string, cb: (...data: unknown[]) => unknown) => this.metaEvents.on(name, cb),
+      },
+      fileManager: {
+        renameFile: async (file: TFile | TFolder, newPath: string) => {
+          this.renameLog.push(`${file.path} -> ${newPath}`);
+          if (this.byPath.has(newPath)) throw new Error(`EEXIST: target exists at ${newPath}`);
+          const oldPath = file.path;
+          const parent = this.parentFolder(newPath); // throws ENOENT like the vault
+          const oldParent = this.parentFolder(oldPath);
+          oldParent.children.splice(oldParent.children.indexOf(file), 1);
+          this.repath(file, newPath);
+          parent.children.push(file);
+          this.vaultEvents.trigger('rename', file, oldPath);
+        },
+        processFrontMatter: async (file: TFile, mutate: (fm: Record<string, unknown>) => void) => {
+          const fm = this.fm.get(file);
+          if (!fm) throw new Error(`ENOENT: no file at ${file.path}`);
+          mutate(fm);
+          this.metaEvents.trigger('changed', file);
+        },
+      },
+    };
+    return facade as unknown as App;
+  }
+}


### PR DESCRIPTION
Closes #268. Test-only — no production code changed; user-facing behavior and copy untouched.

planMove was tested only as a pure planner; its op lists were never executed. These tests feed real planMove output through the view's real `executeMove` against a new in-memory vault harness with real move semantics (subtree-carrying renames, EEXIST/ENOENT throws), locking the two #228 guarantees that had no execution-level coverage:

- **Links heal**: every rename is ONE `fileManager.renameFile` call — a document move is a single op, a folder's move and new order marker fold into a single atomic rename that carries its subtree (asserted via the harness rename log; the harness has no other rename path).
- **Nothing half-moved**: a rename that throws stops the plan — an early failure runs nothing after it and leaves the source exactly where it was; a late failure keeps the earlier atomic operations whole; a file missing at execution time is skipped and the rest continues. One notice per failed plan.

Supporting changes, all test-side:
- `tests/fakeVaultApp.ts`: in-memory Obsidian app facade with a live TFile/TFolder object tree, frontmatter that rides the file object across renames, and vault/metadataCache events — built to also serve the #266 half-migrated-render harness.
- `tests/__mocks__/obsidian.ts`: additive exports (ItemView, Menu, setIcon, setTooltip, FuzzySuggestModal, TAbstractFile) so view modules load in tests.

Tests 393 → 399 (27 suites), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)