### PR TITLE
docs: correct obsidian-dev-docs paths in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,13 @@ Before finishing any task, verify output does not violate plugin guidelines.
 
 
 
-\- @docs/obsidian-dev-docs/docs/plugins/releasing/plugin-guidelines.md
+\- @docs/obsidian-dev-docs/en/Plugins/Releasing/Plugin guidelines.md
 
-\- @docs/obsidian-dev-docs/docs/plugins/releasing/submit-your-plugin.md
+\- @docs/obsidian-dev-docs/en/Plugins/Releasing/Submit your plugin.md
 
-\- @docs/obsidian-dev-docs/docs/reference/
+\- @docs/obsidian-dev-docs/en/Plugins/Releasing/Submission requirements for plugins.md
+
+\- @docs/obsidian-dev-docs/en/Reference/
 
 
 


### PR DESCRIPTION
## Summary
The three reference-document paths in CLAUDE.md pointed at a `docs/obsidian-dev-docs/docs/plugins/...` layout that does not exist in the cache. The real layout is `en/Plugins/Releasing/` and `en/Reference/`.

- Corrected all three paths to the files that actually exist
- Added a fourth bullet for `Submission requirements for plugins.md` — the section claims to cover submission requirements, and that is the file where they (including the minAppVersion counsel) actually live

Docs-only; no source, build, or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)