### PR TITLE
chore(deps): bump GitHub Actions pins and @codemirror/view

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,15 +24,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           generate_release_notes: true
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             main.js

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning dashboard
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@codemirror/state": "6.7.1",
-        "@codemirror/view": "6.43.7",
+        "@codemirror/view": "6.43.8",
         "@types/jest": "^30.0.0",
         "@types/node": "^26.1.2",
         "esbuild": "0.28.1",
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.43.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.7.tgz",
-      "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
+      "version": "6.43.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
+      "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   },
   "overrides": {
     "@codemirror/state": "6.7.1",
-    "@codemirror/view": "6.43.7"
+    "@codemirror/view": "6.43.8"
   },
   "devDependencies": {
     "@codemirror/state": "6.7.1",
-    "@codemirror/view": "6.43.7",
+    "@codemirror/view": "6.43.8",
     "@types/jest": "^30.0.0",
     "@types/node": "^26.1.2",
     "esbuild": "0.28.1",


### PR DESCRIPTION
Bundles the six open Dependabot PRs (#322–#327) into a single commit.

## Bumps

**GitHub Actions**
- `github/codeql-action` init / autobuild / analyze / upload-sarif — 4.37.4 → **4.37.6** (SHA `5595ccaf912efad79be6eef63a5619ff05969be3`)
- `actions/attest-build-provenance` — 4.1.1 → **4.2.2** (SHA `4d101475d8b20a2381f78447822ac1eab6504dd8`)

**Dev dependencies**
- `@codemirror/view` — 6.43.7 → **6.43.8** (both `devDependencies` and the `overrides` block)

## Why one PR instead of six

Two independent reasons, both established in #312 and #321:

1. **The four codeql-action pins can never pass individually.** The action rejects mixed configurations ("Loaded a configuration file for version X but running Y"), so each single-action PR fails its own CodeQL check. All four have to move in the same commit.
2. **Branch protection requires branches to be up to date with base.** Every merge stales every remaining PR, so merging six separately means six rebase-and-retest rounds.

## Verification

- `npm run lint` — 0 errors, 0 warnings
- `npm test` — 412 passed, 28 suites
- `npm run build` — clean
- Rebuilt `main.js` is **byte-identical** to the committed artifact (`git diff --stat main.js` empty; the working-copy modification flag is CRLF noise). None of these six bumps reaches an installed plugin.
- CodeQL Analyze runs on this PR against the new pins, so the pins validate themselves.

## Note for a future session

`actions/attest-build-provenance` v4 is now just a thin wrapper over [`actions/attest`](https://github.com/actions/attest); upstream advises new implementations use `actions/attest` directly. Existing usage continues to be supported, so this PR only moves the pin — no migration, no release-workflow behavior change.

Closes #322
Closes #323
Closes #324
Closes #325
Closes #326
Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)
