### PR TITLE
chore(deps): bump GitHub Actions pins, @codemirror/view and i18next

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,15 +24,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning dashboard
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           sarif_file: results.sarif

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3",
-        "i18next": "^26.3.6"
+        "i18next": "^26.4.0"
       },
       "devDependencies": {
         "@codemirror/state": "6.7.1",
-        "@codemirror/view": "6.43.8",
+        "@codemirror/view": "6.43.9",
         "@types/jest": "^30.0.0",
         "@types/node": "^26.2.0",
         "esbuild": "0.28.2",
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.43.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
-      "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
+      "version": "6.43.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.9.tgz",
+      "integrity": "sha512-sTuUzTpPMFebRhg6dawChoKKgndIwfjmJgKVxBefPElcU2NwQ6AFroupk0SFqEerQyZOGRfDNnSN8Dw/lMAsXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5703,9 +5703,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.3.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
-      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.0.tgz",
+      "integrity": "sha512-rsmK5bFqsD1AetSFSIa43wtNR4WpvvH4p0tLEsTxkC7QTrfdFm06nbQ95bh8Og4wwaCnUEcm9DVYL2cgxitiQg==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   },
   "overrides": {
     "@codemirror/state": "6.7.1",
-    "@codemirror/view": "6.43.8"
+    "@codemirror/view": "6.43.9"
   },
   "devDependencies": {
     "@codemirror/state": "6.7.1",
-    "@codemirror/view": "6.43.8",
+    "@codemirror/view": "6.43.9",
     "@types/jest": "^30.0.0",
     "@types/node": "^26.2.0",
     "esbuild": "0.28.2",
@@ -40,6 +40,6 @@
   "license": "MIT",
   "dependencies": {
     "fflate": "^0.8.3",
-    "i18next": "^26.3.6"
+    "i18next": "^26.4.0"
   }
 }


### PR DESCRIPTION
Bundles the six open Dependabot PRs (#336–#341) into one change, per the established sweep pattern (fourth consecutive six-PR sweep; precedents #321, #328, #335).

## Bumps

- **github/codeql-action init/autobuild/analyze/upload-sarif 4.37.7 → 4.37.8** (all four to SHA `db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28`) — supersedes #338, #339, #340, #341
- **@codemirror/view 6.43.8 → 6.43.9** (devDependencies **and** the `overrides` block) — supersedes #337
- **i18next 26.3.6 → 26.4.0** (runtime dependency) — supersedes #336

## Why bundled

1. The four codeql-action pins can never pass individually — CodeQL rejects mixed-version configurations at runtime, so all four must move in one commit.
2. Branch protection requires branches to be up to date with base, so every merge stales all remaining PRs; six serial merges would mean six rebase-and-retest rounds. One bundle does it in one.

## main.js

i18next is a runtime dependency, so the rebuilt `main.js` genuinely differs (+29 lines). Per the artifact-only rule the rebuilt artifact is deliberately **not** committed here — it folds into `main.js` at the next release rebuild (same handling as i18next 26.3.6, which shipped in 3.0.1).

## Verification

- `npm run lint`: 0 errors, 0 warnings
- `npm test`: 412 tests / 28 suites, all pass
- `npm run build`: clean
- Lockfile churn limited to version/resolved/integrity lines (package.json edited by hand, then `npm install`)
- `npm audit`: unchanged (known #202 dev-only findings)
- CodeQL Analyze runs on the new pins in this PR's own checks — self-validating

No user-visible behavior change; no version bump, no CHANGELOG entry (CI pins + dependency housekeeping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)