### PR TITLE
docs: clarify that the Notebook Navigator guard reads the API version

### DIFF
--- a/main.js
+++ b/main.js
@@ -19715,8 +19715,8 @@ var WritingStudioPlugin = class extends import_obsidian35.Plugin {
       void runSilentMigration(this);
       const nn = (_a2 = this.app.plugins.plugins["notebook-navigator"]) == null ? void 0 : _a2.api;
       if ((_b2 = nn == null ? void 0 : nn.menus) == null ? void 0 : _b2.registerFolderMenu) {
-        const nnMajor = parseInt(nn.getVersion().split(".")[0]);
-        if (nnMajor <= 2) {
+        const nnApiMajor = parseInt(nn.getVersion().split(".")[0]);
+        if (nnApiMajor <= 2) {
           this.nnFolderMenuDispose = nn.menus.registerFolderMenu(({ addItem, folder }) => {
             addItem((item) => {
               item.setTitle(t2("main.menu.openSidebar")).setIcon("folder").onClick(() => {

--- a/main.ts
+++ b/main.ts
@@ -44,7 +44,10 @@ import { WritingDashboardModal } from './modals/WritingDashboardModal';
 import { WordPressSite } from './models/WordPressSite';
 import { WritingModeType } from './models/WritingMode';
 
-// Minimal subset of the Notebook Navigator public API (v1.2–2.x) used by Writing Studio.
+// Minimal subset of the Notebook Navigator public API used by Writing Studio.
+// Versions here are NN's API version (currently 2.0.0), which is numbered
+// independently of the NN plugin release version — the plugin is on 3.x while
+// the API contract is still 2.x.
 // Full spec: https://github.com/johansan/notebook-navigator/blob/main/docs/api-reference.md
 interface NNMenuItem {
   setTitle(title: string): this;
@@ -356,11 +359,14 @@ export default class WritingStudioPlugin extends Plugin {
       void runSilentMigration(this);
 
       // Register folder context menu item in Notebook Navigator if installed.
-      // Guard on major version <= 2 per NN's stability policy (breaking changes require v3+).
+      // getVersion() returns NN's API version, NOT the NN plugin version. Guard on
+      // API major <= 2 per NN's stability policy: API 2.x is additive-only, and
+      // breaking changes to documented members require an API major bump. An NN
+      // plugin major bump on its own does not affect this guard.
       const nn = (this.app as AppWithPlugins).plugins.plugins['notebook-navigator']?.api;
       if (nn?.menus?.registerFolderMenu) {
-        const nnMajor = parseInt(nn.getVersion().split('.')[0]);
-        if (nnMajor <= 2) {
+        const nnApiMajor = parseInt(nn.getVersion().split('.')[0]);
+        if (nnApiMajor <= 2) {
           this.nnFolderMenuDispose = nn.menus.registerFolderMenu(({ addItem, folder }) => {
             addItem(item => {
               item.setTitle(t('main.menu.openSidebar')).setIcon('folder').onClick(() => { void this.openFolder(folder); });


### PR DESCRIPTION
`nn.getVersion()` returns Notebook Navigator'"'"'s **API** version, which is numbered independently of the NN **plugin** release version. The existing comments (`v1.2–2.x`, `major version <= 2`) read ambiguously as plugin versions.

That ambiguity is the risk this closes. NN the plugin shipped 3.0.0 on 2026-05-18 and is now at 3.2.4, while its documented API contract is still **2.0.0** (last API changelog entry 2026-03-07). The guard is therefore working correctly — `<= 2` passes and `registerFolderMenu` registers normally on NN 3.x. Read as plugin versions, the comments invite a future "fix" that would break a working integration.

Comment-only clarification plus a local rename `nnMajor` → `nnApiMajor`. No behavior change; the only `main.js` delta is the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)