### PR TITLE
fix: count Han and kana characters individually in word counts (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Writing Studio are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- Chinese and Japanese text is now counted correctly: every Han character and kana counts as one word (你好 = 2 words), the same convention Obsidian's own counter uses, with full-width punctuation (。、！) counting zero. The shared counter feeds every surface — status bar, word-count frontmatter, goals, sprints, stats, and the export title page — so all of them correct together. Existing Chinese and Japanese documents will show higher (accurate) counts on their next edit; goals set against the old undercounts may want revisiting. Korean and all spaced languages are unchanged. (#297)
+
+  > Thank you for taking the time to report this, and for the clear example — '你好' counting as one word instead of two pointed straight to the cause. You've made Writing Studio better for every writer working in Chinese and Japanese, and I'm grateful for it. The fix counts each Han character and kana on its own, the way Obsidian's own counter does, so your character counts will line up as you'd expect. Thanks again for helping strengthen the plugin. — Don
+
 ### Changed
 - Internal code consolidation, no behavior change: one shared home for path helpers, the illegal-filename-character rule, and the typed-name validation core; `binder-compile` gains a parser like the other frontmatter keys; the document status list is single-sourced. (#276)
 

--- a/main.js
+++ b/main.js
@@ -1276,7 +1276,10 @@ var Translator = class _Translator extends EventEmitter {
     const useOptionsReplaceForData = options.replace && !isString(options.replace);
     let data = useOptionsReplaceForData ? options.replace : options;
     if (useOptionsReplaceForData && typeof options.count !== "undefined") {
-      data.count = options.count;
+      data = {
+        ...data,
+        count: options.count
+      };
     }
     if (this.options.interpolation.defaultVariables) {
       data = {
@@ -1589,10 +1592,10 @@ var Interpolator = class {
     const skipOnVariables = ((_a2 = options == null ? void 0 : options.interpolation) == null ? void 0 : _a2.skipOnVariables) !== void 0 ? options.interpolation.skipOnVariables : this.options.interpolation.skipOnVariables;
     const todos = [{
       regex: this.regexpUnescape,
-      safeValue: (val) => regexSafe(val)
+      safeValue: (val) => val
     }, {
       regex: this.regexp,
-      safeValue: (val) => this.escapeValue ? regexSafe(this.escape(val)) : regexSafe(val)
+      safeValue: (val) => this.escapeValue ? this.escape(val) : val
     }];
     todos.forEach((todo) => {
       replaces = 0;
@@ -1616,9 +1619,9 @@ var Interpolator = class {
           value = makeString(value);
         }
         const safeValue = todo.safeValue(value);
-        str = str.replace(match[0], safeValue);
+        str = str.replace(match[0], regexSafe(safeValue));
         if (skipOnVariables) {
-          todo.regex.lastIndex += value.length;
+          todo.regex.lastIndex += safeValue.length;
           todo.regex.lastIndex -= match[0].length;
         } else {
           todo.regex.lastIndex = 0;
@@ -1669,7 +1672,7 @@ var Interpolator = class {
       clonedOptions = clonedOptions.replace && !isString(clonedOptions.replace) ? clonedOptions.replace : clonedOptions;
       clonedOptions.applyPostProcessor = false;
       delete clonedOptions.defaultValue;
-      const keyEndIndex = /{.*}/.test(match[1]) ? match[1].lastIndexOf("}") + 1 : match[1].indexOf(this.formatSeparator);
+      const keyEndIndex = /{.*}/s.test(match[1]) ? match[1].lastIndexOf("}") + 1 : match[1].indexOf(this.formatSeparator);
       if (keyEndIndex !== -1) {
         formatters = match[1].slice(keyEndIndex).split(this.formatSeparator).map((elem) => elem.trim()).filter(Boolean);
         match[1] = match[1].slice(0, keyEndIndex);
@@ -12176,10 +12179,14 @@ var import_obsidian13 = require("obsidian");
 
 // src/words.ts
 function countWords(content2) {
+  var _a2, _b2;
   const body = content2.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
   const stripped = body.replace(/```[\s\S]*?```/g, "").replace(/`[^`]*`/g, "").replace(/!\[.*?\]\(.*?\)/g, "").replace(/\[.*?\]\(.*?\)/g, "").replace(/#{1,6}\s/g, "").replace(/[*_~`]/g, "").replace(/\n/g, " ").trim();
   if (!stripped) return 0;
-  return stripped.split(/\s+/).filter((w) => w.length > 0).length;
+  const CJK_CHAR = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/gu;
+  const cjkCount = (_b2 = (_a2 = stripped.match(CJK_CHAR)) == null ? void 0 : _a2.length) != null ? _b2 : 0;
+  const residual = stripped.replace(CJK_CHAR, " ").replace(/[\u3000-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]/g, " ");
+  return cjkCount + residual.split(/\s+/).filter((w) => w.length > 0).length;
 }
 
 // src/FolderSidebarView.ts

--- a/src/words.ts
+++ b/src/words.ts
@@ -16,5 +16,19 @@ export function countWords(content: string): number {
     .trim();
 
   if (!stripped) return 0;
-  return stripped.split(/\s+/).filter(w => w.length > 0).length;
+
+  // Han and kana have no inter-word spaces; count each character as one word
+  // (the 字数 convention, matching Obsidian's core counter, #297). Hangul and
+  // all other scripts keep the whitespace-split path below.
+  const CJK_CHAR = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/gu;
+  const cjkCount = stripped.match(CJK_CHAR)?.length ?? 0;
+
+  // Counted characters and full-width CJK punctuation (。、！ U+3000–U+303F,
+  // fullwidth/halfwidth punctuation subranges of U+FF01–U+FF65) become word
+  // boundaries and count zero; fullwidth letters and digits fall through.
+  const residual = stripped
+    .replace(CJK_CHAR, ' ')
+    .replace(/[\u3000-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]/g, ' ');
+
+  return cjkCount + residual.split(/\s+/).filter(w => w.length > 0).length;
 }

--- a/tests/words.test.ts
+++ b/tests/words.test.ts
@@ -33,4 +33,42 @@ describe('countWords', () => {
   it('strips heading markers but counts heading text', () => {
     expect(countWords('# Chapter One\n\nbody')).toBe(3);
   });
+
+  // #297 — Han and kana count one word per character; Hangul and everything
+  // else stay whitespace-split; full-width CJK punctuation counts zero.
+  describe('CJK text (#297)', () => {
+    it('counts each Han character as one word', () => {
+      expect(countWords('你好')).toBe(2);
+      expect(countWords('你好世界')).toBe(4);
+    });
+
+    it('counts mixed Latin and Han text', () => {
+      expect(countWords('hello 你好世界 world')).toBe(6);
+    });
+
+    it('treats Han characters as boundaries inside a Latin run', () => {
+      expect(countWords('abc你好def')).toBe(4);
+    });
+
+    it('counts full-width punctuation as zero', () => {
+      expect(countWords('你好。')).toBe(2);
+      expect(countWords('你好。世界')).toBe(4);
+      expect(countWords('こんにちは、世界！')).toBe(7);
+    });
+
+    it('counts each kana character as one word', () => {
+      expect(countWords('こんにちは')).toBe(5);
+      expect(countWords('カタカナ')).toBe(4);
+      expect(countWords('日本語です。')).toBe(5);
+    });
+
+    it('keeps Hangul whitespace-split', () => {
+      expect(countWords('안녕하세요')).toBe(1);
+      expect(countWords('안녕 하세요')).toBe(2);
+    });
+
+    it('strips markdown before counting CJK text', () => {
+      expect(countWords('# 你好')).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #297.

Chinese and Japanese text has no inter-word spaces, so the whitespace-split counter in `src/words.ts` saw a whole unspaced run as one word ("你好" counted 1). Each Han character and kana now counts as one word — the 字数 convention, matching Obsidian core's counter — and full-width CJK punctuation (。、！) counts zero, acting as a boundary. Hangul and all spaced scripts are byte-identical to before, locked by the existing English fixtures passing unmodified.

Scripts are matched with Unicode script properties (`\p{Script=Han}` etc.), so every current and future extension block of Han/Hiragana/Katakana is covered without hand-listed ranges. Other unspaced scripts (Thai, Khmer, …) are deliberately out of scope — each carries its own counting convention and gets added on demand (maintainer ruling on #297 triage).

`countWords` is the single shared authority, so the status bar, `word-count` frontmatter, goals, sprints, stats, and export title page all correct together with no other source changes.

Tests: 405 → 412 (7 new, each AC example verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)