### PR TITLE
chore(deps): bump GitHub Actions pins and dev dependencies (codeql-action 4.37.4, @codemirror/view 6.43.7, @types/node 26.1.2)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,15 +24,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning dashboard
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       },
       "devDependencies": {
         "@codemirror/state": "6.7.1",
-        "@codemirror/view": "6.43.6",
+        "@codemirror/view": "6.43.7",
         "@types/jest": "^30.0.0",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "esbuild": "0.28.1",
         "eslint-plugin-obsidianmd": "^0.4.1",
         "jest": "^30.4.2",
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.43.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
-      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "version": "6.43.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.7.tgz",
+      "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2253,9 +2253,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   },
   "overrides": {
     "@codemirror/state": "6.7.1",
-    "@codemirror/view": "6.43.6"
+    "@codemirror/view": "6.43.7"
   },
   "devDependencies": {
     "@codemirror/state": "6.7.1",
-    "@codemirror/view": "6.43.6",
+    "@codemirror/view": "6.43.7",
     "@types/jest": "^30.0.0",
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
     "esbuild": "0.28.1",
     "eslint-plugin-obsidianmd": "^0.4.1",
     "jest": "^30.4.2",


### PR DESCRIPTION
Bundles the six open Dependabot PRs into one commit.

## What changed

| Dependency | From | To |
|---|---|---|
| `github/codeql-action/init` | 4.37.3 | 4.37.4 |
| `github/codeql-action/autobuild` | 4.37.3 | 4.37.4 |
| `github/codeql-action/analyze` | 4.37.3 | 4.37.4 |
| `github/codeql-action/upload-sarif` | 4.37.3 | 4.37.4 |
| `@codemirror/view` (dev + override) | 6.43.6 | 6.43.7 |
| `@types/node` (dev) | 26.1.1 | 26.1.2 |

All four codeql-action pins move to SHA `f205ea1c3313d32999d8d6a48b4f6530d4437b38`.

## Why one PR

Two reasons, both established practice in this repo:

1. The codeql-action pins can never pass CI individually — the actions reject a mixed configuration ("Loaded a configuration file for version X but running Y"), so all four must move in the same commit.
2. Branch protection requires branches to be up to date with base, so each merge stales every remaining PR. With six landing at once, serial merges mean six rebase-and-CI cycles.

## Verification

- `npm run lint` — clean, 0 errors / 0 warnings
- `npm test` — 412 passed, 28 suites
- `npm run build` — typecheck and bundle succeed; the rebuilt `main.js` is byte-identical, so the artifact is unchanged (all six bumps are dev-only)

Supersedes #315, #316, #317, #318, #319, #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)