### PR TITLE
chore(deps): Bump github/codeql-action init/autobuild/analyze to 4.37.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,15 +24,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: /language:javascript-typescript


### PR DESCRIPTION
Bumps all three `github/codeql-action` pins in `codeql.yml` from 4.37.0 (`99df26d`) to 4.37.1 (`7188fc3`) in one commit.

The CodeQL action refuses to run when init/autobuild/analyze are on mixed versions ("Loaded a configuration file for version X but running Y"), so the individual Dependabot PRs #298 and #302 can never pass CI — same pattern as #295 last round. No init PR was opened this round; this commit covers it. #298 and #302 will be closed as superseded.

The `upload-sarif` pin in `scorecard.yml` is isolated and merges on its own via #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)